### PR TITLE
chore(ci): update reusable workflows

### DIFF
--- a/.claude/commands/gha.md
+++ b/.claude/commands/gha.md
@@ -170,6 +170,31 @@ reusable: go-ci.yml
 | Manage multiple jobs or runners | Reusable workflow only |
 | Route secrets to jobs | Reusable workflow only |
 
+## self-* workflows (entrypoints for this repo)
+
+Files prefixed with `self-` are **thin entrypoints** for this repository's own automation — not reusable workflows.
+
+- **Must NOT have `workflow_call`** — not offered to external callers
+- Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
+- Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
+- Must not contain business logic
+
+```yaml
+# ✅ Correct self-* structure
+name: Self — Labels Sync
+on:
+  push:
+    branches: [main]
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+jobs:
+  sync:
+    uses: ./.github/workflows/labels-sync.yml
+    secrets: inherit
+```
+
+---
+
 ## Workflow structure
 
 Every reusable workflow must:

--- a/.claude/commands/gha.md
+++ b/.claude/commands/gha.md
@@ -175,6 +175,8 @@ reusable: go-ci.yml
 Files prefixed with `self-` are **thin entrypoints** for this repository's own automation — not reusable workflows.
 
 - **Must NOT have `workflow_call`** — not offered to external callers
+- **`dry_run` is not required** — omit it unless the workflow performs destructive operations
+- **When `dry_run` is present**, it must be: `type: boolean`, `required: false`, `default: true` for destructive ops (delete, purge) or `default: false` for non-destructive ops (sync, notify)
 - Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
 - Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
 - Must not contain business logic

--- a/.claude/commands/gha.md
+++ b/.claude/commands/gha.md
@@ -276,7 +276,16 @@ Always use `.yml` extension — never `.yaml`:
 
 ## Documentation naming
 
-The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension:
+The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension, and must start with the Lerian branding header:
+
+```markdown
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>workflow-name</h1></td>
+  </tr>
+</table>
+```
 
 ```
 .github/workflows/go-ci.yml        → docs/go-ci.md          ✅

--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -65,6 +65,31 @@ reusable: go-ci.yml
 | Manage multiple jobs or runners | Reusable workflow only |
 | Route secrets to jobs | Reusable workflow only |
 
+## self-* workflows (entrypoints for this repo)
+
+Files prefixed with `self-` are **thin entrypoints** for this repository's own automation — not reusable workflows.
+
+- **Must NOT have `workflow_call`** — not offered to external callers
+- Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
+- Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
+- Must not contain business logic
+
+```yaml
+# ✅ Correct self-* structure
+name: Self — Labels Sync
+on:
+  push:
+    branches: [main]
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+jobs:
+  sync:
+    uses: ./.github/workflows/labels-sync.yml
+    secrets: inherit
+```
+
+---
+
 ## Workflow structure
 
 Every reusable workflow must:

--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -70,6 +70,8 @@ reusable: go-ci.yml
 Files prefixed with `self-` are **thin entrypoints** for this repository's own automation — not reusable workflows.
 
 - **Must NOT have `workflow_call`** — not offered to external callers
+- **`dry_run` is not required** — omit it unless the workflow performs destructive operations
+- **When `dry_run` is present**, it must be: `type: boolean`, `required: false`, `default: true` for destructive ops (delete, purge) or `default: false` for non-destructive ops (sync, notify)
 - Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
 - Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
 - Must not contain business logic

--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -173,7 +173,16 @@ Always use `.yml` extension — never `.yaml`:
 
 ## Documentation naming
 
-The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension:
+The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension, and must start with the Lerian branding header:
+
+```markdown
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>workflow-name</h1></td>
+  </tr>
+</table>
+```
 
 ```
 .github/workflows/go-ci.yml        → docs/go-ci.md          ✅

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -39,7 +39,8 @@ reviews:
       instructions: |
         This is a self-use entrypoint for this repository — NOT a reusable workflow.
         Do NOT flag missing `workflow_call` — these files intentionally omit it.
-        Do NOT flag missing `dry_run` — not required for entrypoints.
+        `dry_run` is not required; flag it only if it is marked `required: true` or lacks a default value.
+        When `dry_run` is present it must be: type boolean, required false, default true for destructive operations (delete, purge) or default false for non-destructive ones (sync, notify).
         Must call the corresponding reusable workflow via local path and contain no business logic.
 
     - path: ".github/workflows/*.yml"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -35,10 +35,17 @@ reviews:
     - "!.releaserc.yml"
 
   path_instructions:
+    - path: ".github/workflows/self-*.yml"
+      instructions: |
+        This is a self-use entrypoint for this repository — NOT a reusable workflow.
+        Do NOT flag missing `workflow_call` — these files intentionally omit it.
+        Do NOT flag missing `dry_run` — not required for entrypoints.
+        Must call the corresponding reusable workflow via local path and contain no business logic.
+
     - path: ".github/workflows/*.yml"
       instructions: |
         This is a reusable workflow in a shared CI/CD library. Repo-specific rules:
-        - Both `workflow_call` and `workflow_dispatch` must be present
+        - Both `workflow_call` and `workflow_dispatch` must be present (except self-* files)
         - Workflows that apply state changes must have a `dry_run` boolean input (default: false)
         - Composites must use local path only: `./src/<capability>/<name>` — never an external ref
         - A `docs/<filename>.md` matching this workflow's name must exist or be added in this PR

--- a/.cursor/rules/reusable-workflows.mdc
+++ b/.cursor/rules/reusable-workflows.mdc
@@ -81,9 +81,11 @@ Files prefixed with `self-` (e.g. `self-labels-sync.yml`, `self-branch-cleanup.y
 
 Rules for `self-*` files:
 - **Must NOT have `workflow_call`** — they are not offered to external callers
-- **Must NOT have `dry_run` as a required input** — optional at most, default `true` for destructive operations
+- **`dry_run` is not required** — omit it unless the workflow performs destructive operations
+- **When `dry_run` is present**, it must be: `type: boolean`, `required: false`, `default: true` for destructive ops (delete, purge) or `default: false` for non-destructive ops (sync, notify)
 - Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
 - Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
+- Must not contain business logic
 
 ```yaml
 # ✅ Correct self-* structure

--- a/.cursor/rules/reusable-workflows.mdc
+++ b/.cursor/rules/reusable-workflows.mdc
@@ -75,6 +75,32 @@ reusable: go-ci.yml
 | Manage multiple jobs or runners | Reusable workflow only |
 | Route secrets to jobs | Reusable workflow only |
 
+## self-* workflows (entrypoints for this repo)
+
+Files prefixed with `self-` (e.g. `self-labels-sync.yml`, `self-branch-cleanup.yml`) are **thin entrypoints** for this repository's own automation. They are not reusable workflows.
+
+Rules for `self-*` files:
+- **Must NOT have `workflow_call`** — they are not offered to external callers
+- **Must NOT have `dry_run` as a required input** — optional at most, default `true` for destructive operations
+- Must call the corresponding reusable workflow via local path (`./.github/workflows/<name>.yml`)
+- Triggers are repo-specific: `push`, `schedule`, `pull_request`, `workflow_dispatch`
+
+```yaml
+# ✅ Correct self-* structure
+name: Self — Labels Sync
+on:
+  push:
+    branches: [main]
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+jobs:
+  sync:
+    uses: ./.github/workflows/labels-sync.yml  # local path only
+    secrets: inherit
+```
+
+---
+
 ## Workflow structure
 
 Every reusable workflow must:

--- a/.cursor/rules/reusable-workflows.mdc
+++ b/.cursor/rules/reusable-workflows.mdc
@@ -196,7 +196,16 @@ Always use `.yml` extension — never `.yaml`:
 
 ## Documentation naming
 
-The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension:
+The doc file in `docs/` must have the **exact same name** as the workflow file, with `.md` extension, and must start with the Lerian branding header:
+
+```markdown
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>workflow-name</h1></td>
+  </tr>
+</table>
+```
 
 ```
 .github/workflows/go-ci.yml        → docs/go-ci.md          ✅

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,11 +1,6 @@
 name: Sync Labels
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/labels.yml"
   workflow_call:
     inputs:
       config:

--- a/.github/workflows/self-branch-cleanup.yml
+++ b/.github/workflows/self-branch-cleanup.yml
@@ -1,0 +1,41 @@
+name: Self — Branch Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"  # every Monday at 03:00 UTC
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview deletions without applying them
+        type: boolean
+        default: true
+      stale_days:
+        description: Days without commits before a branch is stale
+        type: number
+        default: 30
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  stale:
+    name: Clean stale branches
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/branch-cleanup.yml
+    with:
+      stale_days: ${{ inputs.stale_days || 30 }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+
+  merged:
+    name: Delete merged branch
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    uses: ./.github/workflows/branch-cleanup.yml
+    with:
+      merged_branch: ${{ github.head_ref }}
+      dry_run: false
+    secrets: inherit

--- a/.github/workflows/self-labels-sync.yml
+++ b/.github/workflows/self-labels-sync.yml
@@ -1,0 +1,26 @@
+name: Self — Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.yml"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview changes without applying them
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    name: Sync labels
+    uses: ./.github/workflows/labels-sync.yml
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit

--- a/docs/labels-sync.md
+++ b/docs/labels-sync.md
@@ -1,0 +1,118 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>labels-sync</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that syncs GitHub labels from a YAML definition file to a repository. Uses the [`src/config/labels-sync`](../src/config/labels-sync/README.md) composite action internally.
+
+## What it does
+
+Reads a `.github/labels.yml` file and applies its label definitions to the target repository — creating missing labels, updating colors and descriptions, and optionally deleting labels that are no longer in the file.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|:---:|---|---|
+| `config` | `string` | No | `.github/labels.yml` | Path to the labels YAML definition file |
+| `dry_run` | `boolean` | No | `false` | Preview changes without applying them |
+| `skip_delete` | `boolean` | No | `false` | Skip deletion of labels absent from the config |
+
+## Secrets
+
+| Secret | Required | Description |
+|---|---|---|
+| `GITHUB_TOKEN` | No | Defaults to the automatic token; needs `issues:write` |
+
+## Labels file format
+
+Create a `.github/labels.yml` in the caller repository:
+
+```yaml
+- name: bug
+  color: "d73a4a"
+  description: Something is not working as expected
+
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or improvement request
+
+- name: documentation
+  color: "0e8a16"
+  description: Improvements or additions to documentation
+```
+
+## Usage
+
+### Sync on labels file change
+
+```yaml
+# .github/workflows/labels-sync.yml
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.yml"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.0.0
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
+```
+
+### Dry run (preview only)
+
+```yaml
+# Use @develop or your feature branch to validate before releasing
+jobs:
+  preview:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@develop
+    with:
+      dry_run: true
+    secrets: inherit
+```
+
+### Sync without deleting unlisted labels
+
+```yaml
+jobs:
+  sync:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.0.0
+    with:
+      skip_delete: true
+    secrets: inherit
+```
+
+### Custom labels file path
+
+```yaml
+jobs:
+  sync:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.0.0
+    with:
+      config: ".github/custom-labels.yml"
+    secrets: inherit
+```
+
+## Permissions
+
+```yaml
+permissions:
+  issues: write
+  contents: read
+```
+
+## Self-use in this repository
+
+This repo uses `self-labels-sync.yml` as a thin entrypoint that calls this workflow via local path. Reusable workflows must not have autonomous push triggers — those belong in a dedicated `self-` file.


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

<!-- Summarize what this PR does and why. List which workflow(s) are affected and what behavior changes. -->

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [x] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

<!-- If applicable, describe exactly what breaks and how callers should migrate. Remove this section if not applicable. -->

None.

## Testing

<!-- Shared workflows can't be unit-tested locally. Describe how you validated the change. -->

- [x] YAML syntax validated locally
- [x] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- Link to the Actions run that validated this change -->

## Related Issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an automatic push trigger for label config; added manual and repo-self entrypoints for label sync.
  * Introduced a self-managed branch-cleanup workflow that runs weekly and deletes merged or stale branches (with dry-run support).

* **Documentation**
  * Added comprehensive label-sync usage docs.
  * Added guidance for self-* entrypoint workflows and updated workflow docs to require a branding header and stricter naming/structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->