### PR TITLE
feat: change default runner to blacksmith-4vcpu-ubuntu-2404

### DIFF
--- a/.github/workflows/api-dog-e2e-tests.yml
+++ b/.github/workflows/api-dog-e2e-tests.yml
@@ -21,7 +21,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       auto_detect_environment:
         description: 'Enable automatic environment detection from tag (beta/rc)'
         type: boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
       runner_type:
         description: 'Runner to use for the workflow'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. If not provided, builds from root.'
         type: string

--- a/.github/workflows/changed-paths.yml
+++ b/.github/workflows/changed-paths.yml
@@ -27,7 +27,7 @@ on:
         description: 'GitHub runner type'
         required: false
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
 
     outputs:
       matrix:

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -50,7 +50,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       enable_argocd_sync:
         description: 'Enable ArgoCD sync after GitOps update'
         type: boolean

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -18,7 +18,7 @@ on:
       runner_type:
         description: 'GitHub runner type for jobs that do not use matrix'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       go_version_lint:
         description: 'Go version for linting and other non-matrix jobs'
         type: string

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -10,7 +10,7 @@ on:
       runner_type:
         description: 'GitHub runner type'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       filter_paths:
         description: 'JSON array of paths to monitor for changes (e.g., ["apps/api", "apps/worker"]). If empty, treats repo as single-app and runs against root directory.'
         type: string

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -10,7 +10,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       go_version:
         description: 'Go version to use for release builds'
         type: string

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -10,7 +10,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       go_version:
         description: 'Go version to use for security scanning'
         type: string

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -13,7 +13,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       filter_paths:
         description: 'Paths to monitor for changes (newline separated). If not provided, treats as single app repo'
         type: string

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,7 +9,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       pr_title_types:
         description: 'Allowed commit types (pipe-separated)'
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       runner_type:
         description: 'Runner to use for the workflow'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. If not provided, treats as single app repo.'
         type: string


### PR DESCRIPTION
## Summary

Change the default runner from `firmino-lxc-runners` to `blacksmith-4vcpu-ubuntu-2404` in all shared workflows.

## Motivation

Based on benchmark results from control-plane testing, blacksmith runners are significantly faster:

| Workflow | Blacksmith | Firmino | Speedup |
|----------|------------|---------|---------|
| Tests | 50s | 132s | **2.6x faster** |
| Security | 58s | 105s | **1.8x faster** |
| Lint | 41s | 166s | **4.0x faster** |
| Go Build | 29s | 209s | **7.2x faster** |
| Security Scan | 87s | 222s | **2.5x faster** |
| Docker Build | 118s | 327s | **2.8x faster** |

## Changes

Updated default `runner_type` in all workflows:
- `build.yml`
- `release.yml`
- `pr-validation.yml`
- `go-pr-analysis.yml`
- `pr-security-scan.yml`
- `go-ci.yml`
- `go-security.yml`
- `go-release.yml`
- `gitops-update.yml`
- `api-dog-e2e-tests.yml`
- `changed-paths.yml`

## Impact

- Existing workflows that explicitly set `runner_type` will not be affected
- Workflows using the default will automatically use the faster blacksmith runners
- Estimated time savings: **~9-12 minutes per PR/release**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default GitHub workflow runner configuration across CI/CD pipelines to use improved infrastructure for faster and more reliable automated testing and deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->