### PR TITLE
chore: group all dependabot updates in single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,13 @@ updates:
     # Add reviewers who should review dependency updates
     reviewers:
       - "LerianStudio/devops-team"
-    # Group all minor and patch updates together
+    # Group all updates together in a single PR
     groups:
       github-actions:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
@@ -45,11 +46,12 @@ updates:
     # Add reviewers
     reviewers:
       - "LerianStudio/devops-team"
-    # Group all minor and patch updates together
+    # Group all updates together in a single PR
     groups:
       go-dependencies:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

Update Dependabot configuration to group ALL dependency updates (major, minor, patch) into a single PR instead of creating separate PRs for major updates.

## Changes

- Added `major` to `update-types` for both `github-actions` and `go-dependencies` groups

## Before
- Minor + patch updates: 1 PR
- Major updates: separate PRs each

## After
- All updates (major + minor + patch): 1 PR per ecosystem