### PR TITLE
fix(go-pr-analysis): post coverage comment before threshold check

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -435,16 +435,6 @@ jobs:
             ${{ matrix.app.working_dir }}/coverage-report.md
           retention-days: 30
 
-      - name: Check coverage threshold
-        if: inputs.fail_on_coverage_threshold
-        run: |
-          COVERAGE=${{ steps.coverage.outputs.coverage }}
-          THRESHOLD=${{ inputs.coverage_threshold }}
-          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
-            echo "::error::Coverage $COVERAGE% is below threshold $THRESHOLD%"
-            exit 1
-          fi
-
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
@@ -512,6 +502,16 @@ jobs:
               });
               console.log('Comment created successfully');
             }
+
+      - name: Check coverage threshold
+        if: inputs.fail_on_coverage_threshold
+        run: |
+          COVERAGE=${{ steps.coverage.outputs.coverage }}
+          THRESHOLD=${{ inputs.coverage_threshold }}
+          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+            echo "::error::Coverage $COVERAGE% is below threshold $THRESHOLD%"
+            exit 1
+          fi
 
       - name: Coverage summary
         working-directory: ${{ matrix.app.working_dir }}


### PR DESCRIPTION
## Summary

Reorder steps in the Coverage job so the PR comment is posted **before** checking the coverage threshold.

## Problem

When `fail_on_coverage_threshold: true` and coverage is below the threshold:
1. Threshold check fails (exit 1)
2. Job stops immediately
3. Coverage comment never gets posted to PR

## Solution

Swap the order of steps:
1. **Post coverage comment** (always runs for PRs)
2. **Check coverage threshold** (fails if below threshold)

This ensures developers can see coverage results in the PR even when coverage is below the threshold and the workflow fails.

## Impact

- Coverage comment will **always** be posted to PRs (when tests pass)
- Workflow will still fail when coverage is below threshold (if `fail_on_coverage_threshold: true`)
- No breaking changes to existing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflow step execution order to streamline the coverage validation process during pull request analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->