### PR TITLE
fix: change slack-notify default runner to blacksmith

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -32,7 +32,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'blacksmith-4vcpu-ubuntu-2404'
     secrets:
       SLACK_WEBHOOK_URL:
         description: 'Slack webhook URL for notifications'


### PR DESCRIPTION
## Summary

Update default runner for slack-notify workflow from `firmino-lxc-runners` to `blacksmith-4vcpu-ubuntu-2404`.

## Changes

- `slack-notify.yml`: Changed default `runner_type` to `blacksmith-4vcpu-ubuntu-2404`

## Why

All other workflows now use blacksmith as default runner for faster execution. This was the last workflow still defaulting to firmino runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration for notification workflow execution environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->