### PR TITLE
fix: use merge strategy for backmerge to handle diverged branches

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -42,12 +42,13 @@ plugins:
     failComment: false
     labels: []
 
-  # Plugin to perform the backmerge between the 'main' and 'develop' branches
+  # Plugin to perform the backmerge between the main and develop branches
   - path: "@saithodev/semantic-release-backmerge"
     backmergeBranches:
       - from: main
         to: develop
-    message: "chore(release): Preparations for next release [skip ci]"
+    backmergeStrategy: merge
+    message: "chore(release): backmerge ${nextRelease.version} [skip ci]"
 
   - path: "@semantic-release/exec"
 
@@ -57,3 +58,4 @@ branches:
     prerelease: beta
   - name: release-candidate
     prerelease: rc
+


### PR DESCRIPTION
## Summary

Fix the semantic-release backmerge configuration to use `merge` strategy instead of the default `rebase` strategy.

## Problem

The backmerge was failing with:
```
! [rejected] HEAD -> develop (non-fast-forward)
error: failed to push some refs
```

This happens because when merging develop → main, the rebase strategy cannot handle cases where develop has additional commits that main doesn't have.

## Solution

- Added `backmergeStrategy: merge` to use merge commits instead of rebasing
- Updated the backmerge message to include version number

## Changes

```yaml
# Before
- path: "@saithodev/semantic-release-backmerge"
  backmergeBranches:
    - from: main
      to: develop
  message: "chore(release): Preparations for next release [skip ci]"

# After  
- path: "@saithodev/semantic-release-backmerge"
  backmergeBranches:
    - from: main
      to: develop
  backmergeStrategy: merge
  message: "chore(release): backmerge ${nextRelease.version} [skip ci]"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release automation configuration to enhance backmerge handling during releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->