### PR TITLE
fix(build): use per-app build context with fallback to global input

### DIFF
--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -261,7 +261,7 @@ jobs:
           working-dir: ${{ matrix.app.working_dir }}
           dockerfile: ${{ matrix.app.dockerfile }}
           dockerfile-name: ${{ inputs.dockerfile_name }}
-          build-context: ${{ inputs.build_context }}
+          build-context: ${{ matrix.app.context || inputs.build_context }}
           build-secrets: ${{ inputs.build_secrets }}
           platforms: ${{ needs.prepare.outputs.platforms }}
           version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The typescript-build workflow was using only the global `inputs.build_context` for all matrix apps. This change allows each app in the matrix to define its own `context` property (`matrix.app.context`), falling back to the global `inputs.build_context` when not set. This enables monorepo setups where different apps need different Docker build contexts.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

## Related Issues