### PR TITLE
chore: merge develop into main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            github_token=${{ secrets.MANAGE_TOKEN }}
 
       # GitOps artifacts for downstream gitops-update workflow
       - name: Create GitOps tag artifact


### PR DESCRIPTION
## Summary

Merge latest develop changes into main for release.

## Changes included

- fix(build): pass github_token secret to Docker build
  - Pass MANAGE_TOKEN as github_token secret to docker/build-push-action
  - Enables Docker builds for repos with private Go module dependencies