### PR TITLE
feat(pr-security-scan): add enable_docker_scan input for CLI projects

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -42,6 +42,10 @@ on:
         description: 'Name of the Dockerfile'
         type: string
         default: 'Dockerfile'
+      enable_docker_scan:
+        description: 'Enable Docker image build and vulnerability scanning. Set to false for projects without Dockerfile (e.g., CLI tools)'
+        type: boolean
+        default: true
 
 permissions:
   id-token: write       # Required for OIDC authentication
@@ -129,6 +133,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
+        if: inputs.enable_docker_scan
         uses: docker/setup-buildx-action@v3
 
       # ----------------- Security Scans -----------------
@@ -156,7 +161,7 @@ jobs:
           skip-dirs: '.git,node_modules,dist,build,.next,coverage,vendor'
 
       - name: Build Docker Image for Scanning
-        if: always()
+        if: always() && inputs.enable_docker_scan
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.monorepo_type == 'type2' && matrix.working_dir == inputs.frontend_folder && inputs.frontend_folder || '.' }}
@@ -170,7 +175,7 @@ jobs:
             ${{ secrets.NPMRC_TOKEN && format('npmrc=//npm.pkg.github.com/:_authToken={0}', secrets.NPMRC_TOKEN) || '' }}
 
       - name: Trivy Vulnerability Scan - Docker Image (Table Output)
-        if: always()
+        if: always() && inputs.enable_docker_scan
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'
@@ -181,7 +186,7 @@ jobs:
           exit-code: '0'
 
       - name: Trivy Vulnerability Scan - Docker Image (SARIF Output)
-        if: always()
+        if: always() && inputs.enable_docker_scan
         uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'

--- a/docs/api-dog-e2e-tests-workflow.md
+++ b/docs/api-dog-e2e-tests-workflow.md
@@ -233,13 +233,11 @@ with:
 
 **Error**: Environment ID not set
 
-**Solution**: When using `auto_detect_environment: true`, ensure both secrets are provided:
+**Solution**: When using `auto_detect_environment: true`, ensure both environment secrets are configured at the repository or organization level:
+- `APIDOG_DEV_ENVIRONMENT_ID`
+- `APIDOG_STG_ENVIRONMENT_ID`
 
-```yaml
-secrets:
-  dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
-  stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
-```
+Then use `secrets: inherit` in your workflow call.
 
 ### CLI Installation Issues
 

--- a/docs/api-dog-e2e-tests-workflow.md
+++ b/docs/api-dog-e2e-tests-workflow.md
@@ -24,10 +24,7 @@ api-tests:
     output_formats: "html,cli"
     node_version: "20"
     runner_type: "firmino-lxc-runners"
-  secrets:
-    test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-    apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-    environment_id: ${{ secrets.APIDOG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ### Auto-detect Environment from Tag
@@ -37,11 +34,7 @@ api-tests:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
   with:
     auto_detect_environment: true
-  secrets:
-    test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-    apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-    dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
-    stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ### Complete Example with GitOps Integration
@@ -74,11 +67,7 @@ jobs:
       auto_detect_environment: true
       test_iterations: "3"
       output_formats: "html,cli,json"
-    secrets:
-      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-      dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
-      stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ## Inputs
@@ -294,10 +283,7 @@ on:
 jobs:
   api-tests:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
-    secrets:
-      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-      environment_id: ${{ secrets.APIDOG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ### Release Pipeline with E2E
@@ -324,11 +310,7 @@ jobs:
       test_iterations: "3"
       output_formats: "html,cli,json"
       runner_type: "firmino-lxc-runners"
-    secrets:
-      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-      dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
-      stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ### Scheduled E2E Tests
@@ -344,19 +326,13 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
     with:
       test_iterations: "2"
-    secrets:
-      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-      environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
+    secrets: inherit
 
   test_stg:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/api-dog-e2e-tests.yml@main
     with:
       test_iterations: "2"
-    secrets:
-      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
-      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
-      environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
+    secrets: inherit
 ```
 
 ## Related Workflows

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -24,15 +24,10 @@ update_gitops:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
     yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
-    docker_username: ${{ secrets.DOCKER_USERNAME }}
-    docker_password: ${{ secrets.DOCKER_PASSWORD }}
+  secrets: inherit
 ```
+
+> **Required Secrets**: `MANAGE_TOKEN`, `LERIAN_CI_CD_USER_NAME`, `LERIAN_CI_CD_USER_EMAIL`, `ARGOCD_GHUSER_TOKEN`, `ARGOCD_URL`, `DOCKER_USERNAME`, `DOCKER_PASSWORD`
 
 **Auto-generated values** (for repo `my-backend-service`):
 - App name: `my-backend-service`
@@ -50,14 +45,7 @@ update_gitops:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
     yaml_key_mappings: '{"backend.tag": ".crm.image.tag", "frontend.tag": ".frontend.image.tag"}'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
-    docker_username: ${{ secrets.DOCKER_USERNAME }}
-    docker_password: ${{ secrets.DOCKER_PASSWORD }}
+  secrets: inherit
 ```
 
 ### Dynamic Mapping Example (Multiple Components like Midaz)
@@ -70,14 +58,7 @@ update_gitops:
   with:
     use_dynamic_mapping: true
     yaml_key_mappings: '{"prefix": "midaz-"}'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
-    docker_username: ${{ secrets.DOCKER_USERNAME }}
-    docker_password: ${{ secrets.DOCKER_PASSWORD }}
+  secrets: inherit
 ```
 
 ### Manual Environment Selection
@@ -97,10 +78,7 @@ update_gitops:
       }
     commit_message_prefix: 'my-backend-service'
     enable_argocd_sync: false
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+  secrets: inherit
 ```
 
 ## Inputs
@@ -282,12 +260,7 @@ update_gitops_backend:
     yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
     commit_message_prefix: 'my-backend-service'
     argocd_app_name: 'firmino-my-backend-service'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
+  secrets: inherit
 ```
 
 ### From Multi-Component App
@@ -322,12 +295,7 @@ update_gitops:
     commit_message_prefix: 'my-fullstack-app'
     argocd_app_name: 'firmino-my-fullstack-app'
     runner_type: 'ubuntu-latest'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
+  secrets: inherit
 ```
 
 ### From Monorepo with Dynamic Mapping
@@ -356,12 +324,7 @@ update_gitops:
     yaml_key_mappings: '{"prefix": "myapp-"}'
     commit_message_prefix: 'my-platform'
     argocd_app_name: 'firmino-my-platform'
-  secrets:
-    manage_token: ${{ secrets.MANAGE_TOKEN }}
-    ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-    argocd_token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-    argocd_url: ${{ secrets.ARGOCD_URL }}
+  secrets: inherit
 ```
 
 ## Troubleshooting

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -72,8 +72,7 @@ jobs:
       enable_tests: true
       enable_coverage: true
       enable_build: true
-    secrets:
-      manage_token: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit
 ```
 
 ### Minimal (Only Tests and Lint)

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -45,10 +45,10 @@ jobs:
       enable_docker: true
       docker_registry: 'ghcr.io'
       docker_platforms: 'linux/amd64,linux/arm64'
-    secrets:
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    secrets: inherit
 ```
+
+> **Note**: Requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets in repository.
 
 ### With Homebrew Formula
 
@@ -65,9 +65,10 @@ jobs:
     with:
       enable_homebrew: true
       homebrew_tap_repo: 'myorg/homebrew-tap'
-    secrets:
-      tap_github_token: ${{ secrets.TAP_GITHUB_TOKEN }}
+    secrets: inherit
 ```
+
+> **Note**: Requires `TAP_GITHUB_TOKEN` secret with write access to tap repository.
 
 ### Full Configuration
 
@@ -92,10 +93,7 @@ jobs:
       enable_homebrew: true
       homebrew_tap_repo: 'myorg/homebrew-tap'
       enable_notifications: true
-    secrets:
-      tap_github_token: ${{ secrets.TAP_GITHUB_TOKEN }}
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    secrets: inherit
 ```
 
 ## Inputs
@@ -159,9 +157,10 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@main
     with:
       goreleaser_distribution: 'goreleaser-pro'
-    secrets:
-      goreleaser_key: ${{ secrets.GORELEASER_KEY }}
+    secrets: inherit
 ```
+
+> **Note**: Requires `GORELEASER_KEY` secret with your GoReleaser Pro license.
 
 ### Skip Tests (Fast Release)
 

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -58,12 +58,9 @@ jobs:
   security-scan:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@main
     with:
-      runner_type: "firmino-lxc-runners"
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
       dockerhub_org: "lerianstudio"
-    secrets:
-      manage_token: ${{ secrets.MANAGE_TOKEN }}
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    secrets: inherit
 ```
 
 ### Monorepo Type 1
@@ -78,17 +75,14 @@ jobs:
   security-scan:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@main
     with:
-      runner_type: "firmino-lxc-runners"
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
         components/onboarding
         components/transaction
         components/console
       path_level: "2"
       dockerhub_org: "lerianstudio"
-    secrets:
-      manage_token: ${{ secrets.MANAGE_TOKEN }}
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    secrets: inherit
 ```
 
 ### Monorepo Type 2
@@ -103,7 +97,7 @@ jobs:
   security-scan:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@main
     with:
-      runner_type: "firmino-lxc-runners"
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
       filter_paths: |-
         frontend
         cmd
@@ -115,23 +109,46 @@ jobs:
       monorepo_type: "type2"
       frontend_folder: "frontend"
       dockerhub_org: "lerianstudio"
-    secrets:
-      manage_token: ${{ secrets.MANAGE_TOKEN }}
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    secrets: inherit
 ```
+
+### CLI / Non-Docker Projects
+
+For projects without a Dockerfile (e.g., CLI tools), disable Docker scanning to only run filesystem secret scanning:
+
+```yaml
+name: PR Security Scan
+on:
+  pull_request:
+    branches: [develop, release-candidate, main]
+
+jobs:
+  security-scan:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@main
+    with:
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
+      enable_docker_scan: false
+    secrets: inherit
+```
+
+This will:
+- ✅ Run Trivy filesystem secret scanning
+- ❌ Skip Docker image build
+- ❌ Skip Docker vulnerability scanning
 
 ## Inputs
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
 | `filter_paths` | string | - | Paths to monitor (newline separated). If empty, treats as single app |
 | `path_level` | string | `2` | Directory depth level to extract app name (monorepo only) |
 | `monorepo_type` | string | `type1` | Monorepo type: `type1` or `type2` |
 | `frontend_folder` | string | `frontend` | Frontend folder name for type2 monorepos |
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `docker_registry` | string | `docker.io` | Docker registry URL |
+| `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
+| `enable_docker_scan` | boolean | `true` | Enable Docker image build and vulnerability scanning. Set to `false` for projects without Dockerfile (e.g., CLI tools) |
 
 ## Secrets
 

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -363,10 +363,10 @@ security-scan:
   with:
     dockerhub_org: "mycompany"
     docker_registry: "ghcr.io"
-  secrets:
-    docker_username: ${{ github.actor }}
-    docker_password: ${{ secrets.GITHUB_TOKEN }}
+  secrets: inherit
 ```
+
+> **Note**: For GitHub Container Registry (ghcr.io), ensure `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets are configured appropriately.
 
 ### Monorepo Type 1 with Multiple Components
 

--- a/docs/pr-validation-workflow.md
+++ b/docs/pr-validation-workflow.md
@@ -72,8 +72,7 @@ jobs:
       min_description_length: 100
       check_changelog: true
       enable_auto_labeler: true
-    secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit
 ```
 
 ### With Custom Scopes

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -27,14 +27,10 @@ on:
 jobs:
   release:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
-    secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.GITHUB_APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_KEY_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.CI_USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.CI_USER_EMAIL }}
+    secrets: inherit
 ```
+
+> **Required Secrets**: `LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID`, `LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY`, `LERIAN_CI_CD_USER_GPG_KEY`, `LERIAN_CI_CD_USER_GPG_KEY_PASSWORD`, `LERIAN_CI_CD_USER_NAME`, `LERIAN_CI_CD_USER_EMAIL`
 
 ### With Custom Runner
 
@@ -42,15 +38,9 @@ jobs:
 release:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
   with:
-    runner_type: "firmino-lxc-runners"
+    runner_type: "blacksmith-4vcpu-ubuntu-2404"
     semantic_version: "23.0.8"
-  secrets:
-    lerian_studio_push_bot_app_id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-    lerian_studio_push_bot_private_key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-    lerian_ci_cd_user_gpg_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-    lerian_ci_cd_user_gpg_key_password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-    lerian_ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-    lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+  secrets: inherit
 ```
 
 ### Complete Release Pipeline
@@ -84,13 +74,7 @@ jobs:
   release:
     needs: tests
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
-    secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.GITHUB_APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_KEY_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.CI_USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.CI_USER_EMAIL }}
+    secrets: inherit
 ```
 
 ## Inputs
@@ -416,13 +400,7 @@ on:
 jobs:
   release:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
-    secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.USER_EMAIL }}
+    secrets: inherit
 ```
 
 ### Release with Build Pipeline
@@ -443,13 +421,7 @@ jobs:
   release:
     needs: test
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
-    secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.USER_EMAIL }}
+    secrets: inherit
 
   build:
     needs: release
@@ -472,13 +444,7 @@ on:
 jobs:
   release:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@main
-    secrets:
-      lerian_studio_push_bot_app_id: ${{ secrets.APP_ID }}
-      lerian_studio_push_bot_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-      lerian_ci_cd_user_gpg_key: ${{ secrets.GPG_KEY }}
-      lerian_ci_cd_user_gpg_key_password: ${{ secrets.GPG_PASSWORD }}
-      lerian_ci_cd_user_name: ${{ secrets.USER_NAME }}
-      lerian_ci_cd_user_email: ${{ secrets.USER_EMAIL }}
+    secrets: inherit
 ```
 
 ## Semantic Release Plugins

--- a/docs/slack-notify-workflow.md
+++ b/docs/slack-notify-workflow.md
@@ -29,8 +29,7 @@ jobs:
     with:
       status: ${{ needs.build.result }}
       workflow_name: "Build Pipeline"
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    secrets: inherit
 ```
 
 ### With Failed Jobs Information
@@ -55,8 +54,7 @@ jobs:
       status: ${{ needs.lint.result == 'failure' && 'failure' || needs.test.result }}
       workflow_name: "CI Pipeline"
       failed_jobs: ${{ needs.lint.result == 'failure' && 'Lint' || '' }}${{ needs.test.result == 'failure' && ', Test' || '' }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    secrets: inherit
 ```
 
 ### With Custom Message
@@ -68,8 +66,7 @@ notify:
     status: "success"
     workflow_name: "Release"
     custom_message: "Version v1.2.3 has been released! 🎉"
-  secrets:
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    secrets: inherit
 ```
 
 ### Using secrets: inherit


### PR DESCRIPTION
## Summary

Add `enable_docker_scan` input to pr-security-scan workflow to support projects without Dockerfiles (e.g., CLI tools).

## Changes

### Workflow (`.github/workflows/pr-security-scan.yml`)
- Added `enable_docker_scan` boolean input (default: `true`)
- Docker Buildx setup: skipped when `enable_docker_scan: false`
- Docker image build: skipped when `enable_docker_scan: false`
- Docker vulnerability scans: skipped when `enable_docker_scan: false`
- Docker login remains enabled to avoid rate limits from Trivy

### Documentation (`docs/pr-security-scan-workflow.md`)
- Added CLI/Non-Docker support to features list
- Added "CLI / Non-Docker Projects" usage example
- Updated workflow steps to show conditional Docker steps
- Updated best practices with blacksmith runners
- Updated all examples to use `secrets: inherit`
- Updated all examples to use `blacksmith-4vcpu-ubuntu-2404` runner

## Usage Example

```yaml
jobs:
  security-scan:
    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@develop
    with:
      runner_type: "blacksmith-4vcpu-ubuntu-2404"
      enable_docker_scan: false
    secrets: inherit
```

## Testing

- Tested on lerian-cli PR #10: https://github.com/LerianStudio/lerian-cli/pull/10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable/disable Docker image build and vulnerability scanning (skip scans for non-Docker projects).

* **Documentation**
  * Updated docs with guidance for skipping Docker scans, new input defaults and dockerfile naming, CLI/Non‑Docker section, and usage examples across workflows.

* **Chores**
  * Default runner type updated and examples simplified to use inherited secrets instead of per-key mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->