### PR TITLE
fix(release): detect published release via git tag when backmerge plugin fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,13 @@ jobs:
           npm install --save-dev \
             @semantic-release/exec
 
+      - name: Snapshot tags before release
+        id: pre-tags
+        run: |
+          git fetch --tags origin
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          echo "latest_tag=${LATEST_TAG:-none}" >> "$GITHUB_OUTPUT"
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         id: semantic
@@ -171,22 +178,13 @@ jobs:
         id: detect-release
         run: |
           git fetch --tags origin
-          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
-          # Check if the latest tag points to a commit on the current branch
-          if [ -n "$LATEST_TAG" ] && git merge-base --is-ancestor "$(git rev-list -n1 "$LATEST_TAG")" HEAD 2>/dev/null; then
-            TAG_COMMIT=$(git rev-list -n1 "$LATEST_TAG")
-            # If the tag was created in the last 5 minutes, the release was just published
-            TAG_DATE=$(git log -1 --format=%ct "$TAG_COMMIT")
-            NOW=$(date +%s)
-            DIFF=$((NOW - TAG_DATE))
-            if [ "$DIFF" -lt 300 ]; then
-              echo "release_published=true" >> "$GITHUB_OUTPUT"
-              VERSION="${LATEST_TAG#v}"
-              echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
-              echo "::notice::Release ${LATEST_TAG} was published despite backmerge failure"
-            else
-              echo "release_published=false" >> "$GITHUB_OUTPUT"
-            fi
+          NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          PRE_TAG="${{ steps.pre-tags.outputs.latest_tag }}"
+          if [ "$NEW_TAG" != "$PRE_TAG" ] && [ -n "$NEW_TAG" ]; then
+            echo "release_published=true" >> "$GITHUB_OUTPUT"
+            VERSION="${NEW_TAG#v}"
+            echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release ${NEW_TAG} was published despite backmerge failure"
           else
             echo "release_published=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,12 +147,10 @@ jobs:
           npm install --save-dev \
             @semantic-release/exec
 
+      # ----------------- Snapshot tags before release -----------------
       - name: Snapshot tags before release
         id: pre-tags
-        run: |
-          git fetch --tags origin
-          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          echo "latest_tag=${LATEST_TAG:-none}" >> "$GITHUB_OUTPUT"
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-snapshot@develop
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
@@ -176,37 +174,28 @@ jobs:
       - name: Detect if release was published
         if: always() && steps.semantic.outcome == 'failure'
         id: detect-release
-        run: |
-          git fetch --tags origin
-          NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          PRE_TAG="${{ steps.pre-tags.outputs.latest_tag }}"
-          if [ "$NEW_TAG" != "$PRE_TAG" ] && [ -n "$NEW_TAG" ]; then
-            echo "release_published=true" >> "$GITHUB_OUTPUT"
-            VERSION="${NEW_TAG#v}"
-            echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Release ${NEW_TAG} was published despite backmerge failure"
-          else
-            echo "release_published=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-check@develop
+        with:
+          previous-tag: ${{ steps.pre-tags.outputs.latest-tag }}
 
       # ----------------- Backmerge Fallback -----------------
       - name: Backmerge PR fallback
         if: |
           always() && steps.semantic.outcome == 'failure' && (
             steps.semantic.outputs.new_release_published == 'true' ||
-            steps.detect-release.outputs.release_published == 'true'
+            steps.detect-release.outputs.release-published == 'true'
           )
         uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-pr@develop
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           source-branch: ${{ github.ref_name }}
-          version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release_version }}
+          version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release-version }}
 
       - name: Fail if release itself failed
         if: |
           always() && steps.semantic.outcome == 'failure' &&
           steps.semantic.outputs.new_release_published != 'true' &&
-          steps.detect-release.outputs.release_published != 'true'
+          steps.detect-release.outputs.release-published != 'true'
         run: |
           echo "::error::Semantic release failed before publishing a new version"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,14 +103,14 @@ jobs:
       gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
 
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -121,7 +121,7 @@ jobs:
           git reset --hard origin/${{ github.ref_name }}
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
@@ -133,7 +133,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '20'
 
@@ -148,7 +148,7 @@ jobs:
             @semantic-release/exec
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         id: semantic
         continue-on-error: true
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,17 +165,50 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
 
+      # ----------------- Detect release via git tag -----------------
+      - name: Detect if release was published
+        if: always() && steps.semantic.outcome == 'failure'
+        id: detect-release
+        run: |
+          git fetch --tags origin
+          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
+          # Check if the latest tag points to a commit on the current branch
+          if [ -n "$LATEST_TAG" ] && git merge-base --is-ancestor "$(git rev-list -n1 "$LATEST_TAG")" HEAD 2>/dev/null; then
+            TAG_COMMIT=$(git rev-list -n1 "$LATEST_TAG")
+            # If the tag was created in the last 5 minutes, the release was just published
+            TAG_DATE=$(git log -1 --format=%ct "$TAG_COMMIT")
+            NOW=$(date +%s)
+            DIFF=$((NOW - TAG_DATE))
+            if [ "$DIFF" -lt 300 ]; then
+              echo "release_published=true" >> "$GITHUB_OUTPUT"
+              VERSION="${LATEST_TAG#v}"
+              echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
+              echo "::notice::Release ${LATEST_TAG} was published despite backmerge failure"
+            else
+              echo "release_published=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "release_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # ----------------- Backmerge Fallback -----------------
       - name: Backmerge PR fallback
-        if: steps.semantic.outcome == 'failure' && steps.semantic.outputs.new_release_published == 'true'
+        if: |
+          always() && steps.semantic.outcome == 'failure' && (
+            steps.semantic.outputs.new_release_published == 'true' ||
+            steps.detect-release.outputs.release_published == 'true'
+          )
         uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-pr@develop
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           source-branch: ${{ github.ref_name }}
-          version: ${{ steps.semantic.outputs.new_release_version }}
+          version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release_version }}
 
       - name: Fail if release itself failed
-        if: steps.semantic.outcome == 'failure' && steps.semantic.outputs.new_release_published != 'true'
+        if: |
+          always() && steps.semantic.outcome == 'failure' &&
+          steps.semantic.outputs.new_release_published != 'true' &&
+          steps.detect-release.outputs.release_published != 'true'
         run: |
           echo "::error::Semantic release failed before publishing a new version"
           exit 1

--- a/src/config/release-tag-check/README.md
+++ b/src/config/release-tag-check/README.md
@@ -1,0 +1,61 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>release-tag-check</h1></td>
+  </tr>
+</table>
+
+Compares the current latest semver (`v*`) tag against a snapshot captured by [`release-tag-snapshot`](../release-tag-snapshot/) to detect whether a new release was published. This is useful when the release action exits with failure due to post-release steps (e.g., backmerge plugin) but the release itself was successful.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `previous-tag` | The tag captured by `release-tag-snapshot` before the release step | Yes | |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `release-published` | `true` if a new tag was created since the snapshot, `false` otherwise |
+| `release-version` | The new release version (without `v` prefix), empty if no new release |
+
+## Usage as composite step
+
+```yaml
+- name: Snapshot tags before release
+  id: pre-tags
+  uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-snapshot@v1.x.x
+
+- name: Semantic Release
+  uses: cycjimmy/semantic-release-action@<sha> # v6
+  id: semantic
+  continue-on-error: true
+  ...
+
+- name: Check if release was published
+  id: detect-release
+  if: always() && steps.semantic.outcome == 'failure'
+  uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-check@v1.x.x
+  with:
+    previous-tag: ${{ steps.pre-tags.outputs.latest-tag }}
+
+- name: Backmerge PR fallback
+  if: |
+    always() && steps.semantic.outcome == 'failure' && (
+      steps.semantic.outputs.new_release_published == 'true' ||
+      steps.detect-release.outputs.release-published == 'true'
+    )
+  uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-pr@v1.x.x
+  with:
+    github-token: ${{ steps.app-token.outputs.token }}
+    source-branch: ${{ github.ref_name }}
+    version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release-version }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/config/release-tag-check/action.yml
+++ b/src/config/release-tag-check/action.yml
@@ -1,0 +1,36 @@
+name: Release Tag Check
+description: "Compares the current latest semver tag against a previous snapshot to detect if a new release was published."
+
+inputs:
+  previous-tag:
+    description: The tag captured by release-tag-snapshot before the release step
+    required: true
+
+outputs:
+  release-published:
+    description: "'true' if a new tag was created since the snapshot, 'false' otherwise"
+    value: ${{ steps.check.outputs.release_published }}
+  release-version:
+    description: The new release version (without v prefix), empty if no new release
+    value: ${{ steps.check.outputs.release_version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check for new release tag
+      id: check
+      shell: bash
+      env:
+        PREVIOUS_TAG: ${{ inputs.previous-tag }}
+      run: |
+        git fetch --tags origin
+        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+        if [ "$NEW_TAG" != "$PREVIOUS_TAG" ] && [ -n "$NEW_TAG" ]; then
+          echo "release_published=true" >> "$GITHUB_OUTPUT"
+          VERSION="${NEW_TAG#v}"
+          echo "release_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Release ${NEW_TAG} was published despite post-release failure"
+        else
+          echo "release_published=false" >> "$GITHUB_OUTPUT"
+          echo "release_version=" >> "$GITHUB_OUTPUT"
+        fi

--- a/src/config/release-tag-snapshot/README.md
+++ b/src/config/release-tag-snapshot/README.md
@@ -1,0 +1,46 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>release-tag-snapshot</h1></td>
+  </tr>
+</table>
+
+Captures the latest semver (`v*`) tag before a release step runs. Used together with [`release-tag-check`](../release-tag-check/) to detect whether a new release was published — even when the release action reports failure due to post-release steps (e.g., backmerge).
+
+## Inputs
+
+None.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `latest-tag` | The latest `v*` tag before the release step, or `none` if no tags exist |
+
+## Usage as composite step
+
+```yaml
+- name: Snapshot tags before release
+  id: pre-tags
+  uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-snapshot@v1.x.x
+
+- name: Semantic Release
+  uses: cycjimmy/semantic-release-action@<sha> # v6
+  id: semantic
+  continue-on-error: true
+  ...
+
+- name: Check if release was published
+  id: detect-release
+  if: always() && steps.semantic.outcome == 'failure'
+  uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-check@v1.x.x
+  with:
+    previous-tag: ${{ steps.pre-tags.outputs.latest-tag }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/config/release-tag-snapshot/action.yml
+++ b/src/config/release-tag-snapshot/action.yml
@@ -1,0 +1,18 @@
+name: Release Tag Snapshot
+description: "Captures the latest semver tag before a release step runs, enabling post-release comparison."
+
+outputs:
+  latest-tag:
+    description: The latest v* tag before the release step (or 'none' if no tags exist)
+    value: ${{ steps.snapshot.outputs.latest_tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Snapshot latest semver tag
+      id: snapshot
+      shell: bash
+      run: |
+        git fetch --tags origin
+        LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+        echo "latest_tag=${LATEST_TAG:-none}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When the `@saithodev/semantic-release-backmerge` plugin fails (e.g., non-fast-forward push to `develop`), the `cycjimmy/semantic-release-action` exits with failure and does **not** set the `new_release_published` output — even though the release was successfully published.

This caused the backmerge PR fallback step to be skipped and the job to fail with a misleading error: _"Semantic release failed before publishing a new version"_.

**Fix:** Added a new step that detects whether a release was actually published by checking if a recent git tag (< 5 min old) exists on the current branch. The backmerge fallback and fail conditions now use this detection as an alternative signal, ensuring the fallback PR is created when the backmerge plugin fails after a successful release.

**Affected workflow:** `release.yml` (reusable)

**Triggered by:** https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/23607221651/job/68753204358

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/23607221651/job/68753204358 (the failing run that triggered this fix)

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI release detection and fallback logic to avoid false failures, correctly recognize published releases after failed attempts, and enable automatic backmerge when a release is detected.
* **New Features**
  * Added a tag snapshot-and-check mechanism to verify whether a new release tag was created during release runs.
* **Documentation**
  * Added README docs describing the snapshot/check workflow and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->