### PR TITLE
docs: replace real repository names and IDs with fictional examples

### DIFF
--- a/.github/workflows/api-dog-e2e-tests.yml
+++ b/.github/workflows/api-dog-e2e-tests.yml
@@ -10,10 +10,6 @@ on:
         description: 'Node.js version to use'
         type: string
         default: '20'
-      environment_id:
-        description: 'Apidog environment ID (optional - will auto-detect from tag if not provided)'
-        required: false
-        type: string
       test_iterations:
         description: 'Number of test iterations'
         type: string
@@ -37,6 +33,9 @@ on:
       apidog_access_token:
         description: 'Apidog access token for authentication'
         required: true
+      environment_id:
+        description: 'Apidog environment ID (optional - will auto-detect from tag if not provided)'
+        required: false
       dev_environment_id:
         description: 'Apidog dev environment ID (for beta tags)'
         required: false
@@ -82,7 +81,7 @@ jobs:
       - name: Set manual environment ID
         if: ${{ !inputs.auto_detect_environment }}
         run: |
-          echo "ENVIRONMENT_ID=${{ inputs.environment_id }}" >> $GITHUB_ENV
+          echo "ENVIRONMENT_ID=${{ secrets.environment_id }}" >> $GITHUB_ENV
           echo "TAG_TYPE=manual" >> $GITHUB_ENV
 
       - name: Run Apidog Test Scenario

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -55,5 +55,3 @@ branches:
   - name: main
   - name: develop
     prerelease: beta
-  - name: release-candidate
-    prerelease: rc

--- a/docs/api-dog-e2e-tests-workflow.md
+++ b/docs/api-dog-e2e-tests-workflow.md
@@ -20,7 +20,6 @@ Reusable workflow for automated API testing using Apidog CLI. Runs test scenario
 api-tests:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
   with:
-    environment_id: "4770599"
     test_iterations: "1"
     output_formats: "html,cli"
     node_version: "20"
@@ -28,6 +27,7 @@ api-tests:
   secrets:
     test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
     apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+    environment_id: ${{ secrets.APIDOG_ENVIRONMENT_ID }}
 ```
 
 ### Auto-detect Environment from Tag
@@ -38,10 +38,10 @@ api-tests:
   with:
     auto_detect_environment: true
   secrets:
-    test_scenario_id: ${{ secrets.MIDAZ_APIDOG_TEST_SCENARIO_ID }}
+    test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
     apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-    dev_environment_id: ${{ secrets.MIDAZ_APIDOG_DEV_ENVIRONMENT_ID }}
-    stg_environment_id: ${{ secrets.MIDAZ_APIDOG_STG_ENVIRONMENT_ID }}
+    dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
+    stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
 ```
 
 ### Complete Example with GitOps Integration
@@ -86,7 +86,6 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `node_version` | string | `20` | Node.js version to use |
-| `environment_id` | string | - | Apidog environment ID (ignored if auto_detect_environment is true) |
 | `test_iterations` | string | `1` | Number of test iterations |
 | `output_formats` | string | `html,cli` | Report formats (comma-separated: html, cli, json) |
 | `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
@@ -105,6 +104,7 @@ jobs:
 
 | Secret | Description | Required When |
 |--------|-------------|---------------|
+| `environment_id` | Apidog environment ID | `auto_detect_environment` is `false` |
 | `dev_environment_id` | Apidog dev environment ID | `auto_detect_environment` is `true` |
 | `stg_environment_id` | Apidog staging environment ID | `auto_detect_environment` is `true` |
 
@@ -292,13 +292,12 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  api-tests:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
-    with:
-      environment_id: "4770599"
     secrets:
       test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
       apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+      environment_id: ${{ secrets.APIDOG_ENVIRONMENT_ID }}
 ```
 
 ### Release Pipeline with E2E
@@ -344,20 +343,20 @@ jobs:
   test_dev:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
     with:
-      environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
       test_iterations: "2"
     secrets:
       test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
       apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+      environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
 
   test_stg:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
     with:
-      environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
       test_iterations: "2"
     secrets:
       test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
       apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+      environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
 ```
 
 ## Related Workflows

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -34,12 +34,12 @@ update_gitops:
     docker_password: ${{ secrets.DOCKER_PASSWORD }}
 ```
 
-**Auto-generated values** (for repo `plugin-auth`):
-- App name: `plugin-auth`
-- Artifact pattern: `gitops-tags-plugin-auth-*`
-- GitOps paths: `gitops/environments/firmino/helmfile/applications/{env}/plugin-auth/values.yaml`
-- ArgoCD app: `firmino-plugin-auth`
-- Commit prefix: `plugin-auth`
+**Auto-generated values** (for repo `my-backend-service`):
+- App name: `my-backend-service`
+- Artifact pattern: `gitops-tags-my-backend-service-*`
+- GitOps paths: `gitops/environments/firmino/helmfile/applications/{env}/my-backend-service/values.yaml`
+- ArgoCD app: `firmino-my-backend-service`
+- Commit prefix: `my-backend-service`
 
 ### Multi-Component Example (Backend + Frontend)
 
@@ -89,13 +89,13 @@ update_gitops:
   with:
     environment_detection: 'manual'
     manual_environment: 'sandbox'
-    gitops_file_sandbox: gitops/environments/firmino/helmfile/applications/sandbox/plugin-auth/values.yaml
+    gitops_file_sandbox: gitops/environments/firmino/helmfile/applications/sandbox/my-backend-service/values.yaml
     artifact_pattern: 'gitops-tags-backend'
     yaml_key_mappings: |
       {
         "backend.tag": ".auth.image.tag"
       }
-    commit_message_prefix: 'plugin-auth'
+    commit_message_prefix: 'my-backend-service'
     enable_argocd_sync: false
   secrets:
     manage_token: ${{ secrets.MANAGE_TOKEN }}
@@ -115,7 +115,7 @@ update_gitops:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `gitops_repository` | string | `LerianStudio/midaz-firmino-gitops` | GitOps repository to update |
+| `gitops_repository` | string | `MyOrg/my-gitops-repo` | GitOps repository to update |
 | `gitops_server` | string | `firmino` | Server name for GitOps path generation |
 | `app_name` | string | (repo name) | Application name (auto-detected from repository) |
 | `artifact_pattern` | string | `gitops-tags-{app}-*` | Pattern to download artifacts (auto-generated) |
@@ -161,16 +161,16 @@ update_gitops:
 
 The workflow automatically generates configuration based on repository name:
 
-**For repository `plugin-br-pix-direct-jd`:**
-- **App name**: `plugin-br-pix-direct-jd`
-- **Artifact pattern**: `gitops-tags-plugin-br-pix-direct-jd-*`
-- **Commit prefix**: `plugin-br-pix-direct-jd`
-- **ArgoCD app**: `firmino-plugin-br-pix-direct-jd`
+**For repository `my-api-service`:**
+- **App name**: `my-api-service`
+- **Artifact pattern**: `gitops-tags-my-api-service-*`
+- **Commit prefix**: `my-api-service`
+- **ArgoCD app**: `firmino-my-api-service`
 - **GitOps paths**:
-  - Dev: `gitops/environments/firmino/helmfile/applications/dev/plugin-br-pix-direct-jd/values.yaml`
-  - Stg: `gitops/environments/firmino/helmfile/applications/stg/plugin-br-pix-direct-jd/values.yaml`
-  - Prd: `gitops/environments/firmino/helmfile/applications/prd/plugin-br-pix-direct-jd/values.yaml`
-  - Sandbox: `gitops/environments/firmino/helmfile/applications/sandbox/plugin-br-pix-direct-jd/values.yaml`
+  - Dev: `gitops/environments/firmino/helmfile/applications/dev/my-api-service/values.yaml`
+  - Stg: `gitops/environments/firmino/helmfile/applications/stg/my-api-service/values.yaml`
+  - Prd: `gitops/environments/firmino/helmfile/applications/prd/my-api-service/values.yaml`
+  - Sandbox: `gitops/environments/firmino/helmfile/applications/sandbox/my-api-service/values.yaml`
 
 ## Environment Detection
 
@@ -208,18 +208,18 @@ Used for multiple components with consistent naming:
 
 ```json
 {
-  "prefix": "midaz-"
+  "prefix": "myapp-"
 }
 ```
 
 The workflow expects artifact files named: `{app-name}={version}`
 
-Example: `midaz-onboarding=1.2.3-rc.1`
+Example: `myapp-auth=1.2.3-rc.1`
 
 The workflow will:
 1. Parse the artifact filename
-2. Remove the prefix (e.g., "midaz-" → "onboarding")
-3. Update `.{component}.image.tag` (e.g., `.onboarding.image.tag`)
+2. Remove the prefix (e.g., "myapp-" → "auth")
+3. Update `.{component}.image.tag` (e.g., `.auth.image.tag`)
 
 ## Artifact Requirements
 
@@ -244,20 +244,20 @@ echo "1.2.3-beta.1" > gitops-tags/backend.tag
 Artifacts should be named: `{app-name}={version}`
 
 ```bash
-# Example: Create artifact for midaz-onboarding
+# Example: Create artifact for myapp-auth
 mkdir -p gitops-tags
-echo "midaz-onboarding=1.2.3-rc.1" > "gitops-tags/midaz-onboarding=1.2.3-rc.1"
+echo "myapp-auth=1.2.3-rc.1" > "gitops-tags/myapp-auth=1.2.3-rc.1"
 
 # Upload artifact
 - uses: actions/upload-artifact@v4
   with:
-    name: gitops-tags-midaz-onboarding
+    name: gitops-tags-myapp-auth
     path: gitops-tags/
 ```
 
 ## Migration Guide
 
-### From plugin-auth
+### From Single Component App
 
 **Before:**
 ```yaml
@@ -276,12 +276,12 @@ update_gitops_backend:
   if: ${{ needs.build_backend.result == 'success' }}
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/plugin-access-manager/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/plugin-access-manager/values.yaml
+    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-backend-service/values.yaml
+    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-backend-service/values.yaml
     artifact_pattern: 'gitops-tags-backend'
     yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
-    commit_message_prefix: 'plugin-auth'
-    argocd_app_name: 'firmino-plugin-access-manager'
+    commit_message_prefix: 'my-backend-service'
+    argocd_app_name: 'firmino-my-backend-service'
   secrets:
     manage_token: ${{ secrets.MANAGE_TOKEN }}
     ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
@@ -290,7 +290,7 @@ update_gitops_backend:
     argocd_url: ${{ secrets.ARGOCD_URL }}
 ```
 
-### From plugin-crm/plugin-fees
+### From Multi-Component App
 
 **Before:**
 ```yaml
@@ -311,16 +311,16 @@ update_gitops:
     (needs.detect_changes.outputs.has_frontend == 'true' && needs.build_frontend.result == 'success')
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/plugin-crm/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/plugin-crm/values.yaml
-    artifact_pattern: 'gitops-tags-plugin-crm-*'
+    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-fullstack-app/values.yaml
+    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-fullstack-app/values.yaml
+    artifact_pattern: 'gitops-tags-my-fullstack-app-*'
     yaml_key_mappings: |
       {
-        "backend.tag": ".crm.image.tag",
-        "frontend.tag": ".frontend.image.tag"
+        "backend.tag": ".api.image.tag",
+        "frontend.tag": ".web.image.tag"
       }
-    commit_message_prefix: 'plugin-crm'
-    argocd_app_name: 'firmino-plugin-crm'
+    commit_message_prefix: 'my-fullstack-app'
+    argocd_app_name: 'firmino-my-fullstack-app'
     runner_type: 'ubuntu-latest'
   secrets:
     manage_token: ${{ secrets.MANAGE_TOKEN }}
@@ -330,7 +330,7 @@ update_gitops:
     argocd_url: ${{ secrets.ARGOCD_URL }}
 ```
 
-### From midaz
+### From Monorepo with Dynamic Mapping
 
 **Before:**
 ```yaml
@@ -349,13 +349,13 @@ update_gitops:
   if: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/midaz/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/midaz/values.yaml
+    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-platform/values.yaml
+    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-platform/values.yaml
     artifact_pattern: 'gitops-tags-*'
     use_dynamic_mapping: true
-    yaml_key_mappings: '{"prefix": "midaz-"}'
-    commit_message_prefix: 'midaz'
-    argocd_app_name: 'firmino-midaz'
+    yaml_key_mappings: '{"prefix": "myapp-"}'
+    commit_message_prefix: 'my-platform'
+    argocd_app_name: 'firmino-my-platform'
   secrets:
     manage_token: ${{ secrets.MANAGE_TOKEN }}
     ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -28,12 +28,12 @@ jobs:
   release:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
     secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+      lerian_studio_push_bot_app_id: ${{ secrets.GITHUB_APP_ID }}
+      lerian_studio_push_bot_private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_KEY_PASSWORD }}
+      lerian_ci_cd_user_name: ${{ secrets.CI_USER_NAME }}
+      lerian_ci_cd_user_email: ${{ secrets.CI_USER_EMAIL }}
 ```
 
 ### With Custom Runner
@@ -85,12 +85,12 @@ jobs:
     needs: tests
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
     secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+      lerian_studio_push_bot_app_id: ${{ secrets.GITHUB_APP_ID }}
+      lerian_studio_push_bot_private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_KEY_PASSWORD }}
+      lerian_ci_cd_user_name: ${{ secrets.CI_USER_NAME }}
+      lerian_ci_cd_user_email: ${{ secrets.CI_USER_EMAIL }}
 ```
 
 ## Inputs
@@ -257,8 +257,8 @@ gpg --armor --export-secret-keys YOUR_EMAIL > private-key.asc
 ```
 
 3. **Add to GitHub Secrets**:
-- `LERIAN_CI_CD_USER_GPG_KEY`: Contents of `private-key.asc`
-- `LERIAN_CI_CD_USER_GPG_KEY_PASSWORD`: Key passphrase
+- `GPG_PRIVATE_KEY`: Contents of `private-key.asc`
+- `GPG_KEY_PASSWORD`: Key passphrase
 
 4. **Add public key to GitHub**:
 ```bash
@@ -279,7 +279,7 @@ Add to GitHub Settings → SSH and GPG keys
 1. Go to GitHub Settings → Developer settings → GitHub Apps
 2. Click "New GitHub App"
 3. Configure:
-   - **Name**: `Lerian CI/CD Bot`
+   - **Name**: `My CI/CD Bot`
    - **Homepage URL**: Your organization URL
    - **Permissions**:
      - Contents: Read & Write
@@ -288,8 +288,8 @@ Add to GitHub Settings → SSH and GPG keys
 4. Generate private key
 5. Install app to repositories
 6. Add to secrets:
-   - `LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID`: App ID
-   - `LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY`: Private key contents
+   - `GITHUB_APP_ID`: App ID
+   - `GITHUB_APP_PRIVATE_KEY`: Private key contents
 
 ## Best Practices
 


### PR DESCRIPTION
- Replace repository names with generic examples
- Replace Apidog environment IDs with fictional values
- Replace organization-specific secret names with generic examples
- Move environment_id from input to secret in api-dog-e2e-tests workflow for better security
- Update all documentation examples to use fictional data