### PR TITLE
fix(frontend-pr-analysis): add pnpm setup step and fix cache-dependen…

### DIFF
--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -237,7 +237,8 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
           cache-dependency-path: |
-            ${{ inputs.package_manager == 'pnpm' && '**/pnpm-lock.yaml' || inputs.package_manager == 'yarn' && '**/yarn.lock' || '**/package-lock.json' }}
+            ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', matrix.app.working_dir) || inputs.package_manager == 'yarn' && format('{0}/yarn.lock', matrix.app.working_dir) || format('{0}/package-lock.json', matrix.app.working_dir) }}
+            ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}
@@ -283,7 +284,8 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
           cache-dependency-path: |
-            ${{ inputs.package_manager == 'pnpm' && '**/pnpm-lock.yaml' || inputs.package_manager == 'yarn' && '**/yarn.lock' || '**/package-lock.json' }}
+            ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', matrix.app.working_dir) || inputs.package_manager == 'yarn' && format('{0}/yarn.lock', matrix.app.working_dir) || format('{0}/package-lock.json', matrix.app.working_dir) }}
+            ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}
@@ -324,7 +326,8 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
           cache-dependency-path: |
-            ${{ inputs.package_manager == 'pnpm' && '**/pnpm-lock.yaml' || inputs.package_manager == 'yarn' && '**/yarn.lock' || '**/package-lock.json' }}
+            ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', matrix.app.working_dir) || inputs.package_manager == 'yarn' && format('{0}/yarn.lock', matrix.app.working_dir) || format('{0}/package-lock.json', matrix.app.working_dir) }}
+            ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}
@@ -370,7 +373,8 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
           cache-dependency-path: |
-            ${{ inputs.package_manager == 'pnpm' && '**/pnpm-lock.yaml' || inputs.package_manager == 'yarn' && '**/yarn.lock' || '**/package-lock.json' }}
+            ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', matrix.app.working_dir) || inputs.package_manager == 'yarn' && format('{0}/yarn.lock', matrix.app.working_dir) || format('{0}/package-lock.json', matrix.app.working_dir) }}
+            ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}
@@ -544,7 +548,8 @@ jobs:
           node-version: ${{ inputs.node_version }}
           cache: ${{ inputs.package_manager }}
           cache-dependency-path: |
-            ${{ inputs.package_manager == 'pnpm' && '**/pnpm-lock.yaml' || inputs.package_manager == 'yarn' && '**/yarn.lock' || '**/package-lock.json' }}
+            ${{ inputs.package_manager == 'pnpm' && format('{0}/pnpm-lock.yaml', matrix.app.working_dir) || inputs.package_manager == 'yarn' && format('{0}/yarn.lock', matrix.app.working_dir) || format('{0}/package-lock.json', matrix.app.working_dir) }}
+            ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}


### PR DESCRIPTION
## Description

  Fix `frontend-pr-analysis` workflow where pnpm was never installed on the runner, causing all 5 analysis jobs to fail with
  `Unable to locate executable file: pnpm`. Also fix hardcoded `cache-dependency-path` to dynamically resolve the correct lock
   file based on the `package_manager` input.

  ## Type of Change

  - [ ] `feat`: New feature or workflow
  - [x] `fix`: Bug fix
  - [ ] `docs`: Documentation update
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Adding or updating tests
  - [ ] `ci`: CI/CD configuration changes
  - [ ] `chore`: Maintenance tasks
  - [ ] `BREAKING CHANGE`: Breaking change (requires major version bump)

  ## Affected Workflows

  - [ ] GitOps Update
  - [ ] API Dog E2E Tests
  - [ ] PR Security Scan
  - [ ] Release Workflow
  - [x] Other (specify): Frontend PR Analysis

  ## Changes Made

  - Add `pnpm/action-setup@v4` step before `setup-node` in all 5 jobs (lint, typecheck, security, tests, build), conditionally
   running only when `package_manager == 'pnpm'`
  - Fix `cache-dependency-path` from hardcoded `package-lock.json` to dynamic resolution: `pnpm-lock.yaml` for pnpm,
  `yarn.lock` for yarn, `package-lock.json` for npm

  ## Breaking Changes

  **None** — `pnpm/action-setup` only runs when `package_manager == 'pnpm'`. Existing npm/yarn callers are unaffected.

  ## Testing

  - [ ] Tested locally
  - [ ] Tested in development environment
  - [x] Tested with example repository: LerianStudio/lerian-landing-pages (PR #7 confirmed pnpm failure)
  - [x] All existing workflows still work

  ## Checklist

  - [x] Code follows conventional commit format
  - [x] Documentation updated (if applicable)
  - [x] Examples updated (if applicable)
  - [x] No hardcoded secrets or sensitive data
  - [x] Backward compatible (or breaking changes documented)
  - [x] Self-review completed
  - [x] Comments added for complex logic

  ## Related Issues

  Related to LerianStudio/lerian-landing-pages#7

  ## Additional Notes

  Confirmed bug in production: LerianStudio/lerian-landing-pages PR #7 had all 5 frontend analysis jobs fail with the same
  error. The runner had Node 22 installed but pnpm was not available because `actions/setup-node` does not install pnpm — it
  requires `pnpm/action-setup` to be run first.
