### PR TITLE
feat(ci): Update build workfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,11 @@ on:
         description: 'JSON mapping of component names to values.yaml keys. If not mapped, uses component name as fallback. Example: {"my-app": "api", "my-app-worker": "worker"}'
         type: string
         default: ''
+      # Docker build arguments
+      build_args:
+        description: 'Newline-separated Docker build arguments. Use {APP_NAME} as placeholder for the detected app name (e.g., SITE={APP_NAME})'
+        type: string
+        default: ''
       # Path normalization
       normalize_to_filter:
         description: 'Normalize changed paths to their filter path (e.g., components/app/cmd -> components/app). Recommended for monorepos to avoid duplicate builds.'
@@ -257,6 +262,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.version }},enable=${{ needs.prepare.outputs.is_release }}
 
+      - name: Resolve build arguments
+        if: inputs.build_args != ''
+        id: resolve-build-args
+        run: |
+          RESOLVED=$(echo "${{ inputs.build_args }}" | sed 's/{APP_NAME}/${{ matrix.app.name }}/g')
+          {
+            echo "args<<EOF"
+            echo "$RESOLVED"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -266,6 +282,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.resolve-build-args.outputs.args }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           secrets: |

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -6,9 +6,11 @@ Reusable workflow for building and pushing Docker images to container registries
 
 - **Monorepo support**: Automatic detection of changed components via filter_paths
 - **Multi-registry**: Push to DockerHub and/or GitHub Container Registry (GHCR)
-- **Smart platform builds**: Beta/RC tags build amd64 only, release tags build amd64+arm64
+- **Smart platform builds**: Beta/RC tags build amd64 only, release tags build amd64+arm64 (overridable with `force_multiplatform`)
 - **Semantic versioning**: Automatic tag extraction and Docker metadata
 - **GitOps integration**: Upload artifacts for downstream gitops-update workflow
+- **Docker build arguments**: Pass custom build args with `{APP_NAME}` placeholder for monorepo-aware Dockerfiles
+- **Helm chart dispatch**: Automatic Helm repository updates on release
 - **Slack notifications**: Automatic success/failure notifications
 
 ## Usage
@@ -60,6 +62,33 @@ jobs:
     secrets: inherit
 ```
 
+### Monorepo with Shared Dockerfile (build_args)
+
+When using a single Dockerfile at the repo root that relies on a build argument to select the site/app:
+
+```yaml
+name: Build
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@main
+    with:
+      filter_paths: |
+        sites/
+      path_level: '2'
+      enable_dockerhub: true
+      enable_gitops_artifacts: true
+      build_context: '.'
+      build_args: |
+        SITE={APP_NAME}
+    secrets: inherit
+```
+
+The `{APP_NAME}` placeholder is automatically replaced with the detected app name from the matrix (e.g., `sites/tracer` → `SITE=tracer`).
+
 ### With GitOps Update
 
 ```yaml
@@ -93,19 +122,60 @@ jobs:
 
 ## Inputs
 
+### Core
+
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
 | `filter_paths` | string | `''` | Newline-separated list of path prefixes. If empty, builds from root (single-app mode) |
 | `path_level` | string | `2` | Directory depth for app name extraction |
+| `normalize_to_filter` | boolean | `true` | Normalize changed paths to their filter path. Recommended for monorepos to avoid duplicate builds |
+
+### Registry
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
 | `enable_dockerhub` | boolean | `true` | Enable pushing to DockerHub |
 | `enable_ghcr` | boolean | `false` | Enable pushing to GitHub Container Registry |
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `ghcr_org` | string | `''` | GHCR organization (defaults to repository owner) |
+
+### Docker Build
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
-| `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
 | `build_context` | string | `.` | Docker build context |
-| `enable_gitops_artifacts` | boolean | `false` | Upload artifacts for gitops-update workflow |
+| `build_args` | string | `''` | Newline-separated Docker build arguments. Use `{APP_NAME}` as placeholder for the detected app name (e.g., `SITE={APP_NAME}`) |
+| `force_multiplatform` | boolean | `false` | Force multi-platform build (amd64+arm64) even for beta/rc tags |
+
+### App Naming
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `app_name_prefix` | string | `''` | Prefix for app names in monorepo (e.g., `midaz` results in `midaz-agent`) |
+| `app_name_overrides` | string | `''` | Explicit app name mappings in `path:name` format. Overrides default extraction for matched paths |
+
+### GitOps
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable_gitops_artifacts` | boolean | `false` | Upload artifacts for downstream gitops-update workflow |
+
+### Helm Dispatch
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable_helm_dispatch` | boolean | `false` | Enable dispatching to Helm repository for chart updates |
+| `helm_repository` | string | `LerianStudio/helm` | Helm repository to dispatch to (org/repo format) |
+| `helm_chart` | string | `''` | Helm chart name to update |
+| `helm_target_ref` | string | `main` | Target branch in Helm repository |
+| `helm_components_base_path` | string | `components` | Base path for components in source repo |
+| `helm_env_file` | string | `.env.example` | Env example file name relative to component path |
+| `helm_detect_env_changes` | boolean | `true` | Whether to detect new environment variables for Helm |
+| `helm_dispatch_on_rc` | boolean | `false` | Enable Helm dispatch for release-candidate (rc) tags |
+| `helm_dispatch_on_beta` | boolean | `false` | Enable Helm dispatch for beta tags |
+| `helm_values_key_mappings` | string | `''` | JSON mapping of component names to values.yaml keys |
 
 ## Secrets
 
@@ -115,8 +185,9 @@ Uses `secrets: inherit` pattern. Required secrets:
 |--------|-------------|---------------|
 | `DOCKER_USERNAME` | DockerHub username | `enable_dockerhub: true` |
 | `DOCKER_PASSWORD` | DockerHub password/token | `enable_dockerhub: true` |
-| `MANAGE_TOKEN` | GitHub token for GHCR | `enable_ghcr: true` |
+| `MANAGE_TOKEN` | GitHub token for GHCR and build secrets | `enable_ghcr: true` or always (used as build secret) |
 | `SLACK_WEBHOOK_URL` | Slack webhook for notifications | Optional |
+| `HELM_REPO_TOKEN` | Token for Helm repository dispatch | `enable_helm_dispatch: true` |
 
 ## Platform Build Strategy
 
@@ -127,6 +198,8 @@ The workflow automatically selects platforms based on the tag type:
 | Beta | `v1.0.0-beta.1` | `linux/amd64` | Faster CI for development |
 | RC | `v1.0.0-rc.1` | `linux/amd64` | Faster CI for staging |
 | Release | `v1.0.0` | `linux/amd64,linux/arm64` | Full multi-arch support |
+
+> Set `force_multiplatform: true` to override and build both platforms for beta/rc tags.
 
 ## Docker Image Tags
 
@@ -158,6 +231,35 @@ app_name_prefix: "myapp"
 Changed files in `components/api/` → Builds `myapp-api` image
 Changed files in `components/worker/` → Builds `myapp-worker` image
 
+## Docker Build Arguments
+
+When `build_args` is provided, the workflow resolves `{APP_NAME}` placeholders before passing arguments to `docker build`. This is useful for monorepos with a shared Dockerfile that selects sub-projects via `ARG`.
+
+**Example Dockerfile:**
+
+```dockerfile
+ARG SITE
+WORKDIR /app
+COPY sites/${SITE} sites/${SITE}
+```
+
+**Caller workflow:**
+
+```yaml
+build_args: |
+  SITE={APP_NAME}
+```
+
+If the detected app is `tracer` (from `sites/tracer`), the build receives `--build-arg SITE=tracer`.
+
+Multiple build args are supported (one per line):
+
+```yaml
+build_args: |
+  SITE={APP_NAME}
+  NODE_ENV=production
+```
+
 ## GitOps Artifacts
 
 When `enable_gitops_artifacts: true`:
@@ -185,11 +287,16 @@ Automatically sends notifications on completion:
 
 ### build
 - Runs for each component in the matrix
+- Resolves build arguments (replaces `{APP_NAME}` placeholders)
 - Builds and pushes Docker images
 - Creates GitOps artifacts if enabled
 
 ### notify
 - Sends Slack notification on completion
+
+### dispatch-helm
+- Dispatches to Helm repository for chart updates (when `enable_helm_dispatch: true`)
+- By default only runs on production releases; can be enabled for rc/beta via `helm_dispatch_on_rc` and `helm_dispatch_on_beta`
 
 ## Best Practices
 
@@ -220,7 +327,17 @@ Automatically sends notifications on completion:
 
 **Issue**: ARM64 builds take too long
 
-**Solution**: ARM64 builds only run on release tags. Beta/RC tags build amd64 only for faster CI.
+**Solution**: ARM64 builds only run on release tags. Beta/RC tags build amd64 only for faster CI. Use `force_multiplatform: true` to override this behavior.
+
+### Docker build fails with missing ARG
+
+**Issue**: Dockerfile uses `ARG` (e.g., `ARG SITE`) but the build fails because the argument is not passed.
+
+**Solution**: Use the `build_args` input with the `{APP_NAME}` placeholder:
+```yaml
+build_args: |
+  SITE={APP_NAME}
+```
 
 ## Related Workflows
 
@@ -228,7 +345,9 @@ Automatically sends notifications on completion:
 - [Release](release-workflow.md) - Create releases that trigger builds
 - [Slack Notify](slack-notify-workflow.md) - Notification system
 
+- [Helm Dispatch](dispatch-helm-workflow.md) - Automatic Helm chart updates
+
 ---
 
-**Last Updated:** 2025-12-09
-**Version:** 1.0.0
+**Last Updated:** 2026-03-03
+**Version:** 1.14.0


### PR DESCRIPTION
## Description

  Add `build_args` input to the build workflow, allowing callers to pass Docker build arguments with automatic `{APP_NAME}`
  placeholder resolution. This enables monorepo projects with shared Dockerfiles that rely on `ARG` to select the correct
  sub-project at build time. Also updates the build workflow documentation to reflect all current inputs.

  ## Type of Change

  - [x] `feat`: New feature or workflow
  - [ ] `fix`: Bug fix
  - [x] `docs`: Documentation update
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Adding or updating tests
  - [ ] `ci`: CI/CD configuration changes
  - [ ] `chore`: Maintenance tasks
  - [ ] `BREAKING CHANGE`: Breaking change (requires major version bump)

  ## Affected Workflows

  - [ ] GitOps Update
  - [ ] API Dog E2E Tests
  - [ ] PR Security Scan
  - [ ] Release Workflow
  - [x] Other (specify): Build and Push Docker Images

  ## Changes Made

  - Add `build_args` input (string, default: '') to the build workflow accepting newline-separated Docker build arguments
  - Add "Resolve build arguments" step that replaces `{APP_NAME}` placeholder with the detected app name from the matrix
  - Pass resolved build-args to `docker/build-push-action`
  - Update `docs/build-workflow.md` with all current inputs (was missing 14+ inputs), new usage example for shared Dockerfile
  monorepos, build arguments section, Helm dispatch docs, and troubleshooting entries

  ## Breaking Changes

  **None** — The new input defaults to empty string, preserving existing behavior. No build-args are passed when the input is
  not provided.

  ## Testing

  - [ ] Tested locally
  - [ ] Tested in development environment
  - [ ] Tested with example repository: LerianStudio/lerian-landing-pages
  - [x] All existing workflows still work

  ## Checklist

  - [x] Code follows conventional commit format
  - [x] Documentation updated (if applicable)
  - [x] Examples updated (if applicable)
  - [x] No hardcoded secrets or sensitive data
  - [x] Backward compatible (or breaking changes documented)
  - [x] Self-review completed
  - [x] Comments added for complex logic

  ## Related Issues

  Related to LerianStudio/lerian-landing-pages#1

  ## Additional Notes

  The `lerian-landing-pages` repository has a shared Dockerfile at root that uses `ARG SITE` to copy and build the correct
  site from `sites/${SITE}`. Without this input, the Docker build fails because the `SITE` arg is never passed. After this is
  merged and released, the landing-pages build workflow should be updated to reference the new version tag.