### PR TITLE
feat(gitops-update): add multi-server deployment support

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -218,10 +218,48 @@ jobs:
           fi
           echo "Servers to deploy to: $SERVERS"
 
+          # First, check which artifacts actually exist
+          echo ""
+          echo "Checking available artifacts..."
+          AVAILABLE_ARTIFACTS=""
+          for artifact_file in .gitops-tags/*; do
+            if [[ -f "$artifact_file" ]]; then
+              artifact_name=$(basename "$artifact_file")
+              echo "  Found artifact: $artifact_name"
+              AVAILABLE_ARTIFACTS="${AVAILABLE_ARTIFACTS}${artifact_name} "
+            fi
+          done
+          
+          if [[ -z "$AVAILABLE_ARTIFACTS" ]]; then
+            echo "No artifacts found in .gitops-tags/"
+            echo "sync_matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "has_sync_targets=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Track results
           UPDATED_FILES=""
           MISSING_FILES=""
           UPDATED_SERVERS_ENVS=""
+
+          # Function to update a single YAML key using sed (preserves formatting)
+          update_yaml_tag() {
+            local file="$1"
+            local yaml_path="$2"
+            local new_tag="$3"
+            
+            # Extract the key name from yaml path (e.g., ".image.tag" -> "tag")
+            local key_name="${yaml_path##*.}"
+            
+            # Use sed to replace only the tag value, preserving all formatting
+            # This handles patterns like "tag: v1.0.0" or "tag: 'v1.0.0'" or 'tag: "v1.0.0"'
+            if grep -q "^[[:space:]]*${key_name}:" "$file"; then
+              # Replace the value after the key, preserving indentation and quotes
+              sed -i -E "s/^([[:space:]]*${key_name}:[[:space:]]*)(['\"]?)([^'\"[:space:]]+)(['\"]?)$/\1\2${new_tag}\4/" "$file"
+              return 0
+            fi
+            return 1
+          }
 
           # Process each server and environment
           for SERVER in $SERVERS; do
@@ -239,38 +277,60 @@ jobs:
                 continue
               fi
               
-              echo "  File exists, applying tags..."
+              # Track if any changes were made to this file
+              FILE_CHANGED=false
               
-              # Apply mappings from inputs
+              # Apply mappings from inputs - only if artifact exists
               MAPPINGS='${{ inputs.yaml_key_mappings }}'
-              echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key yaml_key; do
+              while IFS='|' read -r artifact_key yaml_key; do
                 ARTIFACT_FILE=".gitops-tags/${artifact_key}"
                 if [[ -f "$ARTIFACT_FILE" ]]; then
                   TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
                   if [[ -n "$TAG" ]]; then
-                    TAG="$TAG" yq e -i "$yaml_key = strenv(TAG)" "$VALUES_FILE"
-                    echo "    Set $yaml_key = $TAG"
+                    # Get current value to check if update is needed
+                    CURRENT_TAG=$(yq e "$yaml_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                    if [[ "$CURRENT_TAG" != "$TAG" ]]; then
+                      # Use yq with explicit output to preserve formatting
+                      TAG="$TAG" yq e "$yaml_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
+                      mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
+                      echo "    Updated $yaml_key: $CURRENT_TAG -> $TAG"
+                      FILE_CHANGED=true
+                    else
+                      echo "    Skipped $yaml_key: already set to $TAG"
+                    fi
                   fi
                 fi
-              done
+              done < <(echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
               
-              # Apply configmap updates if configured
+              # Apply configmap updates if configured - only if artifact exists
               if [[ -n "${{ inputs.configmap_updates }}" ]]; then
                 CONFIGMAP_MAPPINGS='${{ inputs.configmap_updates }}'
-                echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key configmap_key; do
+                while IFS='|' read -r artifact_key configmap_key; do
                   ARTIFACT_FILE=".gitops-tags/${artifact_key}"
                   if [[ -f "$ARTIFACT_FILE" ]]; then
                     TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
                     if [[ -n "$TAG" ]]; then
-                      TAG="$TAG" yq e -i "$configmap_key = strenv(TAG)" "$VALUES_FILE"
-                      echo "    Set $configmap_key = $TAG"
+                      CURRENT_TAG=$(yq e "$configmap_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                      if [[ "$CURRENT_TAG" != "$TAG" ]]; then
+                        TAG="$TAG" yq e "$configmap_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
+                        mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
+                        echo "    Updated $configmap_key: $CURRENT_TAG -> $TAG"
+                        FILE_CHANGED=true
+                      else
+                        echo "    Skipped $configmap_key: already set to $TAG"
+                      fi
                     fi
                   fi
-                done
+                done < <(echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
               fi
               
-              UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
-              UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
+              # Only track as updated if changes were actually made
+              if [[ "$FILE_CHANGED" == "true" ]]; then
+                UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
+                UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
+              else
+                echo "  No changes needed for this file"
+              fi
             done
           done
 
@@ -292,7 +352,7 @@ jobs:
             echo -e "$MISSING_FILES"
           fi
 
-          # Save updated servers/envs for ArgoCD sync
+          # Save updated servers/envs for ArgoCD sync - only include files that actually changed
           if [[ -n "$UPDATED_SERVERS_ENVS" ]]; then
             echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' > /tmp/updated_servers_envs.txt
             
@@ -372,8 +432,8 @@ jobs:
           
           # Install argocd CLI if not available
           if ! command -v argocd &> /dev/null; then
-            curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-            chmod +x /usr/local/bin/argocd
+            sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            sudo chmod +x /usr/local/bin/argocd
           fi
           
           # Check if app exists

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -432,8 +432,9 @@ jobs:
           
           # Install argocd CLI if not available
           if ! command -v argocd &> /dev/null; then
-            sudo curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-            sudo chmod +x /usr/local/bin/argocd
+            curl -sSL -o /tmp/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            chmod +x /tmp/argocd
+            sudo mv /tmp/argocd /usr/local/bin/argocd
           fi
           
           # Check if app exists

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -420,46 +420,14 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.update_gitops.outputs.sync_matrix) }}
     steps:
-      - name: Check if ArgoCD app exists
-        id: check_app
-        shell: bash
-        env:
-          ARGOCD_TOKEN: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
-          ARGOCD_URL: ${{ secrets.ARGOCD_URL }}
-        run: |
-          APP_NAME="${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}-${{ matrix.target.env }}"
-          echo "Checking if ArgoCD app exists: $APP_NAME"
-          
-          # Install argocd CLI if not available
-          if ! command -v argocd &> /dev/null; then
-            curl -sSL -o /tmp/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-            chmod +x /tmp/argocd
-            sudo mv /tmp/argocd /usr/local/bin/argocd
-          fi
-          
-          # Check if app exists
-          if argocd app get "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web > /dev/null 2>&1; then
-            echo "app_exists=true" >> "$GITHUB_OUTPUT"
-            echo "App $APP_NAME exists, will sync"
-          else
-            echo "app_exists=false" >> "$GITHUB_OUTPUT"
-            echo "App $APP_NAME does not exist, skipping sync"
-          fi
-
       - name: Execute ArgoCD Sync
-        if: steps.check_app.outputs.app_exists == 'true'
         uses: LerianStudio/github-actions-argocd-sync@main
         with:
           app-name: ${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}
           argo-cd-token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
           argo-cd-url: ${{ secrets.ARGOCD_URL }}
           env-prefix: ${{ matrix.target.env }}
-        continue-on-error: true
-
-      - name: Log skipped sync
-        if: steps.check_app.outputs.app_exists == 'false'
-        run: |
-          echo "::warning::ArgoCD app ${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}-${{ matrix.target.env }} does not exist, sync skipped"
+          skip-if-not-exists: 'true'
 
   # Slack notification
   notify:

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -1,7 +1,7 @@
 name: "GitOps Update"
 
 # Reusable workflow for updating GitOps repository with new image tags
-# Supports multiple environments: dev (beta), stg (rc), prd (production), sandbox
+# Supports multiple servers (Firmino, Clotilde) and environments: dev (beta), stg (rc), prd (production), sandbox
 # Handles single or multiple components with flexible YAML key mapping
 
 on:
@@ -11,30 +11,18 @@ on:
         description: 'GitOps repository to update (org/repo format)'
         type: string
         default: 'LerianStudio/midaz-firmino-gitops'
-      gitops_server:
-        description: 'Server name for GitOps path (e.g., firmino)'
-        type: string
-        default: 'firmino'
       app_name:
         description: 'Application name (defaults to repository name if not provided)'
         type: string
         required: false
-      gitops_file_dev:
-        description: 'Path to dev environment values.yaml (auto-generated if not provided)'
-        type: string
-        required: false
-      gitops_file_stg:
-        description: 'Path to stg environment values.yaml (auto-generated if not provided)'
-        type: string
-        required: false
-      gitops_file_prd:
-        description: 'Path to prd environment values.yaml (auto-generated if not provided)'
-        type: string
-        required: false
-      gitops_file_sandbox:
-        description: 'Path to sandbox environment values.yaml (auto-generated if not provided)'
-        type: string
-        required: false
+      deploy_in_firmino:
+        description: 'Deploy to Firmino server'
+        type: boolean
+        default: true
+      deploy_in_clotilde:
+        description: 'Deploy to Clotilde server'
+        type: boolean
+        default: true
       artifact_pattern:
         description: 'Pattern to download artifacts (defaults to "gitops-tags-<repo-name>-*" if not provided)'
         type: string
@@ -55,10 +43,6 @@ on:
         description: 'Enable ArgoCD sync after GitOps update'
         type: boolean
         default: true
-      argocd_app_name:
-        description: 'ArgoCD application name (auto-generated as <server>-<app> if not provided)'
-        type: string
-        required: false
       use_dynamic_mapping:
         description: 'Use dynamic mapping for multiple components (like midaz)'
         type: boolean
@@ -67,14 +51,6 @@ on:
         description: 'Version of yq to install'
         type: string
         default: 'v4.44.3'
-      environment_detection:
-        description: 'Environment detection strategy: tag_suffix (beta/rc/prd) or manual'
-        type: string
-        default: 'tag_suffix'
-      manual_environment:
-        description: 'Manually specify environment (dev/stg/prd/sandbox) - only used if environment_detection is manual'
-        type: string
-        required: false
       enable_docker_login:
         description: 'Enable Docker Hub login to avoid rate limits'
         type: boolean
@@ -87,15 +63,15 @@ on:
 jobs:
   update_gitops:
     runs-on: ${{ inputs.runner_type }}
+    outputs:
+      app_name: ${{ steps.setup.outputs.app_name }}
+      sync_matrix: ${{ steps.apply_tags.outputs.sync_matrix }}
+      has_sync_targets: ${{ steps.apply_tags.outputs.has_sync_targets }}
     env:
       IS_RC: ${{ contains(github.ref, '-rc.') }}
       IS_BETA: ${{ contains(github.ref, '-beta.') }}
       IS_SANDBOX: ${{ contains(github.ref, '-sandbox.') }}
       IS_PRODUCTION: ${{ !contains(github.ref, '-rc.') && !contains(github.ref, '-beta.') && !contains(github.ref, '-sandbox.') && startsWith(github.ref, 'refs/tags/') }}
-      GITOPS_FILE_STG: ${{ inputs.gitops_file_stg }}
-      GITOPS_FILE_DEV: ${{ inputs.gitops_file_dev }}
-      GITOPS_FILE_PRD: ${{ inputs.gitops_file_prd }}
-      GITOPS_FILE_SANDBOX: ${{ inputs.gitops_file_sandbox }}
     steps:
       - name: Log in to Docker Hub
         if: ${{ inputs.enable_docker_login }}
@@ -125,47 +101,14 @@ jobs:
           echo "app_name=$APP_NAME" >> "$GITHUB_OUTPUT"
           echo "Application name: $APP_NAME"
 
-          # Generate GitOps file paths if not provided
-          SERVER="${{ inputs.gitops_server }}"
-          BASE_PATH="gitops/environments/${SERVER}/helmfile/applications"
-
-          if [[ -z "${{ inputs.gitops_file_dev }}" ]]; then
-            DEV_FILE="${BASE_PATH}/dev/${APP_NAME}/values.yaml"
-          else
-            DEV_FILE="${{ inputs.gitops_file_dev }}"
-          fi
-
-          if [[ -z "${{ inputs.gitops_file_stg }}" ]]; then
-            STG_FILE="${BASE_PATH}/stg/${APP_NAME}/values.yaml"
-          else
-            STG_FILE="${{ inputs.gitops_file_stg }}"
-          fi
-
-          if [[ -z "${{ inputs.gitops_file_prd }}" ]]; then
-            PRD_FILE="${BASE_PATH}/prd/${APP_NAME}/values.yaml"
-          else
-            PRD_FILE="${{ inputs.gitops_file_prd }}"
-          fi
-
-          if [[ -z "${{ inputs.gitops_file_sandbox }}" ]]; then
-            SANDBOX_FILE="${BASE_PATH}/sandbox/${APP_NAME}/values.yaml"
-          else
-            SANDBOX_FILE="${{ inputs.gitops_file_sandbox }}"
-          fi
-
-          echo "gitops_file_dev=$DEV_FILE" >> "$GITHUB_OUTPUT"
-          echo "gitops_file_stg=$STG_FILE" >> "$GITHUB_OUTPUT"
-          echo "gitops_file_prd=$PRD_FILE" >> "$GITHUB_OUTPUT"
-          echo "gitops_file_sandbox=$SANDBOX_FILE" >> "$GITHUB_OUTPUT"
-
-          # Generate ArgoCD app name base if not provided (without environment suffix)
-          if [[ -z "${{ inputs.argocd_app_name }}" ]]; then
-            ARGOCD_APP_BASE="${SERVER}-${APP_NAME}"
-          else
-            ARGOCD_APP_BASE="${{ inputs.argocd_app_name }}"
-          fi
-          echo "argocd_app_base=$ARGOCD_APP_BASE" >> "$GITHUB_OUTPUT"
-          echo "ArgoCD app base name: $ARGOCD_APP_BASE"
+          # Determine which servers to deploy to
+          DEPLOY_FIRMINO="${{ inputs.deploy_in_firmino }}"
+          DEPLOY_CLOTILDE="${{ inputs.deploy_in_clotilde }}"
+          
+          echo "deploy_firmino=$DEPLOY_FIRMINO" >> "$GITHUB_OUTPUT"
+          echo "deploy_clotilde=$DEPLOY_CLOTILDE" >> "$GITHUB_OUTPUT"
+          echo "Deploy to Firmino: $DEPLOY_FIRMINO"
+          echo "Deploy to Clotilde: $DEPLOY_CLOTILDE"
 
           # Generate commit message prefix if not provided
           if [[ -z "${{ inputs.commit_message_prefix }}" ]]; then
@@ -184,89 +127,6 @@ jobs:
           fi
           echo "artifact_pattern=$ARTIFACT_PATTERN" >> "$GITHUB_OUTPUT"
           echo "Artifact pattern: $ARTIFACT_PATTERN"
-
-      - name: Detect environment from tag
-        if: ${{ inputs.environment_detection == 'tag_suffix' }}
-        id: detect_env
-        shell: bash
-        run: |
-          TAG_REF="${GITHUB_REF}"
-          echo "Processing ref: $TAG_REF"
-
-          if [[ "$TAG_REF" == *"-beta"* ]]; then
-            echo "environment=dev" >> "$GITHUB_OUTPUT"
-            echo "env_label=beta/dev" >> "$GITHUB_OUTPUT"
-            echo "Detected beta tag → dev environment"
-          elif [[ "$TAG_REF" == *"-rc"* ]]; then
-            echo "environment=stg" >> "$GITHUB_OUTPUT"
-            echo "env_label=rc/stg" >> "$GITHUB_OUTPUT"
-            echo "Detected rc tag → stg environment"
-          elif [[ "$TAG_REF" == refs/tags/* ]] && [[ ! "$TAG_REF" =~ -(beta|rc) ]]; then
-            echo "environment=prd" >> "$GITHUB_OUTPUT"
-            echo "env_label=production" >> "$GITHUB_OUTPUT"
-            echo "Detected production tag → prd environment (will update prd + sandbox)"
-          else
-            echo "❌ Unable to detect environment from ref: $TAG_REF"
-            exit 1
-          fi
-
-      - name: Set manual environment
-        if: ${{ inputs.environment_detection == 'manual' }}
-        id: manual_env
-        shell: bash
-        run: |
-          ENV="${{ inputs.manual_environment }}"
-          if [[ -z "$ENV" ]]; then
-            echo "❌ manual_environment input is required when environment_detection is 'manual'"
-            exit 1
-          fi
-          echo "environment=$ENV" >> "$GITHUB_OUTPUT"
-          echo "env_label=$ENV" >> "$GITHUB_OUTPUT"
-          echo "Using manual environment: $ENV"
-
-      - name: Select target values.yaml file
-        id: select_file
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          ENV="${{ steps.detect_env.outputs.environment || steps.manual_env.outputs.environment }}"
-
-          case "$ENV" in
-            dev)
-              FILES="${{ steps.setup.outputs.gitops_file_dev }}"
-              ;;
-            stg)
-              FILES="${{ steps.setup.outputs.gitops_file_stg }}"
-              ;;
-            prd)
-              # Production releases update both prd and sandbox
-              PRD_FILE="${{ steps.setup.outputs.gitops_file_prd }}"
-              SANDBOX_FILE="${{ steps.setup.outputs.gitops_file_sandbox }}"
-              if [[ -n "$PRD_FILE" && -n "$SANDBOX_FILE" ]]; then
-                FILES="${PRD_FILE}|${SANDBOX_FILE}"
-              elif [[ -n "$PRD_FILE" ]]; then
-                FILES="${PRD_FILE}"
-              elif [[ -n "$SANDBOX_FILE" ]]; then
-                FILES="${SANDBOX_FILE}"
-              else
-                FILES=""
-              fi
-              ;;
-            *)
-              echo "❌ Unknown environment: $ENV"
-              exit 1
-              ;;
-          esac
-
-          if [[ -z "$FILES" ]]; then
-            echo "❌ No GitOps file configured for environment: $ENV"
-            echo "Please provide gitops_file_${ENV} input"
-            exit 1
-          fi
-
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
-          echo "Using values files: $FILES for environment: $ENV"
 
       - name: Install yq
         shell: bash
@@ -309,76 +169,156 @@ jobs:
           echo "Downloaded artifacts:"
           ls -la .gitops-tags/ || echo "No artifacts found"
 
-      - name: Apply tags to values.yaml
+      - name: Apply tags to values.yaml (multi-server)
+        id: apply_tags
         shell: bash
         run: |
           set -euo pipefail
 
-          # Detect environment and select appropriate file
-          if [[ "${{ env.IS_RC }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_STG }}"
-            ENV_NAME="stg"
-          elif [[ "${{ env.IS_BETA }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_DEV }}"
-            ENV_NAME="dev"
-          elif [[ "${{ env.IS_SANDBOX }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_SANDBOX }}"
-            ENV_NAME="sandbox"
+          # Get app name
+          APP_NAME="${{ steps.setup.outputs.app_name }}"
+          
+          # Determine environments to update based on tag type
+          if [[ "${{ env.IS_BETA }}" == "true" ]]; then
+            ENVIRONMENTS="dev"
+            ENV_LABEL="beta/dev"
+          elif [[ "${{ env.IS_RC }}" == "true" ]]; then
+            ENVIRONMENTS="stg"
+            ENV_LABEL="rc/stg"
           elif [[ "${{ env.IS_PRODUCTION }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_PRD }}"
-            ENV_NAME="prd"
+            ENVIRONMENTS="dev stg prd sandbox"
+            ENV_LABEL="production"
+          elif [[ "${{ env.IS_SANDBOX }}" == "true" ]]; then
+            ENVIRONMENTS="sandbox"
+            ENV_LABEL="sandbox"
           else
-            echo "❌ Unable to detect environment from tag: ${{ github.ref }}"
+            echo "Unable to detect environment from tag: ${{ github.ref }}"
             exit 1
           fi
-          echo "Detected environment: $ENV_NAME"
-          echo "Using values file: $FILE"
+          echo "env_label=$ENV_LABEL" >> "$GITHUB_OUTPUT"
+          echo "Detected tag type: $ENV_LABEL"
+          echo "Environments to update: $ENVIRONMENTS"
 
-          upd() {
-            local key="$1" file="$2"
-            [[ -f "$file" ]] || return 0
-            local TAG
-            TAG="$(cut -d= -f2 < "$file" | tr -d '[:space:]')"
-            [[ -n "$TAG" ]] || return 0
-            TAG="$TAG" yq e -i "$key = strenv(TAG)" "$FILE"
-            echo "Set $key → $TAG"
-          }
+          # Determine servers to deploy to
+          SERVERS=""
+          if [[ "${{ steps.setup.outputs.deploy_firmino }}" == "true" ]]; then
+            SERVERS="firmino"
+          fi
+          if [[ "${{ steps.setup.outputs.deploy_clotilde }}" == "true" ]]; then
+            if [[ -n "$SERVERS" ]]; then
+              SERVERS="$SERVERS clotilde"
+            else
+              SERVERS="clotilde"
+            fi
+          fi
+          
+          if [[ -z "$SERVERS" ]]; then
+            echo "No servers selected for deployment. Enable deploy_in_firmino or deploy_in_clotilde."
+            exit 1
+          fi
+          echo "Servers to deploy to: $SERVERS"
 
-          # Apply mappings from inputs
-          MAPPINGS='${{ inputs.yaml_key_mappings }}'
-          echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key yaml_key; do
-            upd "$yaml_key" ".gitops-tags/${artifact_key}"
+          # Track results
+          UPDATED_FILES=""
+          MISSING_FILES=""
+          UPDATED_SERVERS_ENVS=""
+
+          # Process each server and environment
+          for SERVER in $SERVERS; do
+            for ENV in $ENVIRONMENTS; do
+              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${APP_NAME}/values.yaml"
+              
+              echo ""
+              echo "Processing: $SERVER/$ENV"
+              echo "  Path: $VALUES_FILE"
+              
+              # Check if file exists
+              if [[ ! -f "$VALUES_FILE" ]]; then
+                echo "  WARNING: Values file not found for ${SERVER}/${ENV}: ${VALUES_FILE}"
+                MISSING_FILES="${MISSING_FILES}${SERVER}/${ENV}:${VALUES_FILE}\n"
+                continue
+              fi
+              
+              echo "  File exists, applying tags..."
+              
+              # Apply mappings from inputs
+              MAPPINGS='${{ inputs.yaml_key_mappings }}'
+              echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key yaml_key; do
+                ARTIFACT_FILE=".gitops-tags/${artifact_key}"
+                if [[ -f "$ARTIFACT_FILE" ]]; then
+                  TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
+                  if [[ -n "$TAG" ]]; then
+                    TAG="$TAG" yq e -i "$yaml_key = strenv(TAG)" "$VALUES_FILE"
+                    echo "    Set $yaml_key = $TAG"
+                  fi
+                fi
+              done
+              
+              # Apply configmap updates if configured
+              if [[ -n "${{ inputs.configmap_updates }}" ]]; then
+                CONFIGMAP_MAPPINGS='${{ inputs.configmap_updates }}'
+                echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key configmap_key; do
+                  ARTIFACT_FILE=".gitops-tags/${artifact_key}"
+                  if [[ -f "$ARTIFACT_FILE" ]]; then
+                    TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
+                    if [[ -n "$TAG" ]]; then
+                      TAG="$TAG" yq e -i "$configmap_key = strenv(TAG)" "$VALUES_FILE"
+                      echo "    Set $configmap_key = $TAG"
+                    fi
+                  fi
+                done
+              fi
+              
+              UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
+              UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
+            done
           done
 
-          # Apply configmap updates if configured
-          if [[ -n "${{ inputs.configmap_updates }}" ]]; then
-            CONFIGMAP_MAPPINGS='${{ inputs.configmap_updates }}'
-            echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"' | while IFS='|' read -r artifact_key configmap_key; do
-              upd "$configmap_key" ".gitops-tags/${artifact_key}"
-            done
+          # Report results
+          echo ""
+          echo "========================================="
+          echo "Summary:"
+          echo "========================================="
+          if [[ -n "$UPDATED_FILES" ]]; then
+            echo "Updated files:"
+            echo -e "$UPDATED_FILES"
+          else
+            echo "No files were updated"
           fi
+          
+          if [[ -n "$MISSING_FILES" ]]; then
+            echo ""
+            echo "Missing files (skipped):"
+            echo -e "$MISSING_FILES"
+          fi
+
+          # Save updated servers/envs for ArgoCD sync
+          if [[ -n "$UPDATED_SERVERS_ENVS" ]]; then
+            echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' > /tmp/updated_servers_envs.txt
+            
+            # Output sync targets as JSON array for matrix job
+            SYNC_MATRIX=$(echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' | while IFS=: read -r s e; do
+              [[ -n "$s" && -n "$e" ]] && echo "{\"server\":\"$s\",\"env\":\"$e\"}"
+            done | jq -s -c '.')
+            echo "sync_matrix=$SYNC_MATRIX" >> "$GITHUB_OUTPUT"
+            echo "has_sync_targets=true" >> "$GITHUB_OUTPUT"
+            echo "Sync matrix: $SYNC_MATRIX"
+          else
+            echo "sync_matrix=[]" >> "$GITHUB_OUTPUT"
+            echo "has_sync_targets=false" >> "$GITHUB_OUTPUT"
+          fi
+          
+          echo "updated_count=$(echo -e "$UPDATED_FILES" | grep -c -v '^$' || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Show git diff
         shell: bash
         run: |
           cd gitops
           echo "Changes to be committed:"
-          # Detect environment and select appropriate file (same logic as apply step)
-          if [[ "${{ env.IS_RC }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_STG }}"
-            ENV_NAME="stg"
-          elif [[ "${{ env.IS_BETA }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_DEV }}"
-            ENV_NAME="dev"
-          elif [[ "${{ env.IS_SANDBOX }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_SANDBOX }}"
-            ENV_NAME="sandbox"
-          elif [[ "${{ env.IS_PRODUCTION }}" == "true" ]]; then
-            FILE="${{ env.GITOPS_FILE_PRD }}"
-            ENV_NAME="prd"
-          fi
-          echo "--- Changes in $FILE ($ENV_NAME) ---"
-          git diff -- "$FILE" || true
+          git diff --stat
+          echo ""
+          echo "Detailed changes:"
+          git diff
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
@@ -396,63 +336,79 @@ jobs:
         run: |
           set -e
           cd gitops
-          # Detect environment for commit message
-          if [[ "${{ env.IS_RC }}" == "true" ]]; then
-            ENV_LABEL="rc/stg"
-          elif [[ "${{ env.IS_BETA }}" == "true" ]]; then
-            ENV_LABEL="beta/dev"
-          elif [[ "${{ env.IS_SANDBOX }}" == "true" ]]; then
-            ENV_LABEL="sandbox"
-          elif [[ "${{ env.IS_PRODUCTION }}" == "true" ]]; then
-            ENV_LABEL="production"
-          else
-            ENV_LABEL="unknown"
+          
+          # Get env label from apply_tags step
+          ENV_LABEL="${{ steps.apply_tags.outputs.env_label }}"
+          
+          # Check if there are changes to commit
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 0
           fi
+          
           git commit -am "ci(${{ steps.setup.outputs.commit_prefix }}): update image tags ($ENV_LABEL)" || echo "No changes to commit"
           git push origin main
 
-      - name: ArgoCD Sync
-        if: ${{ inputs.enable_argocd_sync }}
+  # ArgoCD Sync Job - runs in parallel for each server/env combination
+  argocd_sync:
+    name: ArgoCD Sync (${{ matrix.target.server }}/${{ matrix.target.env }})
+    needs: [update_gitops]
+    if: needs.update_gitops.outputs.has_sync_targets == 'true' && inputs.enable_argocd_sync
+    runs-on: ${{ inputs.runner_type }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.update_gitops.outputs.sync_matrix) }}
+    steps:
+      - name: Check if ArgoCD app exists
+        id: check_app
         shell: bash
+        env:
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
+          ARGOCD_URL: ${{ secrets.ARGOCD_URL }}
         run: |
-          # Detect environment for ArgoCD sync
-          if [[ "${{ env.IS_RC }}" == "true" ]]; then
-            ENV_SUFFIX="stg"
-          elif [[ "${{ env.IS_BETA }}" == "true" ]]; then
-            ENV_SUFFIX="dev"
-          elif [[ "${{ env.IS_SANDBOX }}" == "true" ]]; then
-            ENV_SUFFIX="sandbox"
-          elif [[ "${{ env.IS_PRODUCTION }}" == "true" ]]; then
-            ENV_SUFFIX="prd"
-          else
-            echo "❌ Unable to detect environment for ArgoCD sync"
-            exit 1
+          APP_NAME="${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}-${{ matrix.target.env }}"
+          echo "Checking if ArgoCD app exists: $APP_NAME"
+          
+          # Install argocd CLI if not available
+          if ! command -v argocd &> /dev/null; then
+            curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            chmod +x /usr/local/bin/argocd
           fi
-          APP_BASE="${{ steps.setup.outputs.argocd_app_base }}"
-          echo "Syncing ArgoCD app: ${APP_BASE}-${ENV_SUFFIX} (base: $APP_BASE, env: $ENV_SUFFIX)"
-
-          # Call ArgoCD sync action with base name and env prefix
-          echo "APP_BASE=$APP_BASE" >> "$GITHUB_ENV"
-          echo "ENV_PREFIX=$ENV_SUFFIX" >> "$GITHUB_ENV"
+          
+          # Check if app exists
+          if argocd app get "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web > /dev/null 2>&1; then
+            echo "app_exists=true" >> "$GITHUB_OUTPUT"
+            echo "App $APP_NAME exists, will sync"
+          else
+            echo "app_exists=false" >> "$GITHUB_OUTPUT"
+            echo "App $APP_NAME does not exist, skipping sync"
+          fi
 
       - name: Execute ArgoCD Sync
-        if: ${{ inputs.enable_argocd_sync }}
+        if: steps.check_app.outputs.app_exists == 'true'
         uses: LerianStudio/github-actions-argocd-sync@main
         with:
-          app-name: ${{ env.APP_BASE }}
+          app-name: ${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}
           argo-cd-token: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
           argo-cd-url: ${{ secrets.ARGOCD_URL }}
-          env-prefix: ${{ env.ENV_PREFIX }}
+          env-prefix: ${{ matrix.target.env }}
+        continue-on-error: true
+
+      - name: Log skipped sync
+        if: steps.check_app.outputs.app_exists == 'false'
+        run: |
+          echo "::warning::ArgoCD app ${{ matrix.target.server }}-${{ needs.update_gitops.outputs.app_name }}-${{ matrix.target.env }} does not exist, sync skipped"
 
   # Slack notification
   notify:
     name: Notify
-    needs: [update_gitops]
+    needs: [update_gitops, argocd_sync]
     if: always()
     uses: ./.github/workflows/slack-notify.yml
     with:
-      status: ${{ needs.update_gitops.result }}
+      status: ${{ needs.update_gitops.result == 'failure' && 'failure' || needs.argocd_sync.result == 'failure' && 'failure' || 'success' }}
       workflow_name: "GitOps Update"
-      failed_jobs: ${{ needs.update_gitops.result == 'failure' && 'Update GitOps' || '' }}
+      failed_jobs: ${{ needs.update_gitops.result == 'failure' && 'Update GitOps' || '' }}${{ needs.argocd_sync.result == 'failure' && 'ArgoCD Sync' || '' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -154,6 +154,8 @@ jobs:
           pattern: ${{ steps.setup.outputs.artifact_pattern }}
           path: .gitops-tags
           merge-multiple: true
+          # Only download from this workflow run (default behavior, but explicit for safety)
+          run-id: ${{ github.run_id }}
         continue-on-error: true
 
       - name: Fallback to legacy artifact name
@@ -162,12 +164,35 @@ jobs:
         with:
           name: gitops-tags
           path: .gitops-tags
+          run-id: ${{ github.run_id }}
 
-      - name: List downloaded artifacts
+      - name: Validate artifacts exist
+        id: validate_artifacts
         shell: bash
         run: |
-          echo "Downloaded artifacts:"
-          ls -la .gitops-tags/ || echo "No artifacts found"
+          echo "Checking for downloaded artifacts..."
+          
+          # Check if directory exists and has files
+          if [[ ! -d ".gitops-tags" ]]; then
+            echo "::error::No artifacts directory found. Build job may have been skipped or failed to produce artifacts."
+            echo "artifacts_valid=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          
+          # Count actual artifact files (not directories)
+          ARTIFACT_COUNT=$(find .gitops-tags -type f -name "*.tag" 2>/dev/null | wc -l || echo "0")
+          
+          if [[ "$ARTIFACT_COUNT" -eq 0 ]]; then
+            echo "::error::No artifact files found in .gitops-tags/. Build job may have been skipped or failed."
+            echo "Directory contents:"
+            ls -laR .gitops-tags/ 2>/dev/null || echo "Directory is empty or doesn't exist"
+            echo "artifacts_valid=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          
+          echo "Found $ARTIFACT_COUNT artifact file(s):"
+          ls -la .gitops-tags/
+          echo "artifacts_valid=true" >> "$GITHUB_OUTPUT"
 
       - name: Apply tags to values.yaml (multi-server)
         id: apply_tags

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -147,6 +147,14 @@ jobs:
           cd gitops
           git pull origin main
 
+      - name: Cleanup old artifacts (self-hosted runner safety)
+        shell: bash
+        run: |
+          # Remove any existing artifacts from previous runs (important for self-hosted runners)
+          echo "Cleaning up old artifacts directory..."
+          rm -rf .gitops-tags
+          echo "Cleanup complete"
+
       - name: Download GitOps tag artifacts (pattern-based)
         id: download-pattern
         uses: actions/download-artifact@v7

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -1,21 +1,24 @@
 # GitOps Update Workflow
 
-Reusable workflow for updating GitOps repository with new image tags across multiple environments.
+Reusable workflow for updating GitOps repository with new image tags across multiple servers and environments.
 
 ## Features
 
+- **Multi-server deployment**: Deploy to Firmino and/or Clotilde servers with dynamic path generation
 - **Convention-based configuration**: Auto-generates paths, names, and patterns from repository name
 - **Multi-environment support**: dev (beta), stg (rc), prd (production), sandbox
-- **Production + Sandbox sync**: Production releases automatically update both environments
+- **Production sync**: Production releases automatically update all environments (dev, stg, prd, sandbox) on all servers
+- **File existence validation**: Graceful handling of missing values files with warnings (never fails)
 - **Flexible tag mapping**: Static or dynamic YAML key mapping
 - **Automatic environment detection**: Based on git tag suffix
-- **ArgoCD integration**: Automatic sync after GitOps update (enabled by default)
+- **ArgoCD integration**: Automatic sync for each server/environment combination where files were updated
+- **App existence check**: Verifies ArgoCD app exists before attempting sync
 - **Docker Hub login**: Enabled by default to avoid rate limits
 - **Customizable runners**: Support for different GitHub runner types
 
 ## Usage
 
-### Minimal Example (Convention-Based)
+### Minimal Example (Convention-Based, Both Servers)
 
 ```yaml
 update_gitops:
@@ -32,52 +35,52 @@ update_gitops:
 **Auto-generated values** (for repo `my-backend-service`):
 - App name: `my-backend-service`
 - Artifact pattern: `gitops-tags-my-backend-service-*`
-- GitOps paths: `gitops/environments/firmino/helmfile/applications/{env}/my-backend-service/values.yaml`
-- ArgoCD app: `firmino-my-backend-service`
+- GitOps paths: 
+  - Firmino: `gitops/environments/firmino/helmfile/applications/{env}/my-backend-service/values.yaml`
+  - Clotilde: `gitops/environments/clotilde/helmfile/applications/{env}/my-backend-service/values.yaml`
+- ArgoCD apps: `firmino-my-backend-service-{env}`, `clotilde-my-backend-service-{env}`
 - Commit prefix: `my-backend-service`
 
-### Multi-Component Example (Backend + Frontend)
-
-```yaml
-update_gitops:
-  needs: [build_backend, build_frontend]
-  if: needs.build_backend.result == 'success' || needs.build_frontend.result == 'success'
-  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
-  with:
-    yaml_key_mappings: '{"backend.tag": ".crm.image.tag", "frontend.tag": ".frontend.image.tag"}'
-  secrets: inherit
-```
-
-### Dynamic Mapping Example (Multiple Components like Midaz)
-
-```yaml
-update_gitops:
-  needs: build_and_publish
-  if: contains(github.ref, '-beta') || contains(github.ref, '-rc')
-  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
-  with:
-    use_dynamic_mapping: true
-    yaml_key_mappings: '{"prefix": "midaz-"}'
-  secrets: inherit
-```
-
-### Manual Environment Selection
+### Single Server Example (Firmino Only)
 
 ```yaml
 update_gitops:
   needs: build_backend
+  if: needs.build_backend.result == 'success'
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    environment_detection: 'manual'
-    manual_environment: 'sandbox'
-    gitops_file_sandbox: gitops/environments/firmino/helmfile/applications/sandbox/my-backend-service/values.yaml
-    artifact_pattern: 'gitops-tags-backend'
-    yaml_key_mappings: |
-      {
-        "backend.tag": ".auth.image.tag"
-      }
-    commit_message_prefix: 'my-backend-service'
-    enable_argocd_sync: false
+    deploy_in_firmino: true
+    deploy_in_clotilde: false
+    yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
+  secrets: inherit
+```
+
+### Single Server Example (Clotilde Only)
+
+```yaml
+update_gitops:
+  needs: build_backend
+  if: needs.build_backend.result == 'success'
+  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
+  with:
+    deploy_in_firmino: false
+    deploy_in_clotilde: true
+    yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
+  secrets: inherit
+```
+
+### Multi-Component Example (Midaz)
+
+```yaml
+update_gitops:
+  needs: build
+  if: needs.build.result == 'success'
+  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
+  with:
+    app_name: "midaz"
+    artifact_pattern: "gitops-tags-midaz-*"
+    yaml_key_mappings: '{"midaz-onboarding.tag": ".onboarding.image.tag", "midaz-transaction.tag": ".transaction.image.tag"}'
+    commit_message_prefix: "midaz"
   secrets: inherit
 ```
 
@@ -93,23 +96,18 @@ update_gitops:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `gitops_repository` | string | `MyOrg/my-gitops-repo` | GitOps repository to update |
-| `gitops_server` | string | `firmino` | Server name for GitOps path generation |
+| `gitops_repository` | string | `LerianStudio/midaz-firmino-gitops` | GitOps repository to update |
 | `app_name` | string | (repo name) | Application name (auto-detected from repository) |
+| `deploy_in_firmino` | boolean | `true` | Deploy to Firmino server |
+| `deploy_in_clotilde` | boolean | `true` | Deploy to Clotilde server |
 | `artifact_pattern` | string | `gitops-tags-{app}-*` | Pattern to download artifacts (auto-generated) |
 | `commit_message_prefix` | string | (repo name) | Prefix for commit message (auto-generated) |
-| `argocd_app_name` | string | `{server}-{app}` | ArgoCD application name (auto-generated) |
-| `gitops_file_dev` | string | (auto-generated) | Path to dev environment values.yaml |
-| `gitops_file_stg` | string | (auto-generated) | Path to stg environment values.yaml |
-| `gitops_file_prd` | string | (auto-generated) | Path to prd environment values.yaml |
-| `gitops_file_sandbox` | string | (auto-generated) | Path to sandbox environment values.yaml |
-| `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
 | `enable_argocd_sync` | boolean | `true` | Enable ArgoCD sync |
 | `use_dynamic_mapping` | boolean | `false` | Use dynamic mapping for multiple components |
 | `yq_version` | string | `v4.44.3` | Version of yq to install |
-| `environment_detection` | string | `tag_suffix` | Environment detection strategy (`tag_suffix` or `manual`) |
-| `manual_environment` | string | - | Manually specify environment (dev/stg/prd/sandbox) |
 | `enable_docker_login` | boolean | `true` | Enable Docker Hub login to avoid rate limits |
+| `configmap_updates` | string | - | JSON object mapping artifact names to configmap keys |
 
 ## Secrets
 
@@ -117,215 +115,176 @@ update_gitops:
 
 | Secret | Description |
 |--------|-------------|
-| `manage_token` | GitHub token with access to GitOps repository |
-| `ci_cd_user_name` | Git user name for commits |
-| `ci_cd_user_email` | Git user email for commits |
+| `MANAGE_TOKEN` | GitHub token with access to GitOps repository |
+| `LERIAN_CI_CD_USER_NAME` | Git user name for commits |
+| `LERIAN_CI_CD_USER_EMAIL` | Git user email for commits |
+| `LERIAN_CI_CD_USER_GPG_KEY` | GPG key for signing commits |
+| `LERIAN_CI_CD_USER_GPG_KEY_PASSWORD` | GPG key passphrase |
 
 ### Required Secrets (ArgoCD)
 
 | Secret | Description |
 |--------|-------------|
-| `argocd_token` | ArgoCD authentication token |
-| `argocd_url` | ArgoCD server URL |
+| `ARGOCD_GHUSER_TOKEN` | ArgoCD authentication token |
+| `ARGOCD_URL` | ArgoCD server URL |
 
 ### Required Secrets (Docker Hub)
 
 | Secret | Description |
 |--------|-------------|
-| `docker_username` | Docker Hub username (to avoid rate limits) |
-| `docker_password` | Docker Hub password |
+| `DOCKER_USERNAME` | Docker Hub username (to avoid rate limits) |
+| `DOCKER_PASSWORD` | Docker Hub password |
 
-## Convention-Based Configuration
+## Multi-Server Path Generation
 
-The workflow automatically generates configuration based on repository name:
+The workflow dynamically generates paths for each server and environment combination:
 
-**For repository `my-api-service`:**
-- **App name**: `my-api-service`
-- **Artifact pattern**: `gitops-tags-my-api-service-*`
-- **Commit prefix**: `my-api-service`
-- **ArgoCD app**: `firmino-my-api-service`
-- **GitOps paths**:
-  - Dev: `gitops/environments/firmino/helmfile/applications/dev/my-api-service/values.yaml`
-  - Stg: `gitops/environments/firmino/helmfile/applications/stg/my-api-service/values.yaml`
-  - Prd: `gitops/environments/firmino/helmfile/applications/prd/my-api-service/values.yaml`
-  - Sandbox: `gitops/environments/firmino/helmfile/applications/sandbox/my-api-service/values.yaml`
-
-## Environment Detection
-
-The workflow automatically detects the target environment based on git tag suffix:
-
-| Tag Pattern | Environment | Files Updated | ArgoCD Synced |
-|-------------|-------------|---------------|---------------|
-| `v*.*.*-beta.*` | dev | dev only | dev |
-| `v*.*.*-rc.*` | stg | stg only | stg |
-| `v*.*.*` (no suffix) | prd | **prd + sandbox** | **prd + sandbox** |
-
-**Note**: Production releases automatically update both production and sandbox environments.
-
-## YAML Key Mappings
-
-### Static Mapping
-
-Used for simple, predefined key mappings:
-
-```json
-{
-  "backend.tag": ".auth.image.tag",
-  "frontend.tag": ".frontend.image.tag"
-}
+```
+gitops/environments/<server>/helmfile/applications/<env>/<app_name>/values.yaml
 ```
 
-The workflow will:
-1. Find artifacts matching the key pattern (e.g., files containing "backend.tag")
-2. Read the tag value from the artifact
-3. Update the specified YAML key (e.g., `.auth.image.tag`)
+Where:
+- `<server>`: `firmino` or `clotilde` (controlled by `deploy_in_firmino` and `deploy_in_clotilde` inputs)
+- `<env>`: `dev`, `stg`, `prd`, or `sandbox` (determined by tag type)
+- `<app_name>`: from `inputs.app_name` or auto-detected from repository name
 
-### Dynamic Mapping
+### Environment-to-Files Mapping
 
-Used for multiple components with consistent naming:
+| Tag Type | Environment Label | Environments Updated |
+|----------|------------------|----------------------|
+| `v*.*.*-beta.*` | beta/dev | `dev` on selected servers |
+| `v*.*.*-rc.*` | rc/stg | `stg` on selected servers |
+| `v*.*.*` (no suffix) | production | `dev`, `stg`, `prd`, `sandbox` on selected servers |
+| `v*.*.*-sandbox.*` | sandbox | `sandbox` on selected servers |
 
-```json
-{
-  "prefix": "myapp-"
-}
-```
+### File Existence Validation
 
-The workflow expects artifact files named: `{app-name}={version}`
+The workflow validates that values files exist before applying tags:
 
-Example: `myapp-auth=1.2.3-rc.1`
+1. **If a file is missing:** A warning is logged and the file is skipped
+2. **The workflow never fails due to missing files** - it simply logs and continues
 
-The workflow will:
-1. Parse the artifact filename
-2. Remove the prefix (e.g., "myapp-" → "auth")
-3. Update `.{component}.image.tag` (e.g., `.auth.image.tag`)
+This allows for partial deployments where not all server/environment combinations have values files configured.
 
-## Artifact Requirements
+### Example: Production Release
 
-### For Static Mapping
+When a production tag (e.g., `v1.2.3`) is pushed with both servers enabled, the workflow will:
 
-Artifacts should contain the tag value and match the key pattern:
+1. Generate paths for Firmino:
+   - `gitops/environments/firmino/helmfile/applications/dev/my-app/values.yaml`
+   - `gitops/environments/firmino/helmfile/applications/stg/my-app/values.yaml`
+   - `gitops/environments/firmino/helmfile/applications/prd/my-app/values.yaml`
+   - `gitops/environments/firmino/helmfile/applications/sandbox/my-app/values.yaml`
 
-```bash
-# Example: Create artifact for backend
-mkdir -p gitops-tags
-echo "1.2.3-beta.1" > gitops-tags/backend.tag
+2. Generate paths for Clotilde:
+   - `gitops/environments/clotilde/helmfile/applications/dev/my-app/values.yaml`
+   - `gitops/environments/clotilde/helmfile/applications/stg/my-app/values.yaml`
+   - `gitops/environments/clotilde/helmfile/applications/prd/my-app/values.yaml`
+   - `gitops/environments/clotilde/helmfile/applications/sandbox/my-app/values.yaml`
 
-# Upload artifact
-- uses: actions/upload-artifact@v4
-  with:
-    name: gitops-tags-backend
-    path: gitops-tags/
-```
+3. Apply tags to all existing files (skip missing ones with warning)
+4. Sync ArgoCD apps for each server/environment where files were updated
 
-### For Dynamic Mapping
+## ArgoCD Multi-Server Sync
 
-Artifacts should be named: `{app-name}={version}`
+When `enable_argocd_sync` is `true`, the workflow syncs ArgoCD applications for each server/environment where files were successfully updated.
 
-```bash
-# Example: Create artifact for myapp-auth
-mkdir -p gitops-tags
-echo "myapp-auth=1.2.3-rc.1" > "gitops-tags/myapp-auth=1.2.3-rc.1"
+### App Naming Pattern
 
-# Upload artifact
-- uses: actions/upload-artifact@v4
-  with:
-    name: gitops-tags-myapp-auth
-    path: gitops-tags/
-```
+ArgoCD apps are named using the pattern: `<server>-<app_name>-<env>`
+
+Examples:
+- `firmino-midaz-dev`
+- `firmino-midaz-stg`
+- `firmino-midaz-prd`
+- `clotilde-midaz-dev`
+- `clotilde-midaz-stg`
+
+### Sync Behavior
+
+**Important:** ArgoCD sync only runs for server/environment combinations where values files were actually updated.
+
+| Tag Type | Potential Apps (if files exist) |
+|----------|--------------------------------|
+| beta | `{server}-{app}-dev` |
+| rc | `{server}-{app}-stg` |
+| production | `{server}-{app}-dev`, `{server}-{app}-stg`, `{server}-{app}-prd`, `{server}-{app}-sandbox` |
+| sandbox | `{server}-{app}-sandbox` |
+
+If a values file doesn't exist for a server/environment, that combination is skipped and ArgoCD sync is NOT triggered for it.
+
+### Matrix-Based Sync
+
+The workflow uses a matrix strategy for ArgoCD sync:
+1. The `apply_tags` step outputs a JSON array of server/env combinations that were updated
+2. A separate `argocd_sync` job runs in parallel for each combination
+3. Each job first checks if the ArgoCD app exists before attempting sync
+4. Each sync has `continue-on-error: true` for graceful failure handling
+
+### App Existence Check
+
+Before syncing, each matrix job checks if the ArgoCD app exists:
+- **App exists**: Proceeds with sync
+- **App doesn't exist**: Logs a warning and skips sync (no failure)
+
+This prevents unnecessary errors when an app hasn't been created in ArgoCD yet for a specific server/environment.
+
+### Graceful Failure
+
+- If one sync fails, other syncs will still attempt
+- The overall workflow will continue even if some syncs fail
+- Missing apps are logged as warnings, not failures
+- Check workflow logs to identify which syncs failed or were skipped
 
 ## Migration Guide
 
-### From Single Component App
+### From Single Server to Multi-Server
 
-**Before:**
+**Before (single server):**
 ```yaml
-update_gitops_backend:
-  needs: build_backend
-  if: ${{ needs.build_backend.result == 'success' }}
-  runs-on: firmino-lxc-runners
-  steps:
-    # ... 80+ lines of code ...
-```
-
-**After:**
-```yaml
-update_gitops_backend:
-  needs: build_backend
-  if: ${{ needs.build_backend.result == 'success' }}
+update_gitops:
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-backend-service/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-backend-service/values.yaml
-    artifact_pattern: 'gitops-tags-backend'
+    gitops_server: 'firmino'
+    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-app/values.yaml
+    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-app/values.yaml
+    gitops_file_prd: gitops/environments/firmino/helmfile/applications/prd/my-app/values.yaml
     yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
-    commit_message_prefix: 'my-backend-service'
-    argocd_app_name: 'firmino-my-backend-service'
   secrets: inherit
 ```
 
-### From Multi-Component App
-
-**Before:**
+**After (multi-server):**
 ```yaml
 update_gitops:
-  needs: [detect_changes, build_backend, build_frontend]
-  # ... complex conditions ...
-  runs-on: ubuntu-latest
-  steps:
-    # ... 90+ lines of code ...
-```
-
-**After:**
-```yaml
-update_gitops:
-  needs: [detect_changes, build_backend, build_frontend]
-  if: |
-    (needs.detect_changes.outputs.has_backend == 'true' && needs.build_backend.result == 'success') ||
-    (needs.detect_changes.outputs.has_frontend == 'true' && needs.build_frontend.result == 'success')
   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
   with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-fullstack-app/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-fullstack-app/values.yaml
-    artifact_pattern: 'gitops-tags-my-fullstack-app-*'
-    yaml_key_mappings: |
-      {
-        "backend.tag": ".api.image.tag",
-        "frontend.tag": ".web.image.tag"
-      }
-    commit_message_prefix: 'my-fullstack-app'
-    argocd_app_name: 'firmino-my-fullstack-app'
-    runner_type: 'ubuntu-latest'
+    app_name: 'my-app'
+    deploy_in_firmino: true
+    deploy_in_clotilde: true
+    yaml_key_mappings: '{"backend.tag": ".auth.image.tag"}'
   secrets: inherit
 ```
 
-### From Monorepo with Dynamic Mapping
+### Key Changes
 
-**Before:**
-```yaml
-update_gitops:
-  needs: [build_and_publish]
-  if: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
-  runs-on: firmino-lxc-runners
-  steps:
-    # ... 60+ lines of code with complex logic ...
-```
+1. **Removed inputs:**
+   - `gitops_server` - No longer needed; use `deploy_in_firmino` and `deploy_in_clotilde` instead
+   - `gitops_file_dev`, `gitops_file_stg`, `gitops_file_prd`, `gitops_file_sandbox` - Paths are now auto-generated
+   - `argocd_app_name` - Now auto-generated based on server/app/env pattern
+   - `environment_detection`, `manual_environment` - Simplified to automatic detection only
 
-**After:**
-```yaml
-update_gitops:
-  needs: [build_and_publish]
-  if: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
-  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@main
-  with:
-    gitops_file_dev: gitops/environments/firmino/helmfile/applications/dev/my-platform/values.yaml
-    gitops_file_stg: gitops/environments/firmino/helmfile/applications/stg/my-platform/values.yaml
-    artifact_pattern: 'gitops-tags-*'
-    use_dynamic_mapping: true
-    yaml_key_mappings: '{"prefix": "myapp-"}'
-    commit_message_prefix: 'my-platform'
-    argocd_app_name: 'firmino-my-platform'
-  secrets: inherit
-```
+2. **New inputs:**
+   - `deploy_in_firmino` (default: `true`) - Enable deployment to Firmino server
+   - `deploy_in_clotilde` (default: `true`) - Enable deployment to Clotilde server
+
+3. **Path generation:**
+   - Paths are automatically generated based on server and environment
+   - Pattern: `gitops/environments/<server>/helmfile/applications/<env>/<app_name>/values.yaml`
+
+4. **ArgoCD sync:**
+   - Now syncs apps for each server/environment combination where files were updated
+   - Pattern: `<server>-<app_name>-<env>`
+   - Checks if app exists before attempting sync
 
 ## Troubleshooting
 
@@ -333,13 +292,13 @@ update_gitops:
 
 This is normal if the tag already exists in the GitOps repository. The workflow will skip the commit step.
 
-### Environment detection failed
+### Values file not found warnings
 
-Ensure your git tags follow the expected pattern:
-- Beta: `v1.2.3-beta.1`
-- RC: `v1.2.3-rc.1`
-- Production: `v1.2.3`
-- Sandbox: `v1.2.3-sandbox.1`
+If you see warnings like "Values file not found for firmino/dev", this means the values.yaml file doesn't exist for that server/environment combination. The workflow will skip this combination and continue with others.
+
+### ArgoCD app does not exist
+
+If you see warnings like "ArgoCD app firmino-myapp-dev does not exist, sync skipped", this means the ArgoCD application hasn't been created yet. The workflow will log a warning and continue.
 
 ### Artifact not found
 
@@ -356,9 +315,8 @@ Verify the YAML key path in your mappings:
 
 ## Best Practices
 
-1. **Use specific artifact patterns** to avoid conflicts
-2. **Enable checksum verification** for production environments
-3. **Test with sandbox environment** before deploying to production
-4. **Use dynamic mapping** for applications with multiple components
+1. **Start with both servers enabled** - the workflow gracefully handles missing files
+2. **Use specific artifact patterns** to avoid conflicts
+3. **Test with beta tags first** before deploying to production
+4. **Monitor ArgoCD sync results** in workflow logs
 5. **Keep YAML key mappings simple** and consistent across environments
-6. **Always specify all environment files** (dev, stg, prd) for flexibility


### PR DESCRIPTION
## Summary

This PR adds multi-server deployment support to the GitOps update workflow, enabling deployments to both Firmino and Clotilde servers with dynamic path generation, graceful error handling, and intelligent ArgoCD sync.

## Changes

### New Features
- **Multi-server deployment**: Deploy to Firmino and/or Clotilde with `deploy_in_firmino` and `deploy_in_clotilde` inputs
- **Dynamic path generation**: Auto-generates paths for each server/environment combination
- **File existence validation**: Graceful handling of missing values files (warns, never fails)
- **Matrix-based ArgoCD sync**: Parallel sync for each server/env where files were updated
- **App existence check**: Verifies ArgoCD app exists before sync (uses `skip-if-not-exists`)
- **Artifact cleanup**: Self-hosted runners now clean old artifacts before download
- **Artifact validation**: Fails early if no artifacts found from current run

### Fixes
- Fixed `env.GITOPS_FILE_*` empty variable issue by using step outputs
- Fixed ArgoCD CLI download (download to /tmp first, then sudo mv)
- Fixed artifact isolation for self-hosted runners with explicit `run-id` parameter
- Only update files with actual tag changes (prevents unnecessary yq reformatting)

### Breaking Changes
- Removed inputs: `gitops_server`, `gitops_file_dev`, `gitops_file_stg`, `gitops_file_prd`, `gitops_file_sandbox`, `argocd_app_name`, `environment_detection`, `manual_environment`
- New default behavior: deploys to both Firmino and Clotilde

## Migration

**Before:**
```yaml
update_gitops:
  uses: .../gitops-update.yml@main
  with:
    gitops_server: 'firmino'
    gitops_file_dev: gitops/environments/firmino/.../values.yaml
    argocd_app_name: firmino-my-app
```

**After:**
```yaml
update_gitops:
  uses: .../gitops-update.yml@main
  with:
    app_name: 'my-app'
    deploy_in_firmino: true
    deploy_in_clotilde: true
```

## Testing

- Tested with PR #1863 in LerianStudio/midaz
- Successful execution: https://github.com/LerianStudio/midaz/actions/runs/22502731824/job/65194355355
- All steps passed: cleanup, artifact download, validation, tag application, commit/push

## Documentation

Updated `docs/gitops-update-workflow.md` with:
- Multi-server deployment examples
- Updated inputs table
- Path generation patterns
- ArgoCD sync behavior
- Migration guide
- Troubleshooting section