### PR TITLE
fix(changed-paths): use channel-aware tag comparison for beta/rc/release

### DIFF
--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -70,13 +70,29 @@ runs:
           # Tag push or missing before ref
           CURRENT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
           if [[ -n "$CURRENT_TAG" ]]; then
-            # Compare against previous tag to capture all changes since last release
-            PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1 || true)
+            # Detect channel from tag name: beta, rc, or release
+            if [[ "$CURRENT_TAG" == *"-beta"* ]]; then
+              CHANNEL="beta"
+            elif [[ "$CURRENT_TAG" == *"-rc"* ]]; then
+              CHANNEL="rc"
+            else
+              CHANNEL="release"
+            fi
+
+            # Find previous tag of the same channel to avoid cross-channel false negatives
+            # (e.g. rc.1 vs beta.N where beta is a parent commit → empty diff)
+            if [[ "$CHANNEL" == "release" ]]; then
+              PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | grep -v -- "-beta" | grep -v -- "-rc" | head -1 || true)
+            else
+              PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | grep -- "-${CHANNEL}" | head -1 || true)
+            fi
+
             if [[ -n "$PREV_TAG" ]]; then
-              echo "Tag push detected: comparing $PREV_TAG..$CURRENT_TAG"
+              echo "Tag push detected ($CHANNEL channel): comparing $PREV_TAG..$CURRENT_TAG"
               FILES=$(git diff --name-only "$PREV_TAG" HEAD)
             else
-              # First tag ever — list all files
+              # First tag of this channel — build everything
+              echo "First tag for channel '$CHANNEL': building all files"
               FILES=$(git ls-tree -r --name-only HEAD)
             fi
           else


### PR DESCRIPTION
## Problem

When a tag changes channel (e.g. `beta → rc`), the `changed-paths` action compares the new tag against the **globally previous tag**, which may be a parent commit of the new tag's merge commit. This produces a zero diff and skips all builds.

**Concrete example:**
- `v1.5.0-beta.20` was tagged at commit `2630251` (`chore: add semantic-commit skill definition`)
- `v1.5.0-rc.1` is a merge commit with parents: `9ed55252` (release branch) + `2630251` (= beta.20)
- Diff between `beta.20` and `rc.1` = **0 files** → build skipped

## Solution

Detect the channel of the current tag (`beta`, `rc`, or `release`) and compare only against the **previous tag of the same channel**:

| Current tag | Compares against |
|-------------|-----------------|
| `v1.5.0-rc.1` | last `-rc` tag (none → builds everything) |
| `v1.5.0-beta.21` | `v1.5.0-beta.20` |
| `v1.5.0` | last release tag (no `-beta`/`-rc` suffix) |

This guarantees:
- **First tag of a new channel always builds** (no previous same-channel tag to compare)
- **Subsequent tags in the same channel** continue with normal change detection
- **No unnecessary full rebuilds** when tags stay within the same channel

## Changes

Single file: `src/config/changed-paths/action.yml`

Replaces the single `PREV_TAG` line with channel detection + channel-filtered tag lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented channel-based tag detection for release, beta, and rc channels.
  * Made previous-tag selection channel-aware to improve accuracy for each release type.
  * Updated release messaging to indicate the detected channel and comparison range.
  * Added handling for first-time channel releases by building full file lists when no prior tag exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->