### PR TITLE
fix(ci): enable install_from_root for pnpm workspace support

### DIFF
--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -83,6 +83,10 @@ on:
         description: 'Enable build verification'
         type: boolean
         default: true
+      install_from_root:
+        description: 'Run package install from repository root instead of working_dir. Required for pnpm workspaces where the lockfile is at root level.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -241,7 +245,7 @@ jobs:
             ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
-        working-directory: ${{ matrix.app.working_dir }}
+        working-directory: ${{ inputs.install_from_root && '.' || matrix.app.working_dir }}
         run: |
           case "${{ inputs.package_manager }}" in
             yarn) yarn install --frozen-lockfile ;;
@@ -288,7 +292,7 @@ jobs:
             ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
-        working-directory: ${{ matrix.app.working_dir }}
+        working-directory: ${{ inputs.install_from_root && '.' || matrix.app.working_dir }}
         run: |
           case "${{ inputs.package_manager }}" in
             yarn) yarn install --frozen-lockfile ;;
@@ -330,7 +334,7 @@ jobs:
             ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
-        working-directory: ${{ matrix.app.working_dir }}
+        working-directory: ${{ inputs.install_from_root && '.' || matrix.app.working_dir }}
         run: |
           case "${{ inputs.package_manager }}" in
             yarn) yarn install --frozen-lockfile ;;
@@ -377,7 +381,7 @@ jobs:
             ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
-        working-directory: ${{ matrix.app.working_dir }}
+        working-directory: ${{ inputs.install_from_root && '.' || matrix.app.working_dir }}
         run: |
           case "${{ inputs.package_manager }}" in
             yarn) yarn install --frozen-lockfile ;;
@@ -552,7 +556,7 @@ jobs:
             ${{ inputs.package_manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package_manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
 
       - name: Install dependencies
-        working-directory: ${{ matrix.app.working_dir }}
+        working-directory: ${{ inputs.install_from_root && '.' || matrix.app.working_dir }}
         run: |
           case "${{ inputs.package_manager }}" in
             yarn) yarn install --frozen-lockfile ;;


### PR DESCRIPTION
# Pull Request Checklist

  ## Description

  Enable `install_from_root: true` in the PR analysis workflow to support the pnpm workspace structure where the lockfile is
  at the repository root.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Performance improvement
  - [x] CI/CD changes
  - [ ] Dependency update

  ## Affected Sites

  - [x] sites/tracer

  ## Changes Made

  - Add `install_from_root: true` to frontend-pr-analysis workflow invocation

  ## Testing

  - [ ] Visual testing in browser
  - [ ] Responsive design verified (mobile, tablet, desktop)
  - [ ] Cross-browser testing (Chrome, Firefox, Safari, Edge)
  - [ ] Unit tests added/updated
  - [ ] Accessibility tested

  ## Checklist

  - [x] I have run linting and fixed all issues.
  - [x] I have run type checking and resolved all errors.
  - [x] I have tested these changes locally.
  - [x] I have updated the documentation accordingly.
  - [x] I have added necessary comments to the code, especially in complex areas.
  - [x] I have ensured that my changes adhere to the project's coding standards.
  - [x] I have checked for any potential security issues.
  - [x] I have ensured that all tests pass.
  - [ ] I have verified accessibility (semantic HTML, ARIA labels, keyboard navigation).
  - [x] I have confirmed this code is ready for review.

  ## Related Issues

  Related to LerianStudio/github-actions-shared-workflows#96

  ## Screenshots / Recordings

  N/A — CI/CD configuration only.

  ## Additional Notes

  The pnpm workspace has `pnpm-lock.yaml` inside `sites/tracer/`, but pnpm detects `pnpm-workspace.yaml` at root and expects
  install to run from there. `install_from_root: true` fixes `ERR_PNPM_NO_LOCKFILE` in CI.

  ## Note: Please always remember to target your PR to the main branch.