### PR TITLE
fix(ci): compare against previous tag instead of HEAD^ on tag pushes

### DIFF
--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -51,13 +51,27 @@ runs:
           # For PRs, diff between the base branch and current HEAD
           FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD)
         elif [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]] || [[ -z "${{ github.event.before }}" ]]; then
-          # For tags or when before is not available, compare with the previous commit
-          PREV_COMMIT=$(git rev-parse HEAD^)
-          if [[ $? -eq 0 ]]; then
-            FILES=$(git diff --name-only $PREV_COMMIT HEAD)
+          # Tag push or missing before ref
+          CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          if [[ -n "$CURRENT_TAG" ]]; then
+            # Compare against previous tag to capture all changes since last release
+            PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+            if [[ -n "$PREV_TAG" ]]; then
+              echo "Tag push detected: comparing $PREV_TAG..$CURRENT_TAG"
+              FILES=$(git diff --name-only "$PREV_TAG" HEAD)
+            else
+              # First tag ever — list all files
+              FILES=$(git ls-tree -r --name-only HEAD)
+            fi
           else
-            # Fallback for first commit
-            FILES=$(git ls-tree -r --name-only HEAD)
+            # Not a tag — compare with previous commit
+            PREV_COMMIT=$(git rev-parse HEAD^)
+            if [[ $? -eq 0 ]]; then
+              FILES=$(git diff --name-only $PREV_COMMIT HEAD)
+            else
+              # Fallback for first commit
+              FILES=$(git ls-tree -r --name-only HEAD)
+            fi
           fi
         else
           # Normal case - diff between commits


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fixes the `changed-paths` composite action to compare against the **previous tag** instead of `HEAD^` when triggered by a tag push.

**Root cause:** When `github.event.before` is zeroed out (tag push), the action fell back to `git diff HEAD^ HEAD`, which only compares the tagged commit against its immediate parent. If the tagged commit didn't directly touch a given path (e.g., migrations added in earlier merges), the diff was empty and the build was silently skipped.

**Fix:** When HEAD is a tag, find the previous tag via `git tag --sort=-v:refname` and diff against it. This captures all changes accumulated since the last release.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Non-tag triggers are unaffected. For tag pushes, the diff is now broader (previous tag instead of single commit), meaning previously skipped builds will now correctly run.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** To be validated on `plugin-auth` after merge to develop.

## Related Issues

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced change detection to be tag-aware: automatically identifies the current tag on HEAD and compares with the previous tag to determine changed files. Includes improved fallback handling for edge cases while maintaining existing behavior for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->