### PR TITLE
fix(go-pr-analysis): add coverage-unit.out to artifact normalization …

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -418,6 +418,9 @@ jobs:
           if [[ -f "artifacts/coverage.out" ]] && [[ ! -f "coverage.txt" ]]; then
             cp artifacts/coverage.out coverage.txt
           fi
+          if [[ -f "artifacts/coverage-unit.out" ]] && [[ ! -f "coverage.txt" ]]; then
+            cp artifacts/coverage-unit.out coverage.txt
+          fi
 
       - name: Generate coverage (fallback for make test)
         if: steps.detect-make.outputs.use_make == 'true' && steps.detect-make.outputs.no_coverage == 'true'


### PR DESCRIPTION
## Description

  The `go-pr-analysis` shared workflow fails to find the coverage artifact when repositories use `make coverage-unit`, which outputs to
  `artifacts/coverage-unit.out` instead of the expected `artifacts/coverage.out`. This adds the missing path to the normalization step.

  ## Type of Change

  - [ ] `feat`: New feature or workflow
  - [x] `fix`: Bug fix
  - [ ] `docs`: Documentation update
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Adding or updating tests
  - [ ] `ci`: CI/CD configuration changes
  - [ ] `chore`: Maintenance tasks
  - [ ] `BREAKING CHANGE`: Breaking change (requires major version bump)

  ## Affected Workflows

  - [ ] GitOps Update
  - [ ] API Dog E2E Tests
  - [ ] PR Security Scan
  - [ ] Release Workflow
  - [x] Other (specify): Go PR Analysis (`go-pr-analysis.yml`)

  ## Changes Made

  - Add `artifacts/coverage-unit.out` to coverage file normalization in the tests job
  - Follows the same pattern as existing normalizations for `coverage.out`, `reports/unit_coverage.out`, and `artifacts/coverage.out`

  ## Breaking Changes

  **None**

  ## Testing

  - [x] Tested locally
  - [ ] Tested in development environment
  - [x] Tested with example repository: LerianStudio/plugin-auth
  - [x] All existing workflows still work

  ## Checklist

  - [x] Code follows conventional commit format
  - [x] Documentation updated (if applicable)
  - [x] Examples updated (if applicable)
  - [x] No hardcoded secrets or sensitive data
  - [x] Backward compatible (or breaking changes documented)
  - [x] Self-review completed
  - [x] Comments added for complex logic

  ## Related Issues

  Related to LerianStudio/plugin-auth#407

  ## Additional Notes

  The `coverage-unit` Makefile target (from `mk/tests.mk`) generates coverage at `artifacts/coverage-unit.out`. The shared workflow's
  normalization step only checked for `artifacts/coverage.out`, causing the upload step to silently skip and the downstream Coverage job
  to fail with `Artifact not found for name: coverage-plugin-auth`.