### PR TITLE
fix: bump trivy-action from 0.34.1 to 0.35.0

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -138,7 +138,7 @@ jobs:
 
       # ----------------- Security Scans -----------------
       - name: Trivy Secret Scan - Component (Table Output)
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         if: always()
         with:
           scan-type: fs
@@ -150,7 +150,7 @@ jobs:
           version: 'v0.69.2'
 
       - name: Trivy Secret Scan - Component (SARIF Output)
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         if: always()
         with:
           scan-type: fs
@@ -178,7 +178,7 @@ jobs:
 
       - name: Trivy Vulnerability Scan - Docker Image (Table Output)
         if: always() && inputs.enable_docker_scan
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'
           format: 'table'
@@ -190,7 +190,7 @@ jobs:
 
       - name: Trivy Vulnerability Scan - Docker Image (SARIF Output)
         if: always() && inputs.enable_docker_scan
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'
           format: sarif
@@ -204,7 +204,7 @@ jobs:
       # ----------------- Filesystem Vulnerability Scan -----------------
       - name: Trivy Vulnerability Scan - Filesystem (JSON Output)
         id: fs-vuln-scan
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         if: always()
         with:
           scan-type: fs


### PR DESCRIPTION
## Problem

The `aquasecurity/trivy-action@0.34.1` version no longer resolves, causing all `security-scan` jobs to fail immediately with:

```
Unable to resolve action `aquasecurity/trivy-action@0.34.1`, unable to find version `0.34.1`
```

Spotted in [midaz#1930](https://github.com/LerianStudio/midaz/pull/1930) — both `security_scan (ledger)` and `security_scan (transaction)` jobs failed with this error, unrelated to the PR changes.

## Fix

Bumps all 5 occurrences of `trivy-action` in `pr-security-scan.yml` from `0.34.1` → `0.35.0` (latest release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning dependencies to the latest stable versions, enhancing the effectiveness of vulnerability and secret detection in continuous integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->