### PR TITLE
feat(typescript-release): add TypeScript-specific release workflow

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -32,6 +32,10 @@ on:
         description: 'Limits the path to the first N segments (e.g., 2 -> "apps/agent")'
         type: string
         default: '2'
+      dry_run:
+        description: 'Run semantic-release in dry-run mode (no tags/releases created)'
+        type: boolean
+        default: false
 
 jobs:
   prepare:
@@ -148,7 +152,7 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         run: |
           echo '{"name":"${{ matrix.app.name }}","version":"0.0.0","private":true}' > package.json
-          echo '{"branches":["${{ github.ref_name }}"]}' > .releaserc.json
+          echo '{"branches":["main",{"name":"develop","prerelease":"beta"},{"name":"release-candidate","prerelease":"rc"}]}' > .releaserc.json
           rm -f package-lock.json
 
       - name: Install semantic-release plugins
@@ -162,6 +166,7 @@ jobs:
         id: semantic
         with:
           ci: false
+          dry_run: ${{ inputs.dry_run }}
           semantic_version: ${{ inputs.semantic_version }}
           working_directory: ${{ matrix.app.working_dir }}
           extra_plugins: |

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -93,6 +93,8 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
     runs-on: ${{ inputs.runner_type }}
+    env:
+      GH_PACKAGES_TOKEN: ${{ secrets.GH_PAT_FOR_PACKAGES }}
     environment:
       name: create_release
     name: Release ${{ matrix.app.name }}
@@ -141,12 +143,10 @@ jobs:
           node-version: ${{ inputs.node_version }}
 
       - name: Setup .npmrc for GitHub Packages
-        if: ${{ secrets.GH_PAT_FOR_PACKAGES != '' }}
+        if: ${{ env.GH_PACKAGES_TOKEN != '' }}
         run: |
           echo "//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}" > ~/.npmrc
           echo "@lerianstudio:registry=https://npm.pkg.github.com" >> ~/.npmrc
-        env:
-          GH_PACKAGES_TOKEN: ${{ secrets.GH_PAT_FOR_PACKAGES }}
 
       - name: Init package.json and release config
         working-directory: ${{ matrix.app.working_dir }}

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -141,7 +141,7 @@ jobs:
           node-version: ${{ inputs.node_version }}
 
       - name: Setup .npmrc for GitHub Packages
-        if: ${{ env.GH_PACKAGES_TOKEN != '' }}
+        if: ${{ secrets.GH_PAT_FOR_PACKAGES != '' }}
         run: |
           echo "//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}" > ~/.npmrc
           echo "@lerianstudio:registry=https://npm.pkg.github.com" >> ~/.npmrc
@@ -183,7 +183,7 @@ jobs:
   notify:
     name: Notify
     needs: [prepare, publish_release]
-    if: always() && needs.prepare.outputs.has_changes == 'true'
+    if: always() && needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
       status: ${{ needs.publish_release.result }}

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -1,0 +1,188 @@
+name: "TypeScript Release"
+
+# Reusable workflow for TypeScript/Node.js semantic versioning and release management
+# Creates releases based on conventional commits and manages version tags
+# Includes GitHub Packages authentication for private @lerianstudio dependencies
+#
+# Monorepo Support:
+# - If filter_paths is provided: detects changes and runs release for each changed app
+# - If filter_paths is empty: runs release for the entire repository (single app mode)
+
+on:
+  workflow_call:
+    inputs:
+      semantic_version:
+        description: 'Semantic release version to use'
+        type: string
+        default: '23.0.8'
+      runner_type:
+        description: 'Runner to use for the workflow'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      node_version:
+        description: 'Node.js version to use'
+        type: string
+        default: '20'
+      filter_paths:
+        description: 'Newline-separated list of path prefixes to filter. If not provided, treats as single app repo.'
+        type: string
+        required: false
+        default: ''
+      path_level:
+        description: 'Limits the path to the first N segments (e.g., 2 -> "apps/agent")'
+        type: string
+        default: '2'
+
+jobs:
+  prepare:
+    runs-on: ${{ inputs.runner_type }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+      should_skip: ${{ steps.check-skip.outputs.should_skip }}
+    steps:
+      - name: Check if should skip (changelog commits)
+        id: check-skip
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          echo "Checking commit message for skip patterns"
+
+          # Skip if commit message contains [skip ci] or is a changelog update
+          if echo "$COMMIT_MSG" | grep -qiE '\[skip ci\]|chore\(release\): Update CHANGELOGs'; then
+            echo "Skipping release - changelog/skip-ci commit detected"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Proceeding with release"
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get changed paths (monorepo)
+        if: inputs.filter_paths != ''
+        id: changed-paths
+        uses: LerianStudio/github-actions-changed-paths@main
+        with:
+          filter_paths: ${{ inputs.filter_paths }}
+          path_level: ${{ inputs.path_level }}
+          get_app_name: 'true'
+
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          if [ -z "${{ inputs.filter_paths }}" ]; then
+            # Single app mode - release from root
+            APP_NAME="${{ github.event.repository.name }}"
+            echo "matrix=[{\"name\": \"${APP_NAME}\", \"working_dir\": \".\"}]" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            MATRIX='${{ steps.changed-paths.outputs.matrix }}'
+            if [ "$MATRIX" == "[]" ] || [ -z "$MATRIX" ]; then
+              echo "matrix=[]" >> $GITHUB_OUTPUT
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+            else
+              echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  publish_release:
+    needs: prepare
+    if: needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
+    runs-on: ${{ inputs.runner_type }}
+    environment:
+      name: create_release
+    name: Release ${{ matrix.app.name }}
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        app: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
+    outputs:
+      gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
+
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Sync with remote branch
+        run: |
+          git fetch origin ${{ github.ref_name }}
+          git reset --hard origin/${{ github.ref_name }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
+          passphrase: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
+          git_committer_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          git_committer_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Setup .npmrc for GitHub Packages
+        if: ${{ env.GH_PACKAGES_TOKEN != '' }}
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}" > ~/.npmrc
+          echo "@lerianstudio:registry=https://npm.pkg.github.com" >> ~/.npmrc
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PAT_FOR_PACKAGES }}
+
+      - name: Init package.json and release config
+        working-directory: ${{ matrix.app.working_dir }}
+        run: |
+          echo '{"name":"${{ matrix.app.name }}","version":"0.0.0","private":true}' > package.json
+          echo '{"branches":["${{ github.ref_name }}"]}' > .releaserc.json
+          rm -f package-lock.json
+
+      - name: Install semantic-release plugins
+        working-directory: ${{ matrix.app.working_dir }}
+        run: |
+          npm install --save-dev \
+            @semantic-release/exec
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v6
+        id: semantic
+        with:
+          ci: false
+          semantic_version: ${{ inputs.semantic_version }}
+          working_directory: ${{ matrix.app.working_dir }}
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@v7.0.2
+            @saithodev/semantic-release-backmerge
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+
+  # Slack notification
+  notify:
+    name: Notify
+    needs: [prepare, publish_release]
+    if: always() && needs.prepare.outputs.has_changes == 'true'
+    uses: ./.github/workflows/slack-notify.yml
+    with:
+      status: ${{ needs.publish_release.result }}
+      workflow_name: "TypeScript Release"
+      failed_jobs: ${{ needs.publish_release.result == 'failure' && 'Publish Release' || '' }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -155,7 +155,7 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         run: |
           npm install --save-dev \
-            @semantic-release/exec
+            @semantic-release/exec@7.1.0
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v6
@@ -166,7 +166,7 @@ jobs:
           working_directory: ${{ matrix.app.working_dir }}
           extra_plugins: |
             conventional-changelog-conventionalcommits@v7.0.2
-            @saithodev/semantic-release-backmerge
+            @saithodev/semantic-release-backmerge@4.0.1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_AUTHOR_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}

--- a/docs/typescript-release-workflow.md
+++ b/docs/typescript-release-workflow.md
@@ -1,0 +1,338 @@
+# TypeScript Release Workflow
+
+Reusable workflow for TypeScript/Node.js semantic versioning and automated release management. Creates releases based on conventional commits with GPG signing, GitHub Packages authentication for private `@lerianstudio` dependencies, and monorepo support.
+
+## Features
+
+- **Semantic versioning**: Automatic version calculation from conventional commits
+- **GPG signing**: Signed commits and tags for security
+- **GitHub App authentication**: Higher rate limits and better security
+- **GitHub Packages support**: Automatic `.npmrc` configuration for private `@lerianstudio/*` dependencies
+- **Clean package.json**: Overwrites existing `package.json` to avoid dependency resolution conflicts
+- **Monorepo support**: Detects changed paths and runs release for each changed app
+- **Branch strategy**: Pre-configured for `main` (production), `develop` (beta), and `release-candidate` (rc)
+- **Dry-run mode**: Test releases safely without creating tags or GitHub releases
+- **Backmerge support**: Automatic backmerging of releases
+- **Slack notifications**: Configurable release status notifications
+
+## Why Use This Instead of `release.yml`?
+
+The generic `release.yml` uses `npm init -y` which preserves the existing `package.json`. For TypeScript projects with private `@lerianstudio/*` dependencies, this causes `npm install` to attempt resolving all dependencies (including private ones), resulting in **401 Unauthorized** errors during the release step.
+
+`typescript-release.yml` solves this by:
+1. Configuring `.npmrc` with GitHub Packages authentication (when `GH_PAT_FOR_PACKAGES` secret is available)
+2. Overwriting `package.json` with a minimal version that only contains what semantic-release needs
+3. Removing `package-lock.json` to prevent stale dependency resolution
+
+## Usage
+
+### Basic Example
+
+```yaml
+name: Release
+on:
+  push:
+    branches:
+      - develop
+      - release-candidate
+      - main
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Create Release
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@main
+    secrets: inherit
+```
+
+### With Custom Runner and Node Version
+
+```yaml
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@main
+    with:
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
+      node_version: "22"
+    secrets: inherit
+```
+
+### Dry-Run Mode (Safe Testing)
+
+```yaml
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@main
+    with:
+      dry_run: true
+    secrets: inherit
+```
+
+This runs semantic-release without creating tags, GitHub releases, or pushing commits. Useful for validating the release configuration on a new branch or after workflow changes.
+
+### Monorepo Configuration
+
+```yaml
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@main
+    with:
+      filter_paths: |
+        apps/api
+        apps/worker
+        packages/shared
+      path_level: "2"
+    secrets: inherit
+```
+
+### Complete Release Pipeline
+
+```yaml
+name: Release Pipeline
+on:
+  push:
+    branches: [develop, release-candidate, main]
+    tags-ignore: ['**']
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm test
+
+  release:
+    needs: test
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@main
+    with:
+      runner_type: "blacksmith-4vcpu-ubuntu-2404"
+      node_version: "20"
+    secrets: inherit
+```
+
+## Inputs
+
+| Input | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `semantic_version` | string | `23.0.8` | No | Semantic release version to use |
+| `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | No | GitHub runner type |
+| `node_version` | string | `20` | No | Node.js version to use |
+| `filter_paths` | string | `''` | No | Newline-separated list of path prefixes for monorepo filtering |
+| `path_level` | string | `2` | No | Limits the path to the first N segments (e.g., `2` → `apps/agent`) |
+| `dry_run` | boolean | `false` | No | Run semantic-release in dry-run mode (no tags/releases created) |
+
+## Secrets
+
+### Required Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID` | GitHub App ID for authentication |
+| `LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY` | GitHub App private key |
+| `LERIAN_CI_CD_USER_GPG_KEY` | GPG private key for signing commits |
+| `LERIAN_CI_CD_USER_GPG_KEY_PASSWORD` | GPG key passphrase |
+| `LERIAN_CI_CD_USER_NAME` | Git committer name |
+| `LERIAN_CI_CD_USER_EMAIL` | Git committer email |
+| `SLACK_WEBHOOK_URL` | Slack webhook for notifications |
+
+### Optional Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `GH_PAT_FOR_PACKAGES` | Personal Access Token with `read:packages` scope for GitHub Packages. When provided, configures `.npmrc` for `@lerianstudio` scoped packages. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `gpg_fingerprint` | GPG key fingerprint used for signing |
+
+## Branch Strategy
+
+The workflow generates a `.releaserc.json` with pre-configured branch settings:
+
+### develop → Beta Releases
+
+Commits to `develop` branch create beta pre-releases:
+- Version: `v1.2.3-beta.1`
+- Pre-release: Yes
+- Use case: Development testing
+
+### release-candidate → RC Releases
+
+Commits to `release-candidate` branch create RC pre-releases:
+- Version: `v1.2.3-rc.1`
+- Pre-release: Yes
+- Use case: Staging/UAT testing
+
+### main → Production Releases
+
+Commits to `main` branch create production releases:
+- Version: `v1.2.3`
+- Pre-release: No
+- Use case: Production deployment
+
+## Jobs
+
+### prepare
+
+Determines which apps need releases:
+- **Single app mode** (default): When `filter_paths` is empty, releases from repository root
+- **Monorepo mode**: When `filter_paths` is provided, detects changed paths and builds a matrix
+
+Also skips releases for `[skip ci]` and changelog update commits.
+
+### publish_release
+
+Runs semantic-release for each app in the matrix:
+1. Create GitHub App token
+2. Checkout repository with full history
+3. Sync with remote branch
+4. Import GPG key for commit signing
+5. Setup Node.js
+6. Configure `.npmrc` for GitHub Packages (conditional)
+7. Initialize clean `package.json` and `.releaserc.json`
+8. Install semantic-release plugins
+9. Run semantic-release
+
+### notify
+
+Sends Slack notification with release status. Skipped when no changes are detected or when the commit triggers a skip.
+
+## Semantic Release Plugins
+
+### Included Plugins
+
+| Plugin | Version | Description |
+|--------|---------|-------------|
+| `@semantic-release/exec` | `7.1.0` | Execute custom scripts during release |
+| `conventional-changelog-conventionalcommits` | `7.0.2` | Conventional commits support |
+| `@saithodev/semantic-release-backmerge` | `4.0.1` | Automatic backmerging of releases |
+
+## Conventional Commits
+
+The workflow uses conventional commits to determine version bumps:
+
+### Breaking Changes (Major)
+
+```
+feat!: remove deprecated API endpoint
+
+BREAKING CHANGE: The /api/v1/old endpoint has been removed
+```
+
+Version: `1.0.0` → `2.0.0`
+
+### Features (Minor)
+
+```
+feat: add user authentication
+```
+
+Version: `1.0.0` → `1.1.0`
+
+### Fixes (Patch)
+
+```
+fix: resolve memory leak in transaction processor
+```
+
+Version: `1.0.0` → `1.0.1`
+
+### Other Types (No Version Bump)
+
+```
+docs: update API documentation
+chore: update dependencies
+refactor: simplify authentication logic
+```
+
+No version bump, but included in changelog.
+
+## Troubleshooting
+
+### 401 Unauthorized During npm install
+
+**Issue**: `npm install` fails with 401 when resolving `@lerianstudio/*` packages
+
+**Solutions**:
+1. Ensure `GH_PAT_FOR_PACKAGES` secret is configured in the repository
+2. Verify the PAT has `read:packages` scope
+3. Check that the token has access to the `@lerianstudio` organization packages
+
+### Release Not Created
+
+**Issue**: Workflow runs but no release is created
+
+**Solutions**:
+1. Check commit messages follow conventional commits format
+2. Verify you're pushing to a configured branch (`main`, `develop`, or `release-candidate`)
+3. Check if version already exists as a tag
+4. Review semantic-release logs in the workflow run
+5. Try running with `dry_run: true` to see what semantic-release would do
+
+### Final Release Created on develop
+
+**Issue**: A production tag (e.g., `v1.0.0`) was created from the `develop` branch instead of a beta tag
+
+**Solutions**:
+1. This workflow generates `.releaserc.json` automatically with correct branch config — ensure you're not overriding it with a local `.releaserc` file in your repository
+2. Verify the workflow version you're using has the branch prerelease configuration
+
+### GPG Signing Failed
+
+**Issue**: Cannot sign commits with GPG key
+
+**Solutions**:
+1. Verify GPG key is valid and hasn't expired
+2. Check passphrase is correct
+3. Verify key format is ASCII armored
+
+### Skipped Release
+
+**Issue**: Workflow is skipped unexpectedly
+
+**Solutions**:
+1. Check if commit message contains `[skip ci]`
+2. Check if commit message matches `chore(release): Update CHANGELOGs`
+3. For monorepo mode, verify files were changed in the configured `filter_paths`
+
+## Differences from Generic `release.yml`
+
+| Feature | `release.yml` | `typescript-release.yml` |
+|---------|---------------|--------------------------|
+| `.npmrc` setup | No | Yes (conditional on `GH_PAT_FOR_PACKAGES`) |
+| `package.json` init | `npm init -y` (preserves existing) | Clean overwrite (minimal JSON) |
+| Node.js version | Hardcoded `20` | Configurable via `node_version` input |
+| Dry-run mode | Not available | Available via `dry_run` input |
+| `.releaserc.json` | Not generated | Auto-generated with branch strategy |
+| Plugin versions | Unpinned | Pinned for reproducibility |
+
+## Related Workflows
+
+- [Release Workflow](release-workflow.md) - Generic release workflow (Go/other languages)
+- [Go Release](go-release-workflow.md) - Go-specific release with GoReleaser
+- [TypeScript CI](typescript-ci-workflow.md) - TypeScript continuous integration
+
+---
+
+**Last Updated:** 2026-03-04
+**Version:** 1.0.0


### PR DESCRIPTION
# Pull Request Checklist

  ## Pull Request Type

  - [x] Pipeline

  ## Checklist
  Check each item after completion.

  - [x] I have tested these changes locally.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added necessary comments to the code, especially in complex areas.
  - [x] I have ensured that my changes adhere to the project's coding standards.
  - [x] I have checked for any potential security issues.
  - [x] I have ensured that all tests pass.
  - [ ] I have updated the version appropriately (if applicable).
  - [x] I have confirmed this code is ready for review.

  ## Additional Notes

  ### Summary
  Add `typescript-release.yml` reusable workflow for TypeScript/Node.js projects, following the same pattern as
  `go-release.yml`.

  ### Problem
  The generic `release.yml` runs `npm init -y` which doesn't overwrite an existing `package.json`. When TypeScript projects
  with private `@lerianstudio/*` dependencies run `npm install --save-dev @semantic-release/exec`, npm tries to resolve all
  dependencies and fails with 401 Unauthorized (no `.npmrc` configured).

  ### Solution
  | Feature | `release.yml` (generic) | `typescript-release.yml` (new) |
  |---------|------------------------|-------------------------------|
  | `.npmrc` setup | None | Configures GitHub Packages auth via `GH_PAT_FOR_PACKAGES` |
  | `package.json` init | `npm init -y` (keeps existing) | Overwrites with `{"name":"...","version":"0.0.0","private":true}` |
  | Node.js version | Hardcoded `20` | Configurable via `node_version` input |
  | Monorepo support | Yes | Yes (same `filter_paths` mechanism) |

  ### Usage
  ```yaml
  jobs:
    release:
      uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@<tag>
      with:
        runner_type: "blacksmith-4vcpu-ubuntu-2404"
      secrets: inherit