### PR TITLE
feat: change api-dog-e2e-tests.yml default runner

### DIFF
--- a/.github/workflows/api-dog-e2e-tests.yml
+++ b/.github/workflows/api-dog-e2e-tests.yml
@@ -21,7 +21,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'blacksmith-4vcpu-ubuntu-2404'
+        default: 'firmino-lxc-runners'
       auto_detect_environment:
         description: 'Enable automatic environment detection from tag (beta/rc)'
         type: boolean


### PR DESCRIPTION
## Summary

Changes the default runner for `api-dog-e2e-tests.yml` from `blacksmith-4vcpu-ubuntu-2404` to `firmino-lxc-runners`.

## Note

For skipping workflows on documentation-only changes, use GitHub's native `paths-ignore` syntax in the caller workflow:

```yaml
on:
  pull_request:
    paths-ignore:
      - '**.md'
      - 'docs/**'
      - '.github/**'
      - 'LICENSE'
      - 'CODEOWNERS'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to use a different runner environment for end-to-end tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->