### PR TITLE
feat(frontend-pr-analysis): add enable_notify input to control Slack …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,10 @@ on:
         description: 'Name of the Dockerfile'
         type: string
         default: 'Dockerfile'
+      dockerfile_path:
+        description: 'Full path to the Dockerfile (overrides working_dir/dockerfile_name). Use when Dockerfile is not inside the app directory.'
+        type: string
+        default: ''
       app_name_prefix:
         description: 'Prefix for app names in monorepo (e.g., "midaz" results in "midaz-agent")'
         type: string
@@ -277,7 +281,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.build_context }}
-          file: ${{ matrix.app.working_dir }}/${{ inputs.dockerfile_name }}
+          file: ${{ inputs.dockerfile_path != '' && inputs.dockerfile_path || format('{0}/{1}', matrix.app.working_dir, inputs.dockerfile_name) }}
           platforms: ${{ needs.prepare.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ on:
         default: ''
       # Docker build arguments
       build_args:
-        description: 'Newline-separated Docker build arguments. Use {APP_NAME} as placeholder for the detected app name (e.g., SITE={APP_NAME})'
+        description: 'Newline-separated Docker build arguments. Placeholders: {APP_NAME} for full app name (with prefix), {APP_DIR} for directory name (e.g., SITE={APP_DIR})'
         type: string
         default: ''
       # Path normalization
@@ -270,7 +270,8 @@ jobs:
         if: inputs.build_args != ''
         id: resolve-build-args
         run: |
-          RESOLVED=$(echo "${{ inputs.build_args }}" | sed 's/{APP_NAME}/${{ matrix.app.name }}/g')
+          DIR_NAME=$(basename "${{ matrix.app.working_dir }}")
+          RESOLVED=$(echo "${{ inputs.build_args }}" | sed 's/{APP_NAME}/${{ matrix.app.name }}/g' | sed "s/{APP_DIR}/$DIR_NAME/g")
           {
             echo "args<<EOF"
             echo "$RESOLVED"

--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -87,6 +87,10 @@ on:
         description: 'Run package install from repository root instead of working_dir. Required for pnpm workspaces where the lockfile is at root level.'
         type: boolean
         default: false
+      enable_notify:
+        description: 'Enable Slack notification on completion'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -593,7 +597,7 @@ jobs:
   notify:
     name: Notify
     needs: [detect-changes, lint, typecheck, security, tests, build]
-    if: always() && needs.detect-changes.outputs.has_changes == 'true'
+    if: always() && needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_notify
     uses: ./.github/workflows/slack-notify.yml
     with:
       status: ${{ (needs.lint.result == 'failure' || needs.typecheck.result == 'failure' || needs.security.result == 'failure' || needs.tests.result == 'failure' || needs.build.result == 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -59,6 +59,10 @@ on:
         description: 'Enable Docker Hub login to avoid rate limits'
         type: boolean
         default: true
+      version_source:
+        description: 'Source for version info. "artifact" downloads .tag files from build run (default). "event" extracts version from workflow_run event title (no artifact download needed).'
+        type: string
+        default: 'artifact'
       configmap_updates:
         description: 'JSON object mapping artifact names to configmap keys (e.g., {"pix.tag": ".pix.configmap.VERSION"})'
         type: string
@@ -159,67 +163,46 @@ jobs:
           rm -rf .gitops-tags
           echo "Cleanup complete"
 
+      - name: Extract version from event (no artifact download)
+        if: inputs.version_source == 'event'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .gitops-tags
+
+          # Get version from triggering workflow run title (e.g., "v1.1.0" -> "1.1.0")
+          VERSION="${{ github.event.workflow_run.display_title || github.ref_name }}"
+          VERSION="${VERSION#v}"
+
+          APP_NAME="${{ steps.setup.outputs.app_name }}"
+
+          echo "Version source: event"
+          echo "Extracted version: $VERSION"
+          echo "App name: $APP_NAME"
+
+          printf "%s" "$VERSION" > ".gitops-tags/${APP_NAME}.tag"
+          echo "Created synthetic artifact: .gitops-tags/${APP_NAME}.tag"
+          ls -la .gitops-tags/
+
       - name: Download GitOps tag artifacts (pattern-based)
+        if: inputs.version_source != 'event'
         id: download-pattern
         uses: actions/download-artifact@v7
         with:
           pattern: ${{ steps.setup.outputs.artifact_pattern }}
           path: .gitops-tags
           merge-multiple: true
-          # Only download from this workflow run (default behavior, but explicit for safety)
           run-id: ${{ github.event.workflow_run.id || github.run_id }}
         continue-on-error: true
 
-      - name: Check if artifacts were downloaded
-        id: check-download
-        shell: bash
-        run: |
-          COUNT=$(find .gitops-tags -type f -name "*.tag" 2>/dev/null | wc -l || echo "0")
-          echo "artifacts_found=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "Found $COUNT artifact(s) after pattern-based download"
-
       - name: Fallback to legacy artifact name
-        if: steps.check-download.outputs.artifacts_found == '0'
+        if: inputs.version_source != 'event' && steps.download-pattern.outcome == 'failure'
         uses: actions/download-artifact@v7
         with:
           name: gitops-tags
           path: .gitops-tags
           run-id: ${{ github.event.workflow_run.id || github.run_id }}
         continue-on-error: true
-
-      - name: Fallback to cross-workflow download via API
-        if: steps.check-download.outputs.artifacts_found == '0' && github.event.workflow_run.id != ''
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p .gitops-tags
-
-          SOURCE_RUN_ID="${{ github.event.workflow_run.id }}"
-          PATTERN="${{ steps.setup.outputs.artifact_pattern }}"
-          REPO="${{ github.repository }}"
-          REGEX="${PATTERN//\*/.*}"
-
-          echo "Attempting cross-workflow artifact download from run $SOURCE_RUN_ID (pattern: $PATTERN)"
-
-          ARTIFACT_IDS=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}/artifacts" \
-            --jq "[.artifacts[] | select(.name | test(\"^${REGEX}$\"))] | .[] | \"\(.id) \(.name)\"" 2>/dev/null || true)
-
-          if [[ -z "$ARTIFACT_IDS" ]]; then
-            echo "No artifacts found matching '$PATTERN' in run $SOURCE_RUN_ID"
-            exit 0
-          fi
-
-          while read -r AID ANAME; do
-            echo "Downloading: $ANAME (ID: $AID)"
-            gh api "repos/${REPO}/actions/artifacts/${AID}/zip" > "/tmp/${ANAME}.zip"
-            unzip -o "/tmp/${ANAME}.zip" -d .gitops-tags/
-            rm -f "/tmp/${ANAME}.zip"
-          done <<< "$ARTIFACT_IDS"
-
-          echo "Downloaded artifacts:"
-          ls -la .gitops-tags/
 
       - name: Validate artifacts exist
         id: validate_artifacts

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -177,6 +177,41 @@ jobs:
           name: gitops-tags
           path: .gitops-tags
           run-id: ${{ github.event.workflow_run.id || github.run_id }}
+        continue-on-error: true
+
+      - name: Fallback to cross-workflow download via API
+        if: steps.download-pattern.outcome == 'failure' && github.event.workflow_run.id != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .gitops-tags
+
+          SOURCE_RUN_ID="${{ github.event.workflow_run.id }}"
+          PATTERN="${{ steps.setup.outputs.artifact_pattern }}"
+          REPO="${{ github.repository }}"
+          REGEX="${PATTERN//\*/.*}"
+
+          echo "Attempting cross-workflow artifact download from run $SOURCE_RUN_ID (pattern: $PATTERN)"
+
+          ARTIFACT_IDS=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}/artifacts" \
+            --jq "[.artifacts[] | select(.name | test(\"^${REGEX}$\"))] | .[] | \"\(.id) \(.name)\"" 2>/dev/null || true)
+
+          if [[ -z "$ARTIFACT_IDS" ]]; then
+            echo "No artifacts found matching '$PATTERN' in run $SOURCE_RUN_ID"
+            exit 0
+          fi
+
+          while read -r AID ANAME; do
+            echo "Downloading: $ANAME (ID: $AID)"
+            gh api "repos/${REPO}/actions/artifacts/${AID}/zip" > "/tmp/${ANAME}.zip"
+            unzip -o "/tmp/${ANAME}.zip" -d .gitops-tags/
+            rm -f "/tmp/${ANAME}.zip"
+          done <<< "$ARTIFACT_IDS"
+
+          echo "Downloaded artifacts:"
+          ls -la .gitops-tags/
 
       - name: Validate artifacts exist
         id: validate_artifacts

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -170,8 +170,16 @@ jobs:
           run-id: ${{ github.event.workflow_run.id || github.run_id }}
         continue-on-error: true
 
+      - name: Check if artifacts were downloaded
+        id: check-download
+        shell: bash
+        run: |
+          COUNT=$(find .gitops-tags -type f -name "*.tag" 2>/dev/null | wc -l || echo "0")
+          echo "artifacts_found=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Found $COUNT artifact(s) after pattern-based download"
+
       - name: Fallback to legacy artifact name
-        if: steps.download-pattern.outcome == 'failure'
+        if: steps.check-download.outputs.artifacts_found == '0'
         uses: actions/download-artifact@v7
         with:
           name: gitops-tags
@@ -180,7 +188,7 @@ jobs:
         continue-on-error: true
 
       - name: Fallback to cross-workflow download via API
-        if: steps.download-pattern.outcome == 'failure' && github.event.workflow_run.id != ''
+        if: steps.check-download.outputs.artifacts_found == '0' && github.event.workflow_run.id != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -167,7 +167,7 @@ jobs:
           path: .gitops-tags
           merge-multiple: true
           # Only download from this workflow run (default behavior, but explicit for safety)
-          run-id: ${{ github.run_id }}
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
         continue-on-error: true
 
       - name: Fallback to legacy artifact name
@@ -176,7 +176,7 @@ jobs:
         with:
           name: gitops-tags
           path: .gitops-tags
-          run-id: ${{ github.run_id }}
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
 
       - name: Validate artifacts exist
         id: validate_artifacts

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -12,9 +12,13 @@ on:
         type: string
         default: 'LerianStudio/midaz-firmino-gitops'
       app_name:
-        description: 'Application name (defaults to repository name if not provided)'
+        description: 'Application name (defaults to repository name if not provided). Ignored when iterate_artifacts is true.'
         type: string
         required: false
+      iterate_artifacts:
+        description: 'Monorepo mode: iterate over all downloaded .tag artifacts and derive app name from each filename (e.g., landing-tracer.tag -> landing-tracer)'
+        type: boolean
+        default: false
       deploy_in_firmino:
         description: 'Deploy to Firmino server'
         type: boolean
@@ -208,9 +212,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Get app name
+          # Get app name (used in single-app mode only)
           APP_NAME="${{ steps.setup.outputs.app_name }}"
-          
+          ITERATE_ARTIFACTS="${{ inputs.iterate_artifacts }}"
+
           # Determine environments to update based on tag type
           if [[ "${{ env.IS_BETA }}" == "true" ]]; then
             ENVIRONMENTS="dev"
@@ -244,7 +249,7 @@ jobs:
               SERVERS="clotilde"
             fi
           fi
-          
+
           if [[ -z "$SERVERS" ]]; then
             echo "No servers selected for deployment. Enable deploy_in_firmino or deploy_in_clotilde."
             exit 1
@@ -262,7 +267,7 @@ jobs:
               AVAILABLE_ARTIFACTS="${AVAILABLE_ARTIFACTS}${artifact_name} "
             fi
           done
-          
+
           if [[ -z "$AVAILABLE_ARTIFACTS" ]]; then
             echo "No artifacts found in .gitops-tags/"
             echo "sync_matrix=[]" >> "$GITHUB_OUTPUT"
@@ -274,56 +279,52 @@ jobs:
           UPDATED_FILES=""
           MISSING_FILES=""
           UPDATED_SERVERS_ENVS=""
+          UPDATED_APP_NAMES=""
 
-          # Function to update a single YAML key using sed (preserves formatting)
-          update_yaml_tag() {
-            local file="$1"
-            local yaml_path="$2"
-            local new_tag="$3"
-            
-            # Extract the key name from yaml path (e.g., ".image.tag" -> "tag")
-            local key_name="${yaml_path##*.}"
-            
-            # Use sed to replace only the tag value, preserving all formatting
-            # This handles patterns like "tag: v1.0.0" or "tag: 'v1.0.0'" or 'tag: "v1.0.0"'
-            if grep -q "^[[:space:]]*${key_name}:" "$file"; then
-              # Replace the value after the key, preserving indentation and quotes
-              sed -i -E "s/^([[:space:]]*${key_name}:[[:space:]]*)(['\"]?)([^'\"[:space:]]+)(['\"]?)$/\1\2${new_tag}\4/" "$file"
-              return 0
-            fi
-            return 1
-          }
+          # Get YAML key mappings values (the YAML paths to update)
+          MAPPINGS='${{ inputs.yaml_key_mappings }}'
 
-          # Process each server and environment
-          for SERVER in $SERVERS; do
-            for ENV in $ENVIRONMENTS; do
-              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${APP_NAME}/values.yaml"
-              
-              echo ""
-              echo "Processing: $SERVER/$ENV"
-              echo "  Path: $VALUES_FILE"
-              
-              # Check if file exists
-              if [[ ! -f "$VALUES_FILE" ]]; then
-                echo "  WARNING: Values file not found for ${SERVER}/${ENV}: ${VALUES_FILE}"
-                MISSING_FILES="${MISSING_FILES}${SERVER}/${ENV}:${VALUES_FILE}\n"
+          if [[ "$ITERATE_ARTIFACTS" == "true" ]]; then
+            # =============================================
+            # MONOREPO MODE: iterate over each .tag artifact
+            # =============================================
+            echo ""
+            echo "Monorepo mode: iterating over artifacts..."
+
+            for artifact_file in .gitops-tags/*.tag; do
+              [[ ! -f "$artifact_file" ]] && continue
+
+              # Derive app name from artifact filename (e.g., landing-tracer.tag -> landing-tracer)
+              ARTIFACT_APP_NAME=$(basename "$artifact_file" .tag)
+              TAG=$(tr -d '[:space:]' < "$artifact_file")
+
+              if [[ -z "$TAG" ]]; then
+                echo "  WARNING: Empty tag in $artifact_file, skipping"
                 continue
               fi
-              
-              # Track if any changes were made to this file
-              FILE_CHANGED=false
-              
-              # Apply mappings from inputs - only if artifact exists
-              MAPPINGS='${{ inputs.yaml_key_mappings }}'
-              while IFS='|' read -r artifact_key yaml_key; do
-                ARTIFACT_FILE=".gitops-tags/${artifact_key}"
-                if [[ -f "$ARTIFACT_FILE" ]]; then
-                  TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
-                  if [[ -n "$TAG" ]]; then
-                    # Get current value to check if update is needed
+
+              echo ""
+              echo "App: $ARTIFACT_APP_NAME (version: $TAG)"
+              UPDATED_APP_NAMES="${UPDATED_APP_NAMES}${ARTIFACT_APP_NAME} "
+
+              for SERVER in $SERVERS; do
+                for ENV in $ENVIRONMENTS; do
+                  VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${ARTIFACT_APP_NAME}/values.yaml"
+
+                  echo "  Processing: $SERVER/$ENV -> $VALUES_FILE"
+
+                  if [[ ! -f "$VALUES_FILE" ]]; then
+                    echo "    WARNING: Values file not found, skipping"
+                    MISSING_FILES="${MISSING_FILES}${ARTIFACT_APP_NAME}:${SERVER}/${ENV}:${VALUES_FILE}\n"
+                    continue
+                  fi
+
+                  FILE_CHANGED=false
+
+                  # Apply each YAML key mapping using the tag from this artifact
+                  while IFS='|' read -r _ yaml_key; do
                     CURRENT_TAG=$(yq e "$yaml_key" "$VALUES_FILE" 2>/dev/null || echo "")
                     if [[ "$CURRENT_TAG" != "$TAG" ]]; then
-                      # Use yq with explicit output to preserve formatting
                       TAG="$TAG" yq e "$yaml_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
                       mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
                       echo "    Updated $yaml_key: $CURRENT_TAG -> $TAG"
@@ -331,66 +332,110 @@ jobs:
                     else
                       echo "    Skipped $yaml_key: already set to $TAG"
                     fi
+                  done < <(echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
+
+                  if [[ "$FILE_CHANGED" == "true" ]]; then
+                    UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
+                    UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
                   fi
+                done
+              done
+            done
+          else
+            # =============================================
+            # SINGLE-APP MODE: original behavior
+            # =============================================
+            for SERVER in $SERVERS; do
+              for ENV in $ENVIRONMENTS; do
+                VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${APP_NAME}/values.yaml"
+
+                echo ""
+                echo "Processing: $SERVER/$ENV"
+                echo "  Path: $VALUES_FILE"
+
+                if [[ ! -f "$VALUES_FILE" ]]; then
+                  echo "  WARNING: Values file not found for ${SERVER}/${ENV}: ${VALUES_FILE}"
+                  MISSING_FILES="${MISSING_FILES}${SERVER}/${ENV}:${VALUES_FILE}\n"
+                  continue
                 fi
-              done < <(echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
-              
-              # Apply configmap updates if configured - only if artifact exists
-              if [[ -n "${{ inputs.configmap_updates }}" ]]; then
-                CONFIGMAP_MAPPINGS='${{ inputs.configmap_updates }}'
-                while IFS='|' read -r artifact_key configmap_key; do
+
+                FILE_CHANGED=false
+
+                while IFS='|' read -r artifact_key yaml_key; do
                   ARTIFACT_FILE=".gitops-tags/${artifact_key}"
                   if [[ -f "$ARTIFACT_FILE" ]]; then
                     TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
                     if [[ -n "$TAG" ]]; then
-                      CURRENT_TAG=$(yq e "$configmap_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                      CURRENT_TAG=$(yq e "$yaml_key" "$VALUES_FILE" 2>/dev/null || echo "")
                       if [[ "$CURRENT_TAG" != "$TAG" ]]; then
-                        TAG="$TAG" yq e "$configmap_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
+                        TAG="$TAG" yq e "$yaml_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
                         mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
-                        echo "    Updated $configmap_key: $CURRENT_TAG -> $TAG"
+                        echo "    Updated $yaml_key: $CURRENT_TAG -> $TAG"
                         FILE_CHANGED=true
                       else
-                        echo "    Skipped $configmap_key: already set to $TAG"
+                        echo "    Skipped $yaml_key: already set to $TAG"
                       fi
                     fi
                   fi
-                done < <(echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
-              fi
-              
-              # Only track as updated if changes were actually made
-              if [[ "$FILE_CHANGED" == "true" ]]; then
-                UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
-                UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
-              else
-                echo "  No changes needed for this file"
-              fi
+                done < <(echo "$MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
+
+                if [[ -n "${{ inputs.configmap_updates }}" ]]; then
+                  CONFIGMAP_MAPPINGS='${{ inputs.configmap_updates }}'
+                  while IFS='|' read -r artifact_key configmap_key; do
+                    ARTIFACT_FILE=".gitops-tags/${artifact_key}"
+                    if [[ -f "$ARTIFACT_FILE" ]]; then
+                      TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
+                      if [[ -n "$TAG" ]]; then
+                        CURRENT_TAG=$(yq e "$configmap_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                        if [[ "$CURRENT_TAG" != "$TAG" ]]; then
+                          TAG="$TAG" yq e "$configmap_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
+                          mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
+                          echo "    Updated $configmap_key: $CURRENT_TAG -> $TAG"
+                          FILE_CHANGED=true
+                        else
+                          echo "    Skipped $configmap_key: already set to $TAG"
+                        fi
+                      fi
+                    fi
+                  done < <(echo "$CONFIGMAP_MAPPINGS" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
+                fi
+
+                if [[ "$FILE_CHANGED" == "true" ]]; then
+                  UPDATED_FILES="${UPDATED_FILES}${VALUES_FILE}\n"
+                  UPDATED_SERVERS_ENVS="${UPDATED_SERVERS_ENVS}${SERVER}:${ENV}\n"
+                else
+                  echo "  No changes needed for this file"
+                fi
+              done
             done
-          done
+          fi
 
           # Report results
           echo ""
           echo "========================================="
           echo "Summary:"
           echo "========================================="
+          if [[ -n "$UPDATED_APP_NAMES" ]]; then
+            echo "Updated apps: $UPDATED_APP_NAMES"
+          fi
           if [[ -n "$UPDATED_FILES" ]]; then
             echo "Updated files:"
             echo -e "$UPDATED_FILES"
           else
             echo "No files were updated"
           fi
-          
+
           if [[ -n "$MISSING_FILES" ]]; then
             echo ""
             echo "Missing files (skipped):"
             echo -e "$MISSING_FILES"
           fi
 
-          # Save updated servers/envs for ArgoCD sync - only include files that actually changed
+          # Save updated servers/envs for ArgoCD sync - deduplicate since monorepo may update same env multiple times
           if [[ -n "$UPDATED_SERVERS_ENVS" ]]; then
-            echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' > /tmp/updated_servers_envs.txt
-            
-            # Output sync targets as JSON array for matrix job
-            SYNC_MATRIX=$(echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' | while IFS=: read -r s e; do
+            echo -e "$UPDATED_SERVERS_ENVS" | grep -v '^$' | sort -u > /tmp/updated_servers_envs.txt
+
+            SYNC_MATRIX=$(cat /tmp/updated_servers_envs.txt | while IFS=: read -r s e; do
               [[ -n "$s" && -n "$e" ]] && echo "{\"server\":\"$s\",\"env\":\"$e\"}"
             done | jq -s -c '.')
             echo "sync_matrix=$SYNC_MATRIX" >> "$GITHUB_OUTPUT"
@@ -400,7 +445,7 @@ jobs:
             echo "sync_matrix=[]" >> "$GITHUB_OUTPUT"
             echo "has_sync_targets=false" >> "$GITHUB_OUTPUT"
           fi
-          
+
           echo "updated_count=$(echo -e "$UPDATED_FILES" | grep -c -v '^$' || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Show git diff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,9 @@ jobs:
 
       - name: Init package.json
         working-directory: ${{ matrix.app.working_dir }}
-        run: npm init -y
+        run: |
+          echo '{}' > package.json
+          rm -f package-lock.json
 
       - name: Install semantic-release plugins
         working-directory: ${{ matrix.app.working_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Init package.json
         working-directory: ${{ matrix.app.working_dir }}
         run: |
-          echo '{}' > package.json
+          echo '{"name":"${{ matrix.app.name }}","version":"0.0.0","private":true}' > package.json
           rm -f package-lock.json
 
       - name: Install semantic-release plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Init package.json
+      - name: Init package.json and release config
         working-directory: ${{ matrix.app.working_dir }}
         run: |
           echo '{"name":"${{ matrix.app.name }}","version":"0.0.0","private":true}' > package.json
+          echo '{"branches":["${{ github.ref_name }}"]}' > .releaserc.json
           rm -f package-lock.json
 
       - name: Install semantic-release plugins


### PR DESCRIPTION
## Description                                                                                                              
                                                                                                                            
  Add `enable_notify` input to the frontend-pr-analysis workflow to allow callers to disable Slack notifications. Also adds
  `install_from_root` input for pnpm workspace support where the lockfile lives at root level.

  ## Type of Change

  - [x] `feat`: New feature or workflow
  - [x] `fix`: Bug fix
  - [ ] `docs`: Documentation update
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Adding or updating tests
  - [ ] `ci`: CI/CD configuration changes
  - [ ] `chore`: Maintenance tasks
  - [ ] `BREAKING CHANGE`: Breaking change (requires major version bump)

  ## Affected Workflows

  - [ ] GitOps Update
  - [ ] API Dog E2E Tests
  - [ ] PR Security Scan
  - [ ] Release Workflow
  - [x] Other (specify): Frontend PR Analysis

  ## Changes Made

  - Add `enable_notify` boolean input (default: `true`) to control Slack notification job
  - Add `install_from_root` boolean input (default: `false`) to run package install from repo root for pnpm workspaces
  - Add `pnpm/action-setup@v4` step before `setup-node` in all 5 jobs
  - Fix `cache-dependency-path` to be app-scoped with root fallback
  - Condition notify job on `inputs.enable_notify`

  ## Breaking Changes

  **None** — `enable_notify` defaults to `true` and `install_from_root` defaults to `false`, preserving existing behavior.

  ## Testing

  - [ ] Tested locally
  - [ ] Tested in development environment
  - [x] Tested with example repository: LerianStudio/lerian-landing-pages (PR #8)
  - [x] All existing workflows still work

  ## Checklist

  - [x] Code follows conventional commit format
  - [x] Documentation updated (if applicable)
  - [x] Examples updated (if applicable)
  - [x] No hardcoded secrets or sensitive data
  - [x] Backward compatible (or breaking changes documented)
  - [x] Self-review completed
  - [x] Comments added for complex logic

  ## Related Issues

  Related to LerianStudio/lerian-landing-pages#8

  ## Additional Notes

  Three fixes in one PR:
  1. pnpm not installed on runner → `pnpm/action-setup@v4`
  2. Lockfile not found in workspace → `install_from_root` input
  3. Slack notifications not optional → `enable_notify` input
