### PR TITLE
docs: update documentation to reflect two-branch workflow

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -56,6 +56,4 @@ branches:
   - name: main
   - name: develop
     prerelease: beta
-  - name: release-candidate
-    prerelease: rc
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ See [documentation](docs/README.md) for complete examples and configuration opti
 
 This repository uses [Semantic Versioning](https://semver.org/) with automated releases via [semantic-release](https://github.com/semantic-release/semantic-release).
 
+**Branches:**
+- `develop` - Development branch for new features and fixes
+- `main` - Production branch for stable releases
+
 **Release Process:**
 - Commits to `develop` → Beta releases (`v1.2.3-beta.1`)
-- Commits to `release-candidate` → RC releases (`v1.2.3-rc.1`)
 - Commits to `main` → Production releases (`v1.2.3`)
 
 **Commit Message Format:**
@@ -115,3 +118,4 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+


### PR DESCRIPTION
## Summary

Update documentation and configuration to reflect the simplified two-branch workflow (develop and main only).

## Changes

### README.md
- Updated Versioning section to remove release-candidate references
- Added clear branch descriptions:
  - `develop` - Development branch for new features and fixes
  - `main` - Production branch for stable releases
- Simplified release process documentation

### .releaserc.yml
- Removed `release-candidate` branch configuration
- Now only `main` and `develop` branches are configured

## Before
```
- Commits to develop → Beta releases (v1.2.3-beta.1)
- Commits to release-candidate → RC releases (v1.2.3-rc.1)
- Commits to main → Production releases (v1.2.3)
```

## After
```
- Commits to develop → Beta releases (v1.2.3-beta.1)
- Commits to main → Production releases (v1.2.3)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated branch versioning documentation with strategy details
  * Removed release-candidate information from release process

* **Chores**
  * Modified release branch configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->