### PR TITLE
fix(ci): use path segment boundary matching to prevent prefix collisions

### DIFF
--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -128,7 +128,9 @@ runs:
             while read -r DIR; do
               while read -r FILTER; do
                 [[ -z "$FILTER" ]] && continue
-                FILTER="${FILTER%/}"
+                while [[ "$FILTER" == */ && "$FILTER" != "/" ]]; do
+                  FILTER="${FILTER%/}"
+                done
                 if [[ "$DIR" == "$FILTER" ]] || [[ "$DIR" == "$FILTER"/* ]]; then
                   if [[ "$NORMALIZE_TO_FILTER" == "true" ]]; then
                     FILTERED+="$FILTER"$'\n'


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fixes a prefix collision bug in the `changed-paths` composite action's filter matching logic.

**Bug:** The pattern `[[ "$DIR" == "$FILTER"* ]]` matches on string prefix, not path segment boundary. This means `init/casdoor` incorrectly matches `init/casdoor-migrations`, causing the wrong filter to be applied and the `break` to skip the correct filter.

**Fix:** Replace with path-segment-aware matching:
```bash
[[ "$DIR" == "$FILTER" ]] || [[ "$DIR" == "$FILTER"/* ]]
```

Now `init/casdoor` only matches `init/casdoor` or `init/casdoor/...`, never `init/casdoor-migrations`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Callers that had overlapping prefixes and worked around it by ordering `filter_paths` longest-first will continue to work. Callers that were silently affected by the collision will now match correctly.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** To be validated on `plugin-auth` with `init/casdoor` and `init/casdoor-migrations` filters.

## Related Issues

Related to #131 (discovered during tag comparison fix investigation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory filtering: trailing slashes are trimmed and matching now covers exact directories and their nested subdirectories (rather than relying on simple prefix checks), preventing incorrect exclusions and ensuring filtered results are produced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->