### PR TITLE
feat(pr-security-scan): gate merge on security findings

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -213,6 +213,7 @@ jobs:
 
       # ----------------- PR Comment with Security Findings -----------------
       - name: Post Security Scan Results to PR
+        id: post-results
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
@@ -374,6 +375,23 @@ jobs:
                 body
               });
             }
+
+            // Export findings flag for the gate step
+            const fs2 = require('fs');
+            const outputFile = process.env.GITHUB_OUTPUT;
+            fs2.appendFileSync(outputFile, `has_findings=${hasFindings}\n`);
+            fs2.appendFileSync(outputFile, `has_errors=${hasScanErrors}\n`);
+
+      - name: Gate - Fail on Security Findings
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          if [ "${{ steps.post-results.outputs.has_findings }}" = "true" ]; then
+            echo "::error::Security vulnerabilities found. Check the PR comment for details."
+            exit 1
+          fi
+          if [ "${{ steps.post-results.outputs.has_errors }}" = "true" ]; then
+            echo "::warning::Some scan artifacts were missing or could not be parsed."
+          fi
 
       ## To be fixed
       # - name: Upload Secret Scan Results - Repository (SARIF) to GitHub Security Tab

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -377,20 +377,18 @@ jobs:
             }
 
             // Export findings flag for the gate step
-            const fs2 = require('fs');
-            const outputFile = process.env.GITHUB_OUTPUT;
-            fs2.appendFileSync(outputFile, `has_findings=${hasFindings}\n`);
-            fs2.appendFileSync(outputFile, `has_errors=${hasScanErrors}\n`);
+            core.setOutput('has_findings', hasFindings);
+            core.setOutput('has_errors', hasScanErrors);
 
       - name: Gate - Fail on Security Findings
         if: always() && github.event_name == 'pull_request'
         run: |
+          if [ "${{ steps.post-results.outputs.has_errors }}" = "true" ]; then
+            echo "::warning::Some scan artifacts were missing or could not be parsed."
+          fi
           if [ "${{ steps.post-results.outputs.has_findings }}" = "true" ]; then
             echo "::error::Security vulnerabilities found. Check the PR comment for details."
             exit 1
-          fi
-          if [ "${{ steps.post-results.outputs.has_errors }}" = "true" ]; then
-            echo "::warning::Some scan artifacts were missing or could not be parsed."
           fi
 
       ## To be fixed

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -347,38 +347,40 @@ jobs:
               body += `\n✅ **All security checks passed.**\n`;
             }
 
+            // Export findings flag for the gate step (before API calls to ensure they're always set)
+            core.setOutput('has_findings', hasFindings);
+            core.setOutput('has_errors', hasScanErrors);
+
             // Find and update existing comment or create new one
             const marker = `<!-- security-scan-${appName} -->`;
             body = marker + '\n' + body;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100
-            });
-
-            const existing = comments.find(c => c.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body
+                per_page: 100
               });
-            }
 
-            // Export findings flag for the gate step
-            core.setOutput('has_findings', hasFindings);
-            core.setOutput('has_errors', hasScanErrors);
+              const existing = comments.find(c => c.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body
+                });
+              }
+            } catch (e) {
+              core.warning(`Could not post PR security comment: ${e.message}`);
+            }
 
       - name: Gate - Fail on Security Findings
         if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
 ## Summary
  - Add gate step that fails the job when security findings are detected
  - PR comment with detailed findings is always posted regardless
  - Blocks merge on: secrets in code, CVEs in libraries, Docker image vulnerabilities
  - Emits warnings when scan artifacts are missing or unparseable

  ## Test plan
  - [ ] PR with known CVE (e.g., outdated gofiber) — gate fails, comment posted
  - [ ] PR with no vulnerabilities — gate passes, "All checks passed" comment
  - [ ] PR with Docker scan disabled — no false positive from missing Docker SARIF