### PR TITLE
fix(build): pass github_token secret to Docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            github_token=${{ secrets.MANAGE_TOKEN }}
 
       # GitOps artifacts for downstream gitops-update workflow
       - name: Create GitOps tag artifact


### PR DESCRIPTION
## Summary

Pass `MANAGE_TOKEN` as `github_token` secret to docker/build-push-action for Dockerfiles that use `--mount=type=secret,id=github_token` to access private Go modules.

## Problem

Docker builds fail with:
```
cat: can't open '/run/secrets/github_token': No such file or directory
```

When Dockerfile uses:
```dockerfile
RUN --mount=type=secret,id=github_token \
  GITHUB_TOKEN=$(cat /run/secrets/github_token) && ...
```

## Solution

Add `secrets` parameter to docker/build-push-action:
```yaml
secrets: |
  github_token=${{ secrets.MANAGE_TOKEN }}
```

## Impact

- Enables Docker builds for repos with private Go module dependencies
- No breaking changes for repos that don't use this feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image build authentication mechanism for improved security and reliability in the deployment pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->