### PR TITLE
fix(deps): correct tcort markdown-link-check action repository name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,7 +99,7 @@ updates:
         patterns:
           - "amannn/action-semantic-pull-request"
           - "actions/labeler"
-          - "tcort/markdown-link-check-action"
+          - "tcort/github-action-markdown-link-check"
           - "actions/github-script"
           - "mikefarah/yq"
         update-types:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -265,7 +265,7 @@ jobs:
           test -f LICENSE
 
       - name: Validate Markdown links
-        uses: tcort/markdown-link-check-action@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
           config-file: '.github/markdown-link-check-config.json'


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fix incorrect action repository name introduced in #138. The correct fork of the deprecated `gaurav-nelson/github-action-markdown-link-check` is `tcort/github-action-markdown-link-check`, not `tcort/markdown-link-check-action`.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [x] Verified action name matches the actual GitHub repository
- [x] Confirmed inputs `use-quiet-mode` and `config-file` are supported by the tcort fork

**Caller repo / workflow run:** N/A — name correction only.

## Related Issues

Follow-up fix for #138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated markdown link validation tool in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->