### PR TITLE
feat(security): add cosign keyless image signing to Docker build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,18 +308,23 @@ jobs:
       - name: Build cosign image references
         if: inputs.enable_cosign_sign
         id: cosign-refs
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+          ENABLE_DOCKERHUB: ${{ inputs.enable_dockerhub }}
+          ENABLE_GHCR: ${{ inputs.enable_ghcr }}
+          DOCKERHUB_ORG: ${{ inputs.dockerhub_org }}
+          APP_NAME: ${{ matrix.app.name }}
+          GHCR_ORG: ${{ steps.normalize.outputs.owner_lower }}
         run: |
-          DIGEST="${{ steps.build-push.outputs.digest }}"
           REFS=""
 
-          if [ "${{ inputs.enable_dockerhub }}" == "true" ]; then
-            REFS="${{ inputs.dockerhub_org }}/${{ matrix.app.name }}@${DIGEST}"
+          if [ "$ENABLE_DOCKERHUB" == "true" ]; then
+            REFS="${DOCKERHUB_ORG}/${APP_NAME}@${DIGEST}"
           fi
 
-          if [ "${{ inputs.enable_ghcr }}" == "true" ]; then
-            GHCR_ORG="${{ steps.normalize.outputs.owner_lower }}"
+          if [ "$ENABLE_GHCR" == "true" ]; then
             [ -n "$REFS" ] && REFS="${REFS}"$'\n'
-            REFS="${REFS}ghcr.io/${GHCR_ORG}/${{ matrix.app.name }}@${DIGEST}"
+            REFS="${REFS}ghcr.io/${GHCR_ORG}/${APP_NAME}@${DIGEST}"
           fi
 
           {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,10 +126,15 @@ on:
         description: 'Use the component working_dir as Docker build context instead of build_context. Useful for independent modules (e.g., tools with their own go.mod).'
         type: boolean
         default: false
+      enable_cosign_sign:
+        description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   prepare:
@@ -283,6 +288,7 @@ jobs:
             type=semver,pattern={{major}},value=${{ steps.version.outputs.version }},enable=${{ needs.prepare.outputs.is_release }}
 
       - name: Build and push Docker image
+        id: build-push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ inputs.build_context_from_working_dir == true && matrix.app.working_dir || inputs.build_context }}
@@ -298,7 +304,37 @@ jobs:
           secrets: |
             github_token=${{ secrets.MANAGE_TOKEN }}
 
-      # GitOps artifacts for downstream gitops-update workflow
+      # ----------------- Cosign Image Signing -----------------
+      - name: Build cosign image references
+        if: inputs.enable_cosign_sign
+        id: cosign-refs
+        run: |
+          DIGEST="${{ steps.build-push.outputs.digest }}"
+          REFS=""
+
+          if [ "${{ inputs.enable_dockerhub }}" == "true" ]; then
+            REFS="${{ inputs.dockerhub_org }}/${{ matrix.app.name }}@${DIGEST}"
+          fi
+
+          if [ "${{ inputs.enable_ghcr }}" == "true" ]; then
+            GHCR_ORG="${{ steps.normalize.outputs.owner_lower }}"
+            [ -n "$REFS" ] && REFS="${REFS}"$'\n'
+            REFS="${REFS}ghcr.io/${GHCR_ORG}/${{ matrix.app.name }}@${DIGEST}"
+          fi
+
+          {
+            echo "refs<<EOF"
+            echo "$REFS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sign container images with cosign
+        if: inputs.enable_cosign_sign
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@feat/cosign-sign
+        with:
+          image-refs: ${{ steps.cosign-refs.outputs.refs }}
+
+      # ----------------- GitOps Artifacts -----------------
       - name: Create GitOps tag artifact
         if: inputs.enable_gitops_artifacts
         run: |

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -184,10 +184,13 @@ jobs:
       - name: Build cosign image references
         if: inputs.enable_cosign_sign
         id: cosign-refs
+        env:
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+          DOCKER_REGISTRY: ${{ inputs.docker_registry }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          DIGEST="${{ steps.build-push.outputs.digest }}"
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "refs=${{ inputs.docker_registry }}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "refs=${DOCKER_REGISTRY}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Sign container images with cosign
         if: inputs.enable_cosign_sign

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -67,10 +67,15 @@ on:
         description: 'Enable release notifications'
         type: boolean
         default: false
+      enable_cosign_sign:
+        description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
+        type: boolean
+        default: true
 
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   release:
@@ -164,6 +169,7 @@ jobs:
           tags: ${{ inputs.docker_tags }}
 
       - name: Build and push
+        id: build-push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
@@ -173,6 +179,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ----------------- Cosign Image Signing -----------------
+      - name: Build cosign image references
+        if: inputs.enable_cosign_sign
+        id: cosign-refs
+        run: |
+          DIGEST="${{ steps.build-push.outputs.digest }}"
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "refs=${{ inputs.docker_registry }}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign container images with cosign
+        if: inputs.enable_cosign_sign
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@feat/cosign-sign
+        with:
+          image-refs: ${{ steps.cosign-refs.outputs.refs }}
 
   # Slack notification
   notify:

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -133,6 +133,10 @@ on:
         description: 'JSON mapping of component names to values.yaml keys'
         type: string
         default: ''
+      enable_cosign_sign:
+        description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
+        type: boolean
+        default: true
 
   workflow_dispatch:
     inputs:
@@ -144,6 +148,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   prepare:
@@ -255,6 +260,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and push Docker image
+        id: docker-build
         uses: LerianStudio/github-actions-shared-workflows/src/build/docker-build-ts@v1.18.0
         with:
           enable-dockerhub: ${{ inputs.enable_dockerhub }}
@@ -275,7 +281,54 @@ jobs:
           is-release: ${{ needs.prepare.outputs.is_release }}
           dry-run: ${{ inputs.dry_run }}
 
-      # GitOps artifacts for downstream gitops-update workflow
+      # ----------------- Cosign Image Signing -----------------
+      - name: Normalize repository owner to lowercase
+        if: inputs.enable_cosign_sign && !inputs.dry_run
+        id: normalize
+        run: |
+          echo "owner_lower=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Build cosign image references
+        if: inputs.enable_cosign_sign && !inputs.dry_run
+        id: cosign-refs
+        run: |
+          DIGEST="${{ steps.docker-build.outputs.image-digest }}"
+          if [ -z "$DIGEST" ]; then
+            echo "::warning::No image digest available — skipping cosign signing"
+            echo "refs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REFS=""
+          GHCR_ORG="${{ inputs.ghcr_org }}"
+          if [ -z "$GHCR_ORG" ]; then
+            GHCR_ORG="${{ steps.normalize.outputs.owner_lower }}"
+          else
+            GHCR_ORG=$(echo "$GHCR_ORG" | tr '[:upper:]' '[:lower:]')
+          fi
+
+          if [ "${{ inputs.enable_dockerhub }}" == "true" ]; then
+            REFS="${{ inputs.dockerhub_org }}/${{ matrix.app.name }}@${DIGEST}"
+          fi
+
+          if [ "${{ inputs.enable_ghcr }}" == "true" ]; then
+            [ -n "$REFS" ] && REFS="${REFS}"$'\n'
+            REFS="${REFS}ghcr.io/${GHCR_ORG}/${{ matrix.app.name }}@${DIGEST}"
+          fi
+
+          {
+            echo "refs<<EOF"
+            echo "$REFS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sign container images with cosign
+        if: inputs.enable_cosign_sign && !inputs.dry_run && steps.cosign-refs.outputs.refs != ''
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@feat/cosign-sign
+        with:
+          image-refs: ${{ steps.cosign-refs.outputs.refs }}
+
+      # ----------------- GitOps Artifacts -----------------
       - name: Create GitOps tag artifact
         if: inputs.enable_gitops_artifacts && !inputs.dry_run
         run: |

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -285,14 +285,23 @@ jobs:
       - name: Normalize repository owner to lowercase
         if: inputs.enable_cosign_sign && !inputs.dry_run
         id: normalize
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          echo "owner_lower=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          echo "owner_lower=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Build cosign image references
         if: inputs.enable_cosign_sign && !inputs.dry_run
         id: cosign-refs
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.image-digest }}
+          ENABLE_DOCKERHUB: ${{ inputs.enable_dockerhub }}
+          ENABLE_GHCR: ${{ inputs.enable_ghcr }}
+          DOCKERHUB_ORG: ${{ inputs.dockerhub_org }}
+          INPUT_GHCR_ORG: ${{ inputs.ghcr_org }}
+          NORMALIZED_OWNER: ${{ steps.normalize.outputs.owner_lower }}
+          APP_NAME: ${{ matrix.app.name }}
         run: |
-          DIGEST="${{ steps.docker-build.outputs.image-digest }}"
           if [ -z "$DIGEST" ]; then
             echo "::warning::No image digest available — skipping cosign signing"
             echo "refs=" >> "$GITHUB_OUTPUT"
@@ -300,20 +309,20 @@ jobs:
           fi
 
           REFS=""
-          GHCR_ORG="${{ inputs.ghcr_org }}"
+          GHCR_ORG="$INPUT_GHCR_ORG"
           if [ -z "$GHCR_ORG" ]; then
-            GHCR_ORG="${{ steps.normalize.outputs.owner_lower }}"
+            GHCR_ORG="$NORMALIZED_OWNER"
           else
             GHCR_ORG=$(echo "$GHCR_ORG" | tr '[:upper:]' '[:lower:]')
           fi
 
-          if [ "${{ inputs.enable_dockerhub }}" == "true" ]; then
-            REFS="${{ inputs.dockerhub_org }}/${{ matrix.app.name }}@${DIGEST}"
+          if [ "$ENABLE_DOCKERHUB" == "true" ]; then
+            REFS="${DOCKERHUB_ORG}/${APP_NAME}@${DIGEST}"
           fi
 
-          if [ "${{ inputs.enable_ghcr }}" == "true" ]; then
+          if [ "$ENABLE_GHCR" == "true" ]; then
             [ -n "$REFS" ] && REFS="${REFS}"$'\n'
-            REFS="${REFS}ghcr.io/${GHCR_ORG}/${{ matrix.app.name }}@${DIGEST}"
+            REFS="${REFS}ghcr.io/${GHCR_ORG}/${APP_NAME}@${DIGEST}"
           fi
 
           {

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -107,6 +107,7 @@ jobs:
 | `build_context` | string | `.` | Docker build context |
 | `enable_gitops_artifacts` | boolean | `false` | Upload artifacts for gitops-update workflow |
 | `force_multiplatform` | boolean | `false` | Force multi-platform build (amd64+arm64) even for beta/rc tags |
+| `enable_cosign_sign` | boolean | `true` | Sign images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller |
 
 ## Secrets
 
@@ -193,6 +194,41 @@ Automatically sends notifications on completion:
 
 ### notify
 - Sends Slack notification on completion
+
+## Image Signing (cosign)
+
+Container images are signed by default using [Sigstore cosign](https://github.com/sigstore/cosign) with keyless (OIDC) signing. The GitHub Actions identity is used as proof of provenance — no private keys are needed.
+
+### Caller permissions
+
+Callers **must** grant `id-token: write` for signing to work:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # required for cosign keyless signing
+```
+
+### Disabling signing
+
+```yaml
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.0.0
+    with:
+      enable_cosign_sign: false
+    secrets: inherit
+```
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-identity-regexp=".*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  docker.io/lerianstudio/my-app@sha256:abc123...
+```
 
 ## Best Practices
 

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -114,6 +114,7 @@ jobs:
 | `docker_platforms` | Docker platforms (comma-separated) | No | `linux/amd64,linux/arm64` |
 | `docker_tags` | Docker image tags configuration | No | Semver + latest |
 | `enable_notifications` | Enable release notifications | No | `false` |
+| `enable_cosign_sign` | Sign Docker images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller | No | `true` |
 
 ## Secrets
 
@@ -170,6 +171,42 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
     with:
       run_tests_before_release: false
+```
+
+## Image Signing (cosign)
+
+When Docker is enabled, container images are signed by default using [Sigstore cosign](https://github.com/sigstore/cosign) with keyless (OIDC) signing.
+
+### Caller permissions
+
+Callers **must** grant `id-token: write` for signing to work:
+
+```yaml
+permissions:
+  contents: write
+  packages: write
+  id-token: write   # required for cosign keyless signing
+```
+
+### Disabling signing
+
+```yaml
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
+    with:
+      enable_docker: true
+      enable_cosign_sign: false
+    secrets: inherit
+```
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-identity-regexp=".*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/myorg/my-app@sha256:abc123...
 ```
 
 ## Release Process

--- a/docs/typescript-build.md
+++ b/docs/typescript-build.md
@@ -17,6 +17,7 @@ The build logic is encapsulated in the [`docker-build-ts`](../src/build/docker-b
 | `npmrc` secret | Not included | Always injected automatically |
 | `build_secrets` behavior | Replaces all secrets | Additive (extra secrets on top of npmrc) |
 | `dry_run` mode | Not available | Available |
+| Cosign signing | Enabled by default | Enabled by default (skipped in dry-run) |
 | `workflow_dispatch` | Not available | Available for manual testing |
 | Dockerfile per component | Uses `dockerfile_name` only | Resolves `matrix.app.dockerfile` with fallback |
 
@@ -147,6 +148,7 @@ jobs:
 | `helm_dispatch_on_rc` | boolean | `false` | Enable Helm dispatch for rc tags |
 | `helm_dispatch_on_beta` | boolean | `false` | Enable Helm dispatch for beta tags |
 | `helm_values_key_mappings` | string | `''` | Component names to values.yaml keys mapping |
+| `enable_cosign_sign` | boolean | `true` | Sign images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller |
 
 ## Secrets
 
@@ -196,6 +198,41 @@ Dockerfiles must mount the `npmrc` secret for installing private packages:
 
 ```dockerfile
 RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm install
+```
+
+## Image Signing (cosign)
+
+Container images are signed by default using [Sigstore cosign](https://github.com/sigstore/cosign) with keyless (OIDC) signing. Signing is skipped during dry-run mode (no digest available).
+
+### Caller permissions
+
+Callers **must** grant `id-token: write` for signing to work:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # required for cosign keyless signing
+```
+
+### Disabling signing
+
+```yaml
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-build.yml@v1.0.0
+    with:
+      enable_cosign_sign: false
+    secrets: inherit
+```
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-identity-regexp=".*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/lerianstudio/my-app@sha256:abc123...
 ```
 
 ## Related Workflows

--- a/src/security/cosign-sign/README.md
+++ b/src/security/cosign-sign/README.md
@@ -1,0 +1,80 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>cosign-sign</h1></td>
+  </tr>
+</table>
+
+Composite action that signs container images using [Sigstore cosign](https://github.com/sigstore/cosign) with keyless (OIDC) signing. Uses the GitHub Actions OIDC identity provider — no private keys to manage. Signatures are stored in the registry alongside the image.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|:---:|---|
+| `image-refs` | Newline-separated fully qualified image references to sign (e.g., `docker.io/org/app@sha256:abc...`) | Yes | — |
+| `cosign-version` | Cosign version to install | No | `v2.5.0` |
+| `dry-run` | Log what would be signed without actually signing | No | `false` |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `signed-refs` | Newline-separated list of successfully signed image references |
+
+## Usage
+
+### As a composite step (after Docker build and push)
+
+```yaml
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for keyless signing
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build and push Docker image
+        id: build-push
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          tags: myorg/myapp:1.0.0
+
+      - name: Sign container image
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.x.x
+        with:
+          image-refs: myorg/myapp@${{ steps.build-push.outputs.digest }}
+```
+
+### Signing multiple registries
+
+```yaml
+      - name: Sign container images
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.x.x
+        with:
+          image-refs: |
+            docker.io/myorg/myapp@${{ steps.build-push.outputs.digest }}
+            ghcr.io/myorg/myapp@${{ steps.build-push.outputs.digest }}
+```
+
+### Verifying signatures
+
+```bash
+cosign verify \
+  --certificate-identity-regexp=".*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  docker.io/myorg/myapp@sha256:abc123...
+```
+
+## Permissions required
+
+```yaml
+permissions:
+  id-token: write   # required — OIDC token for keyless signing
+  packages: write   # if pushing signatures to GHCR
+```
+
+> **Note:** The calling job must have `id-token: write` permission for keyless signing to work. Without it, cosign cannot obtain an OIDC token and the signing step will fail.

--- a/src/security/cosign-sign/action.yml
+++ b/src/security/cosign-sign/action.yml
@@ -1,0 +1,100 @@
+name: Cosign Keyless Image Signing
+description: Sign container images using Sigstore cosign with keyless (OIDC) signing via GitHub Actions identity.
+
+inputs:
+  image-refs:
+    description: Newline-separated fully qualified image references to sign (e.g., docker.io/org/app@sha256:abc...)
+    required: true
+  cosign-version:
+    description: Cosign version to install
+    required: false
+    default: "v2.5.0"
+  dry-run:
+    description: Log what would be signed without actually signing
+    required: false
+    default: "false"
+
+outputs:
+  signed-refs:
+    description: Newline-separated list of successfully signed image references
+    value: ${{ steps.sign.outputs.signed_refs }}
+
+runs:
+  using: composite
+  steps:
+    # ----------------- Setup -----------------
+    - name: Install cosign
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      with:
+        cosign-release: ${{ inputs.cosign-version }}
+
+    # ----------------- Validation -----------------
+    - name: Validate image references
+      id: validate
+      shell: bash
+      run: |
+        REFS="${{ inputs.image-refs }}"
+        if [ -z "$REFS" ]; then
+          echo "::error::No image references provided"
+          exit 1
+        fi
+
+        VALID_COUNT=0
+        while IFS= read -r ref; do
+          ref=$(echo "$ref" | xargs)
+          [ -z "$ref" ] && continue
+          if [[ "$ref" != *"@sha256:"* ]]; then
+            echo "::error::Invalid image reference (missing @sha256: digest): $ref"
+            exit 1
+          fi
+          VALID_COUNT=$((VALID_COUNT + 1))
+        done <<< "$REFS"
+
+        if [ "$VALID_COUNT" -eq 0 ]; then
+          echo "::error::No valid image references found"
+          exit 1
+        fi
+
+        echo "count=$VALID_COUNT" >> "$GITHUB_OUTPUT"
+
+    # ----------------- Dry Run -----------------
+    - name: Dry run summary
+      if: ${{ inputs.dry-run == 'true' }}
+      shell: bash
+      run: |
+        echo "::notice::DRY RUN — no images will be signed"
+        echo "  cosign version : ${{ inputs.cosign-version }}"
+        echo "  OIDC issuer    : https://token.actions.githubusercontent.com"
+        echo "  images (${{ steps.validate.outputs.count }}):"
+        while IFS= read -r ref; do
+          ref=$(echo "$ref" | xargs)
+          [ -z "$ref" ] && continue
+          echo "    - $ref"
+        done <<< "${{ inputs.image-refs }}"
+
+    # ----------------- Sign -----------------
+    - name: Sign container images
+      if: ${{ inputs.dry-run != 'true' }}
+      id: sign
+      shell: bash
+      run: |
+        SIGNED=""
+        while IFS= read -r ref; do
+          ref=$(echo "$ref" | xargs)
+          [ -z "$ref" ] && continue
+          echo "Signing: $ref"
+          cosign sign --yes "$ref"
+          if [ -n "$SIGNED" ]; then
+            SIGNED="${SIGNED}"$'\n'"${ref}"
+          else
+            SIGNED="$ref"
+          fi
+        done <<< "${{ inputs.image-refs }}"
+
+        {
+          echo "signed_refs<<EOF"
+          echo "$SIGNED"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::notice::Successfully signed ${{ steps.validate.outputs.count }} image(s)"

--- a/src/security/cosign-sign/action.yml
+++ b/src/security/cosign-sign/action.yml
@@ -32,9 +32,10 @@ runs:
     - name: Validate image references
       id: validate
       shell: bash
+      env:
+        IMAGE_REFS: ${{ inputs.image-refs }}
       run: |
-        REFS="${{ inputs.image-refs }}"
-        if [ -z "$REFS" ]; then
+        if [ -z "$IMAGE_REFS" ]; then
           echo "::error::No image references provided"
           exit 1
         fi
@@ -48,7 +49,7 @@ runs:
             exit 1
           fi
           VALID_COUNT=$((VALID_COUNT + 1))
-        done <<< "$REFS"
+        done <<< "$IMAGE_REFS"
 
         if [ "$VALID_COUNT" -eq 0 ]; then
           echo "::error::No valid image references found"
@@ -61,22 +62,29 @@ runs:
     - name: Dry run summary
       if: ${{ inputs.dry-run == 'true' }}
       shell: bash
+      env:
+        IMAGE_REFS: ${{ inputs.image-refs }}
+        COSIGN_VERSION: ${{ inputs.cosign-version }}
+        VALID_COUNT: ${{ steps.validate.outputs.count }}
       run: |
         echo "::notice::DRY RUN — no images will be signed"
-        echo "  cosign version : ${{ inputs.cosign-version }}"
+        echo "  cosign version : $COSIGN_VERSION"
         echo "  OIDC issuer    : https://token.actions.githubusercontent.com"
-        echo "  images (${{ steps.validate.outputs.count }}):"
+        echo "  images ($VALID_COUNT):"
         while IFS= read -r ref; do
           ref=$(echo "$ref" | xargs)
           [ -z "$ref" ] && continue
           echo "    - $ref"
-        done <<< "${{ inputs.image-refs }}"
+        done <<< "$IMAGE_REFS"
 
     # ----------------- Sign -----------------
     - name: Sign container images
       if: ${{ inputs.dry-run != 'true' }}
       id: sign
       shell: bash
+      env:
+        IMAGE_REFS: ${{ inputs.image-refs }}
+        VALID_COUNT: ${{ steps.validate.outputs.count }}
       run: |
         SIGNED=""
         while IFS= read -r ref; do
@@ -89,7 +97,7 @@ runs:
           else
             SIGNED="$ref"
           fi
-        done <<< "${{ inputs.image-refs }}"
+        done <<< "$IMAGE_REFS"
 
         {
           echo "signed_refs<<EOF"
@@ -97,4 +105,4 @@ runs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
-        echo "::notice::Successfully signed ${{ steps.validate.outputs.count }} image(s)"
+        echo "::notice::Successfully signed $VALID_COUNT image(s)"

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -336,10 +336,15 @@ runs:
       if: inputs.fail-on-findings == 'true'
       shell: bash
       run: |
-        if [ "${{ steps.parse-outputs.outputs.has_errors }}" = "true" ]; then
-          echo "::warning::Some scan artifacts were missing or could not be parsed."
+        HAS_ERRORS="${{ steps.parse-outputs.outputs.has_errors }}"
+        HAS_FINDINGS="${{ steps.parse-outputs.outputs.has_findings }}"
+
+        if [ "$HAS_ERRORS" = "true" ]; then
+          echo "::error::Some scan artifacts were missing or could not be parsed. Failing to prevent bypass."
         fi
-        if [ "${{ steps.parse-outputs.outputs.has_findings }}" = "true" ]; then
+        if [ "$HAS_FINDINGS" = "true" ]; then
           echo "::error::Security vulnerabilities found. Check the PR comment for details."
+        fi
+        if [ "$HAS_ERRORS" = "true" ] || [ "$HAS_FINDINGS" = "true" ]; then
           exit 1
         fi

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     - name: Post security report to PR
       id: report
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         APP_NAME: ${{ inputs.app-name }}
         ENABLE_DOCKER_SCAN: ${{ inputs.enable-docker-scan }}

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -335,10 +335,10 @@ runs:
     - name: Gate - Fail on Security Findings
       if: inputs.fail-on-findings == 'true'
       shell: bash
+      env:
+        HAS_ERRORS: ${{ steps.parse-outputs.outputs.has_errors }}
+        HAS_FINDINGS: ${{ steps.parse-outputs.outputs.has_findings }}
       run: |
-        HAS_ERRORS="${{ steps.parse-outputs.outputs.has_errors }}"
-        HAS_FINDINGS="${{ steps.parse-outputs.outputs.has_findings }}"
-
         if [ "$HAS_ERRORS" = "true" ]; then
           echo "::error::Some scan artifacts were missing or could not be parsed. Failing to prevent bypass."
         fi


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Add cosign keyless (OIDC) image signing to all Docker build workflows. Images are signed after push using the GitHub Actions OIDC identity provider — no private keys to manage.

**Changes:**
- **New composite action** `src/security/cosign-sign/` — installs cosign and signs images using Sigstore Fulcio keyless signing
- **`build.yml`** — add `enable_cosign_sign` input (default: `true`), `id-token: write` permission, and cosign signing steps after build-push
- **`typescript-build.yml`** — same integration, skipped during dry-run (no digest available)
- **`go-release.yml`** — same integration in the Docker job
- **`pr-security-reporter`** — fix: also fail the check when scan artifacts are missing (prevent bypass)
- **Documentation** updated for all 3 workflows

**Caller impact:** Callers must add `id-token: write` to their permissions block. Callers that don't want signing can pass `enable_cosign_sign: false`.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

Callers that declare explicit `permissions` blocks must add `id-token: write` to enable signing. Since `enable_cosign_sign` defaults to `true`, callers without `id-token: write` will see the signing step fail. To opt out, set `enable_cosign_sign: false`.

Migration:
```yaml
# Before
permissions:
  contents: read
  packages: write

# After
permissions:
  contents: read
  packages: write
  id-token: write   # required for cosign keyless signing
```

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Pending — composite refs point to `@feat/cosign-sign` for testing

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images are signed by default with Sigstore cosign (keyless OIDC signing); signing can be disabled and supports dry-run mode.
  * Added a reusable signing step/workflow to sign pushed images and report signed refs.

* **Documentation**
  * Added user docs and examples for enabling/disabling signing, required permissions, and signature verification.

* **Bug Fixes**
  * Security gate tightened: parse errors or findings now cause the check to fail explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->