### PR TITLE
fix: rename github_token to manage_token to avoid reserved name conflict

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -68,7 +68,7 @@ on:
         type: boolean
         default: false
     secrets:
-      github_token:
+      manage_token:
         description: 'GitHub token for creating releases (defaults to GITHUB_TOKEN if not provided)'
         required: false
       tap_github_token:
@@ -119,7 +119,7 @@ jobs:
           version: ${{ inputs.goreleaser_version }}
           args: ${{ inputs.goreleaser_args }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.manage_token || secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.goreleaser_key }}
 
   homebrew:


### PR DESCRIPTION
## Problem
GitHub Actions reserves the name `github_token` and workflows that try to use it as a secret parameter name will fail with a validation error.

## Solution
Renamed the secret parameter from `github_token` to `manage_token` in the go-release workflow.

## Changes
- Updated secret parameter definition on line 71
- Updated secret usage on line 122
- The secret remains optional (`required: false`) and defaults to `GITHUB_TOKEN` if not provided

## Testing
This fix is required for workflows calling this reusable workflow to pass validation.