### PR TITLE
feat(security): add CodeQL analysis and pre-release version gate

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Post Security Scan Results to PR
         id: post-results
         if: always() && github.event_name == 'pull_request'
-        uses: LerianStudio/github-actions-shared-workflows/src/security/pr-security-reporter@v1.23.1
+        uses: LerianStudio/github-actions-shared-workflows/src/security/pr-security-reporter@feat/pr-security-scan-codeql-prerelease
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
           app-name: ${{ env.APP_NAME }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -95,6 +95,7 @@ on:
         default: true
 
 permissions:
+  actions: read         # Required for CodeQL status reporting
   id-token: write       # Required for OIDC authentication
   contents: read        # Required to checkout the repository
   pull-requests: write  # Allows commenting on PRs

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -223,6 +223,7 @@ jobs:
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
+          github-token: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post Security Scan Results to PR

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -97,6 +97,10 @@ on:
         description: 'Block dependencies pinned to pre-release versions (-beta, -rc)'
         type: boolean
         default: true
+      prerelease_block_branches:
+        description: 'Comma-separated list of PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only.'
+        type: string
+        default: 'release-candidate,main'
 
 permissions:
   actions: read         # Required for CodeQL status reporting
@@ -235,9 +239,27 @@ jobs:
 
       - name: Gate - Fail on Pre-release Versions
         if: always() && inputs.enable_prerelease_check && steps.prerelease-check.outputs.has-findings == 'true'
+        env:
+          BLOCK_BRANCHES: ${{ inputs.prerelease_block_branches }}
+          TARGET_BRANCH: ${{ github.base_ref }}
+          FINDINGS_COUNT: ${{ steps.prerelease-check.outputs.findings-count }}
         run: |
-          echo "::error::Pre-release version pins detected (${{ steps.prerelease-check.outputs.findings-count }} finding(s)). Production code must not depend on beta or release candidate versions."
-          exit 1
+          SHOULD_BLOCK=false
+          IFS=',' read -ra BRANCHES <<< "$BLOCK_BRANCHES"
+          for branch in "${BRANCHES[@]}"; do
+            branch=$(echo "$branch" | xargs)
+            if [ "$TARGET_BRANCH" = "$branch" ]; then
+              SHOULD_BLOCK=true
+              break
+            fi
+          done
+
+          if [ "$SHOULD_BLOCK" = "true" ]; then
+            echo "::error::Pre-release version pins detected ($FINDINGS_COUNT finding(s)). Target branch '$TARGET_BRANCH' does not allow beta or release candidate dependencies."
+            exit 1
+          else
+            echo "::warning::Pre-release version pins detected ($FINDINGS_COUNT finding(s)). Allowed on '$TARGET_BRANCH' — will be blocked on: $BLOCK_BRANCHES."
+          fi
 
   # ----------------- CodeQL Analysis -----------------
   codeql_scan:

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -89,6 +89,10 @@ on:
         description: 'Fail the workflow when CodeQL detects security issues'
         type: boolean
         default: true
+      codeql_upload_sarif:
+        description: 'Upload CodeQL SARIF results to the GitHub Security tab. Requires Code Security (GHAS) enabled on the repo.'
+        type: boolean
+        default: false
       enable_prerelease_check:
         description: 'Block dependencies pinned to pre-release versions (-beta, -rc)'
         type: boolean
@@ -285,6 +289,7 @@ jobs:
         uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-analyze@feat/pr-security-scan-codeql-prerelease
         with:
           category: '/language:${{ inputs.codeql_languages }}'
+          upload: ${{ inputs.codeql_upload_sarif }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post CodeQL Results to PR

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -223,7 +223,6 @@ jobs:
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
-          github-token: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post Security Scan Results to PR
@@ -236,6 +235,7 @@ jobs:
           enable-docker-scan: ${{ inputs.enable_docker_scan }}
           enable-health-score: ${{ inputs.enable_health_score && inputs.enable_docker_scan }}
           dockerfile-has-non-root-user: ${{ steps.dockerfile-checks.outputs.has-non-root-user || 'false' }}
+          prerelease-findings-file: ${{ steps.prerelease-check.outputs.artifact_file }}
           fail-on-findings: 'true'
 
       - name: Gate - Fail on Pre-release Versions

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -267,6 +267,14 @@ jobs:
           languages: ${{ inputs.codeql_languages }}
           config-file: ${{ steps.codeql-config.outputs.config-file }}
 
+      - name: Configure private Go modules access
+        if: steps.codeql-config.outputs.skip != 'true'
+        env:
+          TOKEN: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "GOPRIVATE=github.com/LerianStudio/*" >> "$GITHUB_ENV"
+
       - name: Autobuild
         if: steps.codeql-config.outputs.skip != 'true'
         uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -68,7 +68,9 @@ on:
         type: boolean
         default: true
       docker_build_args:
-        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi\nCOMPONENT_NAME=api"). For sensitive values (tokens, keys, passwords), use BuildKit secrets instead — build arguments are visible in image history.'
+        description: >-
+          Newline-separated Docker build arguments (e.g., "APP_NAME=spi\nCOMPONENT_NAME=api").
+          For sensitive values, use BuildKit secrets — build arguments are visible in image history.
         type: string
         required: false
         default: ''
@@ -186,6 +188,7 @@ jobs:
         if: always() && inputs.enable_docker_scan
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
+          # yamllint disable-line rule:line-length
           context: ${{ inputs.build_context_from_working_dir == true && matrix.working_dir || (inputs.monorepo_type == 'type2' && matrix.working_dir == inputs.frontend_folder && inputs.frontend_folder || '.') }}
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64
@@ -334,6 +337,15 @@ jobs:
         uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1.23.1
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # yamllint disable-line rule:line-length
           status: ${{ (needs.security_scan.result == 'failure' || needs.codeql_scan.result == 'failure') && 'failure' || needs.security_scan.result }}
           workflow-name: "PR Security Scan"
-          failed-jobs: ${{ needs.security_scan.result == 'failure' && needs.codeql_scan.result == 'failure' && 'Security Scan, CodeQL Scan' || needs.security_scan.result == 'failure' && 'Security Scan' || needs.codeql_scan.result == 'failure' && 'CodeQL Scan' || '' }}
+          # yamllint disable-line rule:line-length
+          failed-jobs: >-
+            ${{
+              needs.security_scan.result == 'failure' && needs.codeql_scan.result == 'failure'
+                && 'Security Scan, CodeQL Scan'
+              || needs.security_scan.result == 'failure' && 'Security Scan'
+              || needs.codeql_scan.result == 'failure' && 'CodeQL Scan'
+              || ''
+            }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -76,6 +76,23 @@ on:
         description: 'Use the component working_dir as Docker build context instead of repo root. Useful for independent modules (e.g., tools with their own go.mod).'
         type: boolean
         default: false
+      enable_codeql:
+        description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
+        type: boolean
+        default: false
+      codeql_languages:
+        description: 'Languages to analyze with CodeQL (comma-separated, e.g., "go", "javascript-typescript", "actions")'
+        type: string
+        required: false
+        default: ''
+      codeql_fail_on_findings:
+        description: 'Fail the workflow when CodeQL detects security issues'
+        type: boolean
+        default: true
+      enable_prerelease_check:
+        description: 'Block dependencies pinned to pre-release versions (-beta, -rc)'
+        type: boolean
+        default: true
 
 permissions:
   id-token: write       # Required for OIDC authentication
@@ -100,7 +117,7 @@ jobs:
       # ----------------- Detect Changes & Build Matrix -----------------
       - name: Get changed paths
         id: changed-paths
-        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.23.1
         with:
           filter-paths: ${{ inputs.filter_paths }}
           shared-paths: ${{ inputs.shared_paths }}
@@ -150,7 +167,7 @@ jobs:
       - name: Trivy Filesystem Scan
         id: fs-scan
         if: always()
-        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.23.1
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
@@ -175,7 +192,7 @@ jobs:
       - name: Trivy Image Scan
         id: image-scan
         if: always() && inputs.enable_docker_scan
-        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-image-scan@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-image-scan@v1.23.1
         with:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'
           app-name: ${{ env.APP_NAME }}
@@ -185,15 +202,24 @@ jobs:
       - name: Dockerfile Compliance Checks
         id: dockerfile-checks
         if: always() && inputs.enable_docker_scan && inputs.enable_health_score
-        uses: LerianStudio/github-actions-shared-workflows/src/security/dockerfile-checks@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/dockerfile-checks@v1.23.1
         with:
           dockerfile-path: ${{ env.DOCKERFILE_PATH }}
+
+      # ----------------- Pre-release Version Gate -----------------
+      - name: Pre-release Version Check
+        id: prerelease-check
+        if: always() && inputs.enable_prerelease_check
+        uses: LerianStudio/github-actions-shared-workflows/src/security/prerelease-check@feat/pr-security-scan-codeql-prerelease
+        with:
+          scan-ref: ${{ matrix.working_dir }}
+          app-name: ${{ env.APP_NAME }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post Security Scan Results to PR
         id: post-results
         if: always() && github.event_name == 'pull_request'
-        uses: LerianStudio/github-actions-shared-workflows/src/security/pr-security-reporter@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/pr-security-reporter@v1.23.1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
           app-name: ${{ env.APP_NAME }}
@@ -202,32 +228,75 @@ jobs:
           dockerfile-has-non-root-user: ${{ steps.dockerfile-checks.outputs.has-non-root-user || 'false' }}
           fail-on-findings: 'true'
 
-      ## To be fixed
-      # - name: Upload Secret Scan Results - Repository (SARIF) to GitHub Security Tab
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   if: always()
-      #   continue-on-error: true
-      #   with:
-      #     sarif_file: 'trivy-secret-scan-repo-${{ env.APP_NAME }}.sarif'
+      - name: Gate - Fail on Pre-release Versions
+        if: always() && inputs.enable_prerelease_check && steps.prerelease-check.outputs.has-findings == 'true'
+        run: |
+          echo "::error::Pre-release version pins detected (${{ steps.prerelease-check.outputs.findings-count }} finding(s)). Production code must not depend on beta or release candidate versions."
+          exit 1
 
-      # - name: Upload Vulnerability Scan Results - Docker Image (SARIF) to GitHub Security Tab
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   if: always()
-      #   continue-on-error: true
-      #   with:
-      #     sarif_file: 'trivy-vulnerability-scan-docker-${{ env.APP_NAME }}.sarif'
+  # ----------------- CodeQL Analysis -----------------
+  codeql_scan:
+    needs: prepare_matrix
+    if: inputs.enable_codeql && inputs.codeql_languages != '' && needs.prepare_matrix.outputs.matrix != '[]'
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      # ----------------- Setup -----------------
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract changed paths from matrix
+        id: extract-paths
+        env:
+          MATRIX: ${{ needs.prepare_matrix.outputs.matrix }}
+        run: |
+          PATHS=$(echo "$MATRIX" | jq -r '.[].working_dir' | paste -sd ',' -)
+          echo "paths=$PATHS" >> "$GITHUB_OUTPUT"
+
+      # ----------------- CodeQL Config -----------------
+      - name: Generate CodeQL Config
+        id: codeql-config
+        uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-config@feat/pr-security-scan-codeql-prerelease
+        with:
+          changed-paths: ${{ steps.extract-paths.outputs.paths }}
+
+      # ----------------- CodeQL Analysis -----------------
+      - name: Initialize CodeQL
+        if: steps.codeql-config.outputs.skip != 'true'
+        uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-init@feat/pr-security-scan-codeql-prerelease
+        with:
+          languages: ${{ inputs.codeql_languages }}
+          config-file: ${{ steps.codeql-config.outputs.config-file }}
+
+      - name: Autobuild
+        if: steps.codeql-config.outputs.skip != 'true'
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+
+      - name: Perform CodeQL Analysis
+        if: steps.codeql-config.outputs.skip != 'true'
+        uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-analyze@feat/pr-security-scan-codeql-prerelease
+        with:
+          category: '/language:${{ inputs.codeql_languages }}'
+
+      # ----------------- Results & Security Gate -----------------
+      - name: Post CodeQL Results to PR
+        if: always() && github.event_name == 'pull_request' && steps.codeql-config.outputs.skip != 'true'
+        uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-reporter@feat/pr-security-scan-codeql-prerelease
+        with:
+          github-token: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
+          languages: ${{ inputs.codeql_languages }}
+          fail-on-findings: ${{ inputs.codeql_fail_on_findings }}
 
   # ----------------- Slack Notification -----------------
   notify:
     name: Notify
-    needs: [prepare_matrix, security_scan]
+    needs: [prepare_matrix, security_scan, codeql_scan]
     if: always() && needs.prepare_matrix.outputs.matrix != '[]'
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Slack Notification
-        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1.23.1
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: ${{ needs.security_scan.result }}
+          status: ${{ (needs.security_scan.result == 'failure' || needs.codeql_scan.result == 'failure') && 'failure' || needs.security_scan.result }}
           workflow-name: "PR Security Scan"
-          failed-jobs: ${{ needs.security_scan.result == 'failure' && 'Security Scan' || '' }}
+          failed-jobs: ${{ needs.security_scan.result == 'failure' && needs.codeql_scan.result == 'failure' && 'Security Scan, CodeQL Scan' || needs.security_scan.result == 'failure' && 'Security Scan' || needs.codeql_scan.result == 'failure' && 'CodeQL Scan' || '' }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -235,7 +235,7 @@ jobs:
           enable-docker-scan: ${{ inputs.enable_docker_scan }}
           enable-health-score: ${{ inputs.enable_health_score && inputs.enable_docker_scan }}
           dockerfile-has-non-root-user: ${{ steps.dockerfile-checks.outputs.has-non-root-user || 'false' }}
-          prerelease-findings-file: ${{ steps.prerelease-check.outputs.artifact_file }}
+          prerelease-findings-file: ${{ steps.prerelease-check.outputs.artifact-file }}
           fail-on-findings: 'true'
 
       - name: Gate - Fail on Pre-release Versions

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -208,6 +208,7 @@ jobs:
         uses: ./src/security/codeql-analyze
         with:
           category: '/language:actions'
+          upload: 'true'
 
       - name: Post CodeQL Results to PR
         if: always() && github.event_name == 'pull_request' && steps.codeql-config.outputs.skip != 'true'

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -47,7 +47,7 @@ jobs:
       all_files: ${{ steps.detect.outputs.all-files }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Detect changed files
         id: detect
@@ -63,7 +63,7 @@ jobs:
     if: needs.changed-files.outputs.yaml_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: YAML Lint
         uses: ./src/lint/yamllint
@@ -78,7 +78,7 @@ jobs:
     if: needs.changed-files.outputs.workflow_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Action Lint
         uses: ./src/lint/actionlint
@@ -93,7 +93,7 @@ jobs:
     if: needs.changed-files.outputs.action_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Pinned Actions Check
         uses: ./src/lint/pinned-actions
@@ -108,7 +108,7 @@ jobs:
     if: needs.changed-files.outputs.markdown_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Markdown Link Check
         uses: ./src/lint/markdown-link-check
@@ -123,7 +123,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Spelling Check
         uses: ./src/lint/typos
@@ -138,7 +138,7 @@ jobs:
     if: needs.changed-files.outputs.action_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Shell Check
         uses: ./src/lint/shellcheck
@@ -153,7 +153,7 @@ jobs:
     if: needs.changed-files.outputs.action_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: README Check
         uses: ./src/lint/readme-check
@@ -168,7 +168,7 @@ jobs:
     if: needs.changed-files.outputs.composite_files != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Composite Schema Lint
         uses: ./src/lint/composite-schema
@@ -188,7 +188,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Generate CodeQL config for changed files
         id: codeql-config
@@ -231,7 +231,7 @@ jobs:
     if: always() && github.event_name == 'pull_request' && needs.changed-files.result == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Post Lint Report
         uses: ./src/notify/pr-lint-reporter

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -196,6 +196,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `enable_codeql` | boolean | `false` | Enable CodeQL static analysis. Requires `codeql_languages` to be set |
 | `codeql_languages` | string | `''` | Languages to analyze with CodeQL (comma-separated, e.g., `go`, `javascript-typescript`, `actions`) |
 | `codeql_fail_on_findings` | boolean | `true` | Fail the workflow when CodeQL detects security issues |
+| `codeql_upload_sarif` | boolean | `false` | Upload CodeQL SARIF results to the GitHub Security tab. Requires Code Security (GHAS) enabled on the repo |
 | `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
 
 ## Secrets

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -160,7 +160,7 @@ jobs:
     secrets: inherit
 ```
 
-This will run all standard scans plus CodeQL analysis scoped to changed paths. Results are posted as a separate PR comment and uploaded to the GitHub Security tab.
+This will run all standard scans plus CodeQL analysis scoped to changed paths. Results are posted as a PR comment. To also upload SARIF to the GitHub Security tab, set `codeql_upload_sarif: true` (requires Code Security / GHAS enabled on the repo).
 
 **Supported languages:** `go`, `javascript-typescript`, `actions`, `python`, `java-kotlin`, `csharp`, `ruby`, `swift`, `cpp`
 
@@ -177,7 +177,7 @@ jobs:
     secrets: inherit
 ```
 
-When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for version pins containing `-beta` or `-rc` suffixes and fails the PR if any are found.
+When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for unstable version pins (`-alpha`, `-beta`, `-rc`, `-dev`, etc.). On branches listed in `prerelease_block_branches` (default: `release-candidate,main`) the PR is blocked. On other branches (e.g., `develop`) findings are reported as warnings only.
 
 ## Inputs
 
@@ -304,9 +304,9 @@ Runs when `enable_codeql: true` and `codeql_languages` is set:
 
 ### Pre-release Version Gate
 
-**What it does**: Scans `go.mod`, `package.json`, and `Dockerfile` for version pins containing `-beta` or `-rc` suffixes
+**What it does**: Scans `go.mod`, `package.json`, and `Dockerfile` for unstable version pins
 
-**Pattern matched**: `X.Y.Z-beta.*` and `X.Y.Z-rc.*` (any semver followed by a pre-release identifier)
+**Pattern matched**: `X.Y.Z-<letter...>` for Go/npm (any pre-release suffix starting with a letter). For Docker, only known pre-release prefixes: `-alpha`, `-beta`, `-rc`, `-dev`, `-preview`, `-canary`, `-snapshot`, `-nightly`. Stable Docker variants like `-slim`, `-alpine`, `-bookworm` are allowed.
 
 **Exit behavior**: `exit-code: 1` on branches listed in `prerelease_block_branches` (default: `release-candidate,main`). On other branches (e.g., `develop`), findings are reported as warnings only.
 

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -198,6 +198,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `codeql_fail_on_findings` | boolean | `true` | Fail the workflow when CodeQL detects security issues |
 | `codeql_upload_sarif` | boolean | `false` | Upload CodeQL SARIF results to the GitHub Security tab. Requires Code Security (GHAS) enabled on the repo |
 | `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
+| `prerelease_block_branches` | string | `release-candidate,main` | Comma-separated PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only |
 
 ## Secrets
 
@@ -307,7 +308,7 @@ Runs when `enable_codeql: true` and `codeql_languages` is set:
 
 **Pattern matched**: `X.Y.Z-beta.*` and `X.Y.Z-rc.*` (any semver followed by a pre-release identifier)
 
-**Exit behavior**: `exit-code: 1` (fails workflow when pre-release versions are found)
+**Exit behavior**: `exit-code: 1` on branches listed in `prerelease_block_branches` (default: `release-candidate,main`). On other branches (e.g., `develop`), findings are reported as warnings only.
 
 ## Monorepo Type 2 Behavior
 

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -6,6 +6,8 @@ Reusable workflow for comprehensive security scanning on pull requests. Supports
 
 - **Secret scanning**: Trivy filesystem scan for exposed secrets (scans only changed component folder)
 - **Vulnerability scanning**: Docker image vulnerability detection (optional)
+- **CodeQL static analysis**: GitHub CodeQL for semantic code analysis (opt-in via `enable_codeql`)
+- **Pre-release version gate**: Blocks dependencies pinned to `-beta` or `-rc` versions (enabled by default)
 - **CLI/Non-Docker support**: Skip Docker scanning for projects without Dockerfile via `enable_docker_scan: false`
 - **Monorepo support**: Automatic detection of changed components
 - **Component-scoped scanning**: Only scans the specific component folder that changed, not entire repo
@@ -138,9 +140,9 @@ This will:
 - ❌ Skip Docker vulnerability scanning
 - ❌ Skip Docker Scout analysis
 
-### Docker Scout Analysis
+### With CodeQL Analysis
 
-Enable Docker Scout for additional vulnerability scoring and CVE analysis on your Docker images:
+Enable CodeQL for semantic static analysis on top of the standard security scans:
 
 ```yaml
 name: PR Security Scan
@@ -153,16 +155,29 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.0.0
     with:
       runner_type: "blacksmith-4vcpu-ubuntu-2404"
-      enable_docker_scout: true
+      enable_codeql: true
+      codeql_languages: 'go'
     secrets: inherit
 ```
 
-This will run all standard scans plus Docker Scout quickview and CVE analysis.
+This will run all standard scans plus CodeQL analysis scoped to changed paths. Results are posted as a separate PR comment and uploaded to the GitHub Security tab.
 
-**Requirements:**
-- Docker Hub account with Scout access (Free, Team, or Business)
-- `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets configured
-- `enable_docker_scan` must also be `true` (default) — Scout reuses the same image built for Trivy scanning
+**Supported languages:** `go`, `javascript-typescript`, `actions`, `python`, `java-kotlin`, `csharp`, `ruby`, `swift`, `cpp`
+
+### With Pre-release Version Gate
+
+Pre-release checks are enabled by default. To disable:
+
+```yaml
+jobs:
+  security-scan:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.0.0
+    with:
+      enable_prerelease_check: false
+    secrets: inherit
+```
+
+When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for version pins containing `-beta` or `-rc` suffixes and fails the PR if any are found.
 
 ## Inputs
 
@@ -177,7 +192,11 @@ This will run all standard scans plus Docker Scout quickview and CVE analysis.
 | `docker_registry` | string | `docker.io` | Docker registry URL |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
 | `enable_docker_scan` | boolean | `true` | Enable Docker image build and vulnerability scanning. Set to `false` for projects without Dockerfile (e.g., CLI tools) |
-| `enable_docker_scout` | boolean | `false` | Enable Docker Scout image analysis for vulnerability scoring. Requires Docker Hub with Scout access |
+| `enable_health_score` | boolean | `true` | Enable Docker Hub Health Score compliance checks (non-root user, CVEs, licenses) |
+| `enable_codeql` | boolean | `false` | Enable CodeQL static analysis. Requires `codeql_languages` to be set |
+| `codeql_languages` | string | `''` | Languages to analyze with CodeQL (comma-separated, e.g., `go`, `javascript-typescript`, `actions`) |
+| `codeql_fail_on_findings` | boolean | `true` | Fail the workflow when CodeQL detects security issues |
+| `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
 
 ## Secrets
 
@@ -219,14 +238,26 @@ For each component in the matrix:
 1. **Docker Login**: Authenticate to registry (avoids rate limits)
 2. **Checkout Repository**: Clone the code
 3. **Setup Docker Buildx**: Enable multi-platform builds *(skipped if `enable_docker_scan: false`)*
-4. **Trivy Secret Scan (Table)**: Scan filesystem for secrets - **fails on detection**
-5. **Trivy Secret Scan (SARIF)**: Generate SARIF report
-6. **Build Docker Image**: Build image for vulnerability scanning *(skipped if `enable_docker_scan: false`)*
-7. **Trivy Vulnerability Scan (Table)**: Scan image for vulnerabilities *(skipped if `enable_docker_scan: false`)*
-8. **Trivy Vulnerability Scan (SARIF)**: Generate SARIF report *(skipped if `enable_docker_scan: false`)*
-9. **Docker Scout Analysis**: Quickview and CVE analysis *(skipped unless `enable_docker_scout: true` AND `enable_docker_scan: true`)*
+4. **Trivy Filesystem Scan**: Scan filesystem for secrets and vulnerabilities
+5. **Build Docker Image**: Build image for vulnerability scanning *(skipped if `enable_docker_scan: false`)*
+6. **Trivy Image Scan**: Scan image for vulnerabilities and licenses *(skipped if `enable_docker_scan: false`)*
+7. **Dockerfile Compliance Checks**: Non-root user and health score checks *(skipped unless `enable_health_score: true` AND `enable_docker_scan: true`)*
+8. **Pre-release Version Check**: Scan for `-beta`/`-rc` version pins *(skipped if `enable_prerelease_check: false`)*
+9. **Post Security Scan Results**: PR comment with consolidated findings
 
-> **Note**: When `enable_docker_scan: false`, only filesystem secret scanning runs. This is useful for CLI tools and projects without Dockerfiles.
+> **Note**: When `enable_docker_scan: false`, only filesystem scanning and pre-release checks run.
+
+### Job 3: codeql_scan *(optional)*
+
+Runs when `enable_codeql: true` and `codeql_languages` is set:
+
+1. **Checkout Repository**: Clone the code
+2. **Extract Changed Paths**: Derive scoped paths from the component matrix
+3. **Generate CodeQL Config**: Scope analysis to changed paths
+4. **Initialize CodeQL**: Set up CodeQL with configured languages and query suite
+5. **Autobuild**: Automatically build the project for compiled languages
+6. **Perform CodeQL Analysis**: Run semantic analysis and upload SARIF
+7. **Post CodeQL Results**: PR comment with findings table and security gate
 
 ## Security Scans
 
@@ -258,6 +289,24 @@ For each component in the matrix:
 - Application libraries
 
 **Exit behavior**: `exit-code: 0` (informative only, doesn't fail workflow)
+
+### CodeQL Analysis
+
+**What it does**: Runs GitHub CodeQL semantic analysis for security vulnerabilities and code quality issues
+
+**Scope**: Automatically scoped to changed paths in the PR (via `codeql-config` composite)
+
+**Query suite**: `security-extended` (default) — covers OWASP Top 10, CWE Top 25, and more
+
+**Exit behavior**: Configurable via `codeql_fail_on_findings` (default: fails on findings)
+
+### Pre-release Version Gate
+
+**What it does**: Scans `go.mod`, `package.json`, and `Dockerfile` for version pins containing `-beta` or `-rc` suffixes
+
+**Pattern matched**: `X.Y.Z-beta.*` and `X.Y.Z-rc.*` (any semver followed by a pre-release identifier)
+
+**Exit behavior**: `exit-code: 1` (fails workflow when pre-release versions are found)
 
 ## Monorepo Type 2 Behavior
 
@@ -493,7 +542,7 @@ Generated for each scan type:
 - `trivy-secret-scan-repo-{app-name}.sarif`
 - `trivy-vulnerability-scan-docker-{app-name}.sarif`
 
-Can be uploaded to GitHub Security tab (currently commented out in workflow).
+Uploaded to GitHub Security tab via CodeQL when `enable_codeql` is enabled.
 
 ## Related Workflows
 

--- a/src/security/codeql-analyze/action.yml
+++ b/src/security/codeql-analyze/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
       with:
         category: ${{ inputs.category }}
         output: ${{ inputs.output }}

--- a/src/security/codeql-analyze/action.yml
+++ b/src/security/codeql-analyze/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Output directory for SARIF files'
     required: false
     default: '../results'
+  upload:
+    description: 'Upload SARIF to GitHub Security tab (requires Code Security / GHAS enabled on the repo)'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -18,3 +22,4 @@ runs:
       with:
         category: ${{ inputs.category }}
         output: ${{ inputs.output }}
+        upload: ${{ inputs.upload }}

--- a/src/security/codeql-init/action.yml
+++ b/src/security/codeql-init/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
       with:
         languages: ${{ inputs.languages }}
         queries: ${{ inputs.queries }}

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -305,13 +305,15 @@ runs:
               // step in the workflow. Setting hasFindings would make the reporter's
               // own gate (fail-on-findings) exit 1 on ALL branches, bypassing the
               // warn-on-develop / block-on-rc-main semantics.
+              const MAX_PRERELEASE = 50;
               let out = `---\n\n## Pre-release Version Check\n\n`;
               out += `\u{1F6AB} **Found ${findings.length} unstable version pin(s).** Only stable releases (\`x.y.z\`) and SHA-based pins are allowed.\n\n`;
               out += `| File | Line | Content |\n`;
               out += `|------|------|----------|\n`;
-              for (const f of findings) {
-                out += `| \`${md(f.file)}\` | ${f.line} | \`${md(f.content)}\` |\n`;
+              for (const f of findings.slice(0, MAX_PRERELEASE)) {
+                out += `| \`${md(f.file)}\` | ${f.line} | \`${md(truncate(String(f.content ?? ''), 120))}\` |\n`;
               }
+              if (findings.length > MAX_PRERELEASE) out += `\n_... and ${findings.length - MAX_PRERELEASE} more findings._\n`;
               out += `\n`;
               out += `> Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases.\n\n`;
               return out;

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -294,7 +294,11 @@ runs:
                 return `---\n\n## Pre-release Version Check\n\n\u2705 No unstable version pins found.\n\n`;
               }
 
-              hasFindings = true;
+              // Do NOT set hasFindings here — prerelease findings are gated
+              // separately by the branch-aware "Gate - Fail on Pre-release Versions"
+              // step in the workflow. Setting hasFindings would make the reporter's
+              // own gate (fail-on-findings) exit 1 on ALL branches, bypassing the
+              // warn-on-develop / block-on-rc-main semantics.
               let out = `---\n\n## Pre-release Version Check\n\n`;
               out += `\u{1F6AB} **Found ${findings.length} unstable version pin(s).** Only stable releases (\`x.y.z\`) and SHA-based pins are allowed.\n\n`;
               out += `| File | Line | Content |\n`;

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Whether the Dockerfile sets a non-root USER directive
     required: false
     default: "false"
+  prerelease-findings-file:
+    description: 'Path to JSON file with pre-release version findings from the prerelease-check composite. Leave empty to skip.'
+    required: false
+    default: ''
   fail-on-findings:
     description: 'Fail the step with exit code 1 when security findings are detected (true/false)'
     required: false
@@ -44,6 +48,7 @@ runs:
         ENABLE_DOCKER_SCAN: ${{ inputs.enable-docker-scan }}
         ENABLE_HEALTH_SCORE: ${{ inputs.enable-health-score }}
         DOCKERFILE_HAS_NON_ROOT_USER: ${{ inputs.dockerfile-has-non-root-user }}
+        PRERELEASE_FINDINGS_FILE: ${{ inputs.prerelease-findings-file }}
       with:
         github-token: ${{ inputs.github-token }}
         result-encoding: string
@@ -277,12 +282,41 @@ runs:
             return out;
           }
 
+          // ── Pre-release Version Scan ──
+          function buildPrereleaseScan() {
+            const file = process.env.PRERELEASE_FINDINGS_FILE;
+            if (!file) return '';
+
+            try {
+              if (!fs.existsSync(file)) return '';
+              const findings = JSON.parse(fs.readFileSync(file, 'utf8'));
+              if (!Array.isArray(findings) || findings.length === 0) {
+                return `---\n\n## Pre-release Version Check\n\n\u2705 No unstable version pins found.\n\n`;
+              }
+
+              hasFindings = true;
+              let out = `---\n\n## Pre-release Version Check\n\n`;
+              out += `\u{1F6AB} **Found ${findings.length} unstable version pin(s).** Only stable releases (\`x.y.z\`) and SHA-based pins are allowed.\n\n`;
+              out += `| File | Line | Content |\n`;
+              out += `|------|------|----------|\n`;
+              for (const f of findings) {
+                out += `| \`${md(f.file)}\` | ${f.line} | \`${md(f.content)}\` |\n`;
+              }
+              out += `\n`;
+              out += `> Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases.\n\n`;
+              return out;
+            } catch (e) {
+              return `---\n\n## Pre-release Version Check\n\n\u26A0\uFE0F Could not parse findings: ${e.message}\n\n`;
+            }
+          }
+
           // ── Build Report ──
           body += `## \u{1F512} Security Scan Results \u2014 \`${appName}\`\n\n`;
           body += `## Trivy\n\n`;
           body += buildTrivyFsScan();
           body += buildTrivyDockerScan();
           body += buildHealthScoreSection();
+          body += buildPrereleaseScan();
 
           // ── Useful Links ──
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -288,9 +288,15 @@ runs:
             if (!file) return '';
 
             try {
-              if (!fs.existsSync(file)) return '';
+              if (!fs.existsSync(file)) {
+                hasScanErrors = true;
+                return `---\n\n## Pre-release Version Check\n\n\u26A0\uFE0F Findings artifact not found.\n\n`;
+              }
               const findings = JSON.parse(fs.readFileSync(file, 'utf8'));
-              if (!Array.isArray(findings) || findings.length === 0) {
+              if (!Array.isArray(findings)) {
+                throw new Error('Expected a JSON array of findings');
+              }
+              if (findings.length === 0) {
                 return `---\n\n## Pre-release Version Check\n\n\u2705 No unstable version pins found.\n\n`;
               }
 
@@ -310,6 +316,7 @@ runs:
               out += `> Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases.\n\n`;
               return out;
             } catch (e) {
+              hasScanErrors = true;
               return `---\n\n## Pre-release Version Check\n\n\u26A0\uFE0F Could not parse findings: ${e.message}\n\n`;
             }
           }

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -1,0 +1,73 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>prerelease-check</h1></td>
+  </tr>
+</table>
+
+Composite action that scans dependency files for pre-release version pins (`-beta`, `-rc`) that should not reach production. Checks `go.mod`, `package.json`, and `Dockerfile` for unstable version references and reports findings via GitHub annotations and step summary.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|:---:|---|
+| `scan-ref` | Directory to scan for pre-release versions | No | `.` |
+| `app-name` | Application name for reporting context | No | — |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `has-findings` | `true` if pre-release versions were detected |
+| `findings-count` | Number of pre-release version findings |
+
+## What it scans
+
+| File | Pattern | Example match |
+|---|---|---|
+| `go.mod` | `vX.Y.Z-beta.*` / `vX.Y.Z-rc.*` | `v1.2.3-beta.1` |
+| `package.json` | `"X.Y.Z-beta.*"` / `"X.Y.Z-rc.*"` | `"2.0.0-rc.1"` |
+| `Dockerfile` | `:X.Y.Z-beta.*` / `:X.Y.Z-rc.*` | `golang:1.21.0-beta1` |
+
+## Usage
+
+### As a composite step (within a security workflow job)
+
+```yaml
+jobs:
+  security:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pre-release Version Check
+        id: prerelease-check
+        uses: LerianStudio/github-actions-shared-workflows/src/security/prerelease-check@v1.x.x
+        with:
+          scan-ref: '.'
+          app-name: 'my-app'
+
+      - name: Fail on pre-release versions
+        if: steps.prerelease-check.outputs.has-findings == 'true'
+        run: exit 1
+```
+
+### Via the reusable workflow
+
+Pre-release checks are built into the `pr-security-scan` workflow and enabled by default:
+
+```yaml
+jobs:
+  security-scan:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@v1.x.x
+    with:
+      enable_prerelease_check: true   # default
+    secrets: inherit
+```
+
+## Permissions required
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -5,7 +5,7 @@
   </tr>
 </table>
 
-Composite action that scans dependency files for pre-release version pins (`-beta`, `-rc`) that should not reach production. Checks `go.mod`, `package.json`, and `Dockerfile` for unstable version references and reports findings via GitHub annotations and step summary.
+Composite action that scans dependency files for unstable version pins. Only stable semver (`x.y.z`) and SHA-based pins (including Go pseudo-versions) are allowed. Checks `go.mod`, `package.json`, and `Dockerfile` and reports findings via GitHub annotations and step summary.
 
 ## Inputs
 
@@ -18,16 +18,18 @@ Composite action that scans dependency files for pre-release version pins (`-bet
 
 | Output | Description |
 |---|---|
-| `has-findings` | `true` if pre-release versions were detected |
-| `findings-count` | Number of pre-release version findings |
+| `has-findings` | `true` if unstable versions were detected |
+| `findings-count` | Number of unstable version findings |
 
 ## What it scans
 
-| File | Pattern | Example match |
+Matches any semver with a pre-release suffix starting with a letter (`x.y.z-<letter...>`).
+
+| File | Blocked (unstable) | Allowed (stable) |
 |---|---|---|
-| `go.mod` | `vX.Y.Z-beta.*` / `vX.Y.Z-rc.*` | `v1.2.3-beta.1` |
-| `package.json` | `"X.Y.Z-beta.*"` / `"X.Y.Z-rc.*"` | `"2.0.0-rc.1"` |
-| `Dockerfile` | `:X.Y.Z-beta.*` / `:X.Y.Z-rc.*` | `golang:1.21.0-beta1` |
+| `go.mod` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1`, `v1.2.3-dev.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` (pseudo-version) |
+| `package.json` | `"2.0.0-beta.1"`, `"1.0.0-canary.3"` | `"2.0.0"` |
+| `Dockerfile` | `golang:1.21.0-beta1`, `node:20.0.0-rc.1` | `golang:1.21.0`, `golang:1.21.0@sha256:...` |
 
 ## Usage
 

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -12,7 +12,7 @@ Composite action that scans dependency files for unstable version pins. Only sta
 | Input | Description | Required | Default |
 |---|---|:---:|---|
 | `scan-ref` | Directory to scan for pre-release versions | No | `.` |
-| `app-name` | Application name for reporting context | No | — |
+| `app-name` | Application name for reporting context | No | `''` |
 
 ## Outputs
 
@@ -20,16 +20,17 @@ Composite action that scans dependency files for unstable version pins. Only sta
 |---|---|
 | `has-findings` | `true` if unstable versions were detected |
 | `findings-count` | Number of unstable version findings |
+| `artifact-file` | Path to the JSON findings file for consumption by `pr-security-reporter` |
 
 ## What it scans
 
-Matches any semver with a pre-release suffix starting with a letter (`x.y.z-<letter...>`).
+For `go.mod` and `package.json`: matches any semver with a pre-release suffix starting with a letter (`x.y.z-<letter...>`). For `Dockerfile`: only matches known pre-release prefixes to avoid false positives on stable image variants.
 
-| File | Blocked (unstable) | Allowed (stable) |
-|---|---|---|
-| `go.mod` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1`, `v1.2.3-dev.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` (pseudo-version) |
-| `package.json` | `"2.0.0-beta.1"`, `"1.0.0-canary.3"` | `"2.0.0"` |
-| `Dockerfile` | `golang:1.21.0-beta1`, `node:20.0.0-rc.1` | `golang:1.21.0`, `golang:1.21.0@sha256:...` |
+| File | Scanned patterns | Blocked (unstable) | Allowed (stable) |
+|---|---|---|---|
+| `go.mod` | `vX.Y.Z-<letter...>` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` |
+| `package.json` | `"[~^>=]*X.Y.Z-<letter...>"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
+| `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
 
 ## Usage
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -37,6 +37,10 @@ runs:
         # Excludes Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha) because
         # their suffix starts with digits, not letters. SHA pins are also allowed.
         PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z]'
+
+        # Docker-specific pattern: only match known pre-release prefixes to avoid
+        # false positives on stable image variants like -slim, -alpine, -bookworm.
+        DOCKER_PRERELEASE='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)'
         FINDINGS=()
 
         # Scan the component scan-ref AND the repo root. In Go monorepos a single
@@ -75,7 +79,7 @@ runs:
               SEEN_FILES+=("$real")
               while IFS= read -r match; do
                 FINDINGS+=("${base}/package.json|$match")
-              done < <(grep -nE "\"${PRERELEASE_PATTERN}" "$base/package.json" || true)
+              done < <(grep -nE "\"[~^<>=]*${PRERELEASE_PATTERN}" "$base/package.json" || true)
             fi
           fi
 
@@ -88,7 +92,7 @@ runs:
             relpath="${df#./}"
             while IFS= read -r match; do
               FINDINGS+=("${relpath}|$match")
-            done < <(grep -nE ":${PRERELEASE_PATTERN}" "$df" || true)
+            done < <(grep -nE ":${DOCKER_PRERELEASE}" "$df" || true)
           done
         done
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -173,10 +173,8 @@ runs:
         script: |
           const fs = require('fs');
 
-          const appName = process.env.APP_NAME || 'default';
           const artifactFile = process.env.ARTIFACT_FILE;
           const findingsCount = process.env.FINDINGS_COUNT;
-          const label = process.env.APP_NAME ? ` — \`${appName}\`` : '';
 
           let findings = [];
           try {
@@ -192,7 +190,7 @@ runs:
             String(value ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').replace(/`/g, '\\`');
 
           let body = '';
-          body += `## \u{1F6AB} Pre-release Version Pins${label}\n\n`;
+          body += `## \u{1F6AB} Pre-release Version Pins\n\n`;
           body += `**Found ${findingsCount} unstable version pin(s).** Production code must only depend on stable releases (\`x.y.z\`) or SHA-based pins.\n\n`;
           body += `| File | Line | Content |\n`;
           body += `|------|------|----------|\n`;
@@ -205,7 +203,12 @@ runs:
           const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           body += `---\n\n<sub>\u{1F50D} [View full scan logs](${runUrl})</sub>\n\n`;
 
-          const marker = `<!-- prerelease-check-${appName} -->`;
+          // Shared marker (no app-name suffix): in monorepos each matrix component
+          // runs this composite and would otherwise post duplicate comments for
+          // shared files like the root go.mod. A single marker lets each run
+          // update the same comment in place. Components run sequentially via
+          // max-parallel: 1, so no race condition.
+          const marker = `<!-- prerelease-check -->`;
           body = marker + '\n' + body;
 
           try {
@@ -216,15 +219,35 @@ runs:
               per_page: 100,
             });
 
-            const existing = comments.find(c => c.body?.includes(marker));
+            // Match both the new shared marker and legacy per-app markers
+            // (<!-- prerelease-check-<app-name> -->) so stale comments from
+            // previous runs are cleaned up when transitioning to the shared marker.
+            const legacyMarkerPrefix = '<!-- prerelease-check-';
+            const matching = comments.filter(c =>
+              c.body?.includes(marker) || c.body?.includes(legacyMarkerPrefix)
+            );
+
             const params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               body,
             };
 
-            if (existing) {
-              await github.rest.issues.updateComment({ ...params, comment_id: existing.id });
+            if (matching.length > 0) {
+              // Update the first matching comment, delete any extras.
+              const [primary, ...duplicates] = matching;
+              await github.rest.issues.updateComment({ ...params, comment_id: primary.id });
+              for (const dup of duplicates) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: dup.id,
+                  });
+                } catch (e) {
+                  core.warning(`Could not delete duplicate prerelease comment ${dup.id}: ${e.message}`);
+                }
+              }
             } else {
               await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
             }

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -1,5 +1,5 @@
 name: Pre-release Version Check
-description: Scans dependency files for pre-release version pins (-beta, -rc) that should not reach production.
+description: Scans dependency files for unstable version pins. Only stable semver (x.y.z) and Go pseudo-versions (SHA-based) are allowed.
 
 inputs:
   scan-ref:
@@ -29,7 +29,11 @@ runs:
         SCAN_DIR: ${{ inputs.scan-ref }}
         APP_NAME: ${{ inputs.app-name }}
       run: |
-        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(beta|rc)[.0-9]*'
+        # Matches x.y.z-<letter...> — any semver with a pre-release suffix starting
+        # with a letter (alpha, beta, rc, dev, preview, canary, snapshot, etc.).
+        # Excludes Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha) because
+        # their suffix starts with digits, not letters. SHA pins are also allowed.
+        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z]'
         FINDINGS=()
 
         # ----------------- go.mod -----------------
@@ -43,7 +47,7 @@ runs:
         if [ -f "$SCAN_DIR/package.json" ]; then
           while IFS= read -r match; do
             FINDINGS+=("package.json|$match")
-          done < <(grep -nE "\"${PRERELEASE_PATTERN}\"" "$SCAN_DIR/package.json" || true)
+          done < <(grep -nE "\"${PRERELEASE_PATTERN}" "$SCAN_DIR/package.json" || true)
         fi
 
         # ----------------- Dockerfile -----------------
@@ -64,7 +68,7 @@ runs:
           LABEL=""
           [ -n "$APP_NAME" ] && LABEL=" ($APP_NAME)"
 
-          echo "::error::Found $COUNT pre-release version pin(s)${LABEL}. Production code must not depend on beta or release candidate versions."
+          echo "::error::Found $COUNT unstable version pin(s)${LABEL}. Only stable versions (x.y.z) and SHA-based pins are allowed."
 
           {
             echo "### :warning: Pre-release Version Pins${LABEL}"
@@ -80,7 +84,7 @@ runs:
               echo "| \`${FILE}\` | ${LINE} | \`${CONTENT}\` |"
             done
             echo ""
-            echo "> Replace \`-beta.*\` and \`-rc.*\` versions with stable releases."
+            echo "> Only stable versions (\`x.y.z\`) and SHA-based pins are allowed. Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases."
           } >> "$GITHUB_STEP_SUMMARY"
 
           for f in "${FINDINGS[@]}"; do
@@ -88,7 +92,7 @@ runs:
             REST="${f#*|}"
             LINE="${REST%%:*}"
             CONTENT="${REST#*:}"
-            echo "::warning file=${SCAN_DIR}/${FILE},line=${LINE}::Pre-release version pin: $(echo "$CONTENT" | sed 's/^[[:space:]]*//')"
+            echo "::warning file=${SCAN_DIR}/${FILE},line=${LINE}::Unstable version pin: $(echo "$CONTENT" | sed 's/^[[:space:]]*//')"
           done
         else
           echo "has_findings=false" >> "$GITHUB_OUTPUT"

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -159,4 +159,3 @@ runs:
           echo "[]" > "$ARTIFACT_FILE"
           echo "No pre-release version pins found."
         fi
-

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -36,27 +36,57 @@ runs:
         PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z]'
         FINDINGS=()
 
-        # ----------------- go.mod -----------------
-        if [ -f "$SCAN_DIR/go.mod" ]; then
-          while IFS= read -r match; do
-            FINDINGS+=("go.mod|$match")
-          done < <(grep -nE "v${PRERELEASE_PATTERN}" "$SCAN_DIR/go.mod" || true)
+        # Scan the component scan-ref AND the repo root. In Go monorepos a single
+        # root go.mod is shared across components; without scanning root we'd miss
+        # dependency pins for components whose scan-ref is a subdirectory.
+        SEEN_FILES=()
+        SCAN_PATHS=("$SCAN_DIR")
+        if [ "$SCAN_DIR" != "." ] && [ "$SCAN_DIR" != "./" ]; then
+          SCAN_PATHS+=(".")
         fi
 
-        # ----------------- package.json -----------------
-        if [ -f "$SCAN_DIR/package.json" ]; then
-          while IFS= read -r match; do
-            FINDINGS+=("package.json|$match")
-          done < <(grep -nE "\"${PRERELEASE_PATTERN}" "$SCAN_DIR/package.json" || true)
-        fi
+        already_seen() {
+          local target="$1"
+          for s in "${SEEN_FILES[@]}"; do
+            [ "$s" = "$target" ] && return 0
+          done
+          return 1
+        }
 
-        # ----------------- Dockerfile -----------------
-        for df in "$SCAN_DIR/Dockerfile" "$SCAN_DIR/"*.dockerfile "$SCAN_DIR/Dockerfile."*; do
-          [ -f "$df" ] || continue
-          fname=$(basename "$df")
-          while IFS= read -r match; do
-            FINDINGS+=("${fname}|$match")
-          done < <(grep -nE ":${PRERELEASE_PATTERN}" "$df" || true)
+        for base in "${SCAN_PATHS[@]}"; do
+          # ----------------- go.mod -----------------
+          if [ -f "$base/go.mod" ]; then
+            real=$(realpath "$base/go.mod")
+            if ! already_seen "$real"; then
+              SEEN_FILES+=("$real")
+              while IFS= read -r match; do
+                FINDINGS+=("${base}/go.mod|$match")
+              done < <(grep -nE "v${PRERELEASE_PATTERN}" "$base/go.mod" || true)
+            fi
+          fi
+
+          # ----------------- package.json -----------------
+          if [ -f "$base/package.json" ]; then
+            real=$(realpath "$base/package.json")
+            if ! already_seen "$real"; then
+              SEEN_FILES+=("$real")
+              while IFS= read -r match; do
+                FINDINGS+=("${base}/package.json|$match")
+              done < <(grep -nE "\"${PRERELEASE_PATTERN}" "$base/package.json" || true)
+            fi
+          fi
+
+          # ----------------- Dockerfile -----------------
+          for df in "$base/Dockerfile" "$base/"*.dockerfile "$base/Dockerfile."*; do
+            [ -f "$df" ] || continue
+            real=$(realpath "$df")
+            already_seen "$real" && continue
+            SEEN_FILES+=("$real")
+            relpath="${df#./}"
+            while IFS= read -r match; do
+              FINDINGS+=("${relpath}|$match")
+            done < <(grep -nE ":${PRERELEASE_PATTERN}" "$df" || true)
+          done
         done
 
         COUNT=${#FINDINGS[@]}
@@ -92,7 +122,7 @@ runs:
             REST="${f#*|}"
             LINE="${REST%%:*}"
             CONTENT="${REST#*:}"
-            echo "::warning file=${SCAN_DIR}/${FILE},line=${LINE}::Unstable version pin: $(echo "$CONTENT" | sed 's/^[[:space:]]*//')"
+            echo "::warning file=${FILE},line=${LINE}::Unstable version pin: $(echo "$CONTENT" | sed 's/^[[:space:]]*//')"
           done
         else
           echo "has_findings=false" >> "$GITHUB_OUTPUT"

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: 'Application name for reporting context'
     required: false
     default: ''
-  github-token:
-    description: 'GitHub token for posting PR comments. When empty, the PR comment step is skipped.'
-    required: false
-    default: ''
 
 outputs:
   has-findings:
@@ -161,96 +157,3 @@ runs:
           echo "No pre-release version pins found."
         fi
 
-    - name: Post PR comment with pre-release findings
-      if: github.event_name == 'pull_request' && inputs.github-token != '' && steps.scan.outputs.has_findings == 'true'
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-      env:
-        APP_NAME: ${{ inputs.app-name }}
-        ARTIFACT_FILE: ${{ steps.scan.outputs.artifact_file }}
-        FINDINGS_COUNT: ${{ steps.scan.outputs.findings_count }}
-      with:
-        github-token: ${{ inputs.github-token }}
-        script: |
-          const fs = require('fs');
-
-          const artifactFile = process.env.ARTIFACT_FILE;
-          const findingsCount = process.env.FINDINGS_COUNT;
-
-          let findings = [];
-          try {
-            findings = JSON.parse(fs.readFileSync(artifactFile, 'utf8'));
-          } catch (e) {
-            core.warning(`Could not read prerelease findings: ${e.message}`);
-            return;
-          }
-
-          if (findings.length === 0) return;
-
-          const md = (value) =>
-            String(value ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').replace(/`/g, '\\`');
-
-          let body = '';
-          body += `## \u{1F6AB} Pre-release Version Pins\n\n`;
-          body += `**Found ${findingsCount} unstable version pin(s).** Production code must only depend on stable releases (\`x.y.z\`) or SHA-based pins.\n\n`;
-          body += `| File | Line | Content |\n`;
-          body += `|------|------|----------|\n`;
-          for (const f of findings) {
-            body += `| \`${md(f.file)}\` | ${f.line} | \`${md(f.content)}\` |\n`;
-          }
-          body += `\n`;
-          body += `> Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases before merging.\n\n`;
-
-          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-          body += `---\n\n<sub>\u{1F50D} [View full scan logs](${runUrl})</sub>\n\n`;
-
-          // Shared marker (no app-name suffix): in monorepos each matrix component
-          // runs this composite and would otherwise post duplicate comments for
-          // shared files like the root go.mod. A single marker lets each run
-          // update the same comment in place. Components run sequentially via
-          // max-parallel: 1, so no race condition.
-          const marker = `<!-- prerelease-check -->`;
-          body = marker + '\n' + body;
-
-          try {
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-
-            // Match both the new shared marker and legacy per-app markers
-            // (<!-- prerelease-check-<app-name> -->) so stale comments from
-            // previous runs are cleaned up when transitioning to the shared marker.
-            const legacyMarkerPrefix = '<!-- prerelease-check-';
-            const matching = comments.filter(c =>
-              c.body?.includes(marker) || c.body?.includes(legacyMarkerPrefix)
-            );
-
-            const params = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            };
-
-            if (matching.length > 0) {
-              // Update the first matching comment, delete any extras.
-              const [primary, ...duplicates] = matching;
-              await github.rest.issues.updateComment({ ...params, comment_id: primary.id });
-              for (const dup of duplicates) {
-                try {
-                  await github.rest.issues.deleteComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: dup.id,
-                  });
-                } catch (e) {
-                  core.warning(`Could not delete duplicate prerelease comment ${dup.id}: ${e.message}`);
-                }
-              }
-            } else {
-              await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
-            }
-          } catch (e) {
-            core.warning(`Could not post PR pre-release comment: ${e.message}`);
-          }

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Application name for reporting context'
     required: false
     default: ''
+  github-token:
+    description: 'GitHub token for posting PR comments. When empty, the PR comment step is skipped.'
+    required: false
+    default: ''
 
 outputs:
   has-findings:
@@ -92,6 +96,11 @@ runs:
         COUNT=${#FINDINGS[@]}
         echo "findings_count=$COUNT" >> "$GITHUB_OUTPUT"
 
+        # Persist findings as JSON so the next step can post a PR comment.
+        ARTIFACT_NAME="${APP_NAME:-default}"
+        ARTIFACT_FILE="prerelease-findings-${ARTIFACT_NAME}.json"
+        echo "artifact_file=$ARTIFACT_FILE" >> "$GITHUB_OUTPUT"
+
         if [ "$COUNT" -gt 0 ]; then
           echo "has_findings=true" >> "$GITHUB_OUTPUT"
 
@@ -99,6 +108,28 @@ runs:
           [ -n "$APP_NAME" ] && LABEL=" ($APP_NAME)"
 
           echo "::error::Found $COUNT unstable version pin(s)${LABEL}. Only stable versions (x.y.z) and SHA-based pins are allowed."
+
+          # Build JSON array of findings for the reporter step.
+          {
+            echo "["
+            FIRST=true
+            for f in "${FINDINGS[@]}"; do
+              FILE="${f%%|*}"
+              REST="${f#*|}"
+              LINE="${REST%%:*}"
+              CONTENT="${REST#*:}"
+              CONTENT_TRIMMED=$(echo "$CONTENT" | sed 's/^[[:space:]]*//')
+              CONTENT_ESCAPED=$(echo "$CONTENT_TRIMMED" | jq -Rs .)
+              if [ "$FIRST" = "true" ]; then
+                FIRST=false
+              else
+                echo ","
+              fi
+              printf '  {"file":"%s","line":%s,"content":%s}' "$FILE" "$LINE" "$CONTENT_ESCAPED"
+            done
+            echo ""
+            echo "]"
+          } > "$ARTIFACT_FILE"
 
           {
             echo "### :warning: Pre-release Version Pins${LABEL}"
@@ -126,5 +157,77 @@ runs:
           done
         else
           echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          echo "[]" > "$ARTIFACT_FILE"
           echo "No pre-release version pins found."
         fi
+
+    - name: Post PR comment with pre-release findings
+      if: github.event_name == 'pull_request' && inputs.github-token != '' && steps.scan.outputs.has_findings == 'true'
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        APP_NAME: ${{ inputs.app-name }}
+        ARTIFACT_FILE: ${{ steps.scan.outputs.artifact_file }}
+        FINDINGS_COUNT: ${{ steps.scan.outputs.findings_count }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+
+          const appName = process.env.APP_NAME || 'default';
+          const artifactFile = process.env.ARTIFACT_FILE;
+          const findingsCount = process.env.FINDINGS_COUNT;
+          const label = process.env.APP_NAME ? ` — \`${appName}\`` : '';
+
+          let findings = [];
+          try {
+            findings = JSON.parse(fs.readFileSync(artifactFile, 'utf8'));
+          } catch (e) {
+            core.warning(`Could not read prerelease findings: ${e.message}`);
+            return;
+          }
+
+          if (findings.length === 0) return;
+
+          const md = (value) =>
+            String(value ?? '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').replace(/`/g, '\\`');
+
+          let body = '';
+          body += `## \u{1F6AB} Pre-release Version Pins${label}\n\n`;
+          body += `**Found ${findingsCount} unstable version pin(s).** Production code must only depend on stable releases (\`x.y.z\`) or SHA-based pins.\n\n`;
+          body += `| File | Line | Content |\n`;
+          body += `|------|------|----------|\n`;
+          for (const f of findings) {
+            body += `| \`${md(f.file)}\` | ${f.line} | \`${md(f.content)}\` |\n`;
+          }
+          body += `\n`;
+          body += `> Replace pre-release suffixes (\`-alpha\`, \`-beta\`, \`-rc\`, \`-dev\`, etc.) with stable releases before merging.\n\n`;
+
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          body += `---\n\n<sub>\u{1F50D} [View full scan logs](${runUrl})</sub>\n\n`;
+
+          const marker = `<!-- prerelease-check-${appName} -->`;
+          body = marker + '\n' + body;
+
+          try {
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            };
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...params, comment_id: existing.id });
+            } else {
+              await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
+            }
+          } catch (e) {
+            core.warning(`Could not post PR pre-release comment: ${e.message}`);
+          }

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -18,6 +18,9 @@ outputs:
   findings-count:
     description: 'Number of pre-release version findings'
     value: ${{ steps.scan.outputs.findings_count }}
+  artifact-file:
+    description: 'Path to the JSON findings file for consumption by pr-security-reporter'
+    value: ${{ steps.scan.outputs.artifact_file }}
 
 runs:
   using: composite

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -1,0 +1,96 @@
+name: Pre-release Version Check
+description: Scans dependency files for pre-release version pins (-beta, -rc) that should not reach production.
+
+inputs:
+  scan-ref:
+    description: 'Directory to scan for pre-release versions'
+    required: false
+    default: '.'
+  app-name:
+    description: 'Application name for reporting context'
+    required: false
+    default: ''
+
+outputs:
+  has-findings:
+    description: 'true if pre-release versions were detected'
+    value: ${{ steps.scan.outputs.has_findings }}
+  findings-count:
+    description: 'Number of pre-release version findings'
+    value: ${{ steps.scan.outputs.findings_count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Scan for pre-release versions
+      id: scan
+      shell: bash
+      env:
+        SCAN_DIR: ${{ inputs.scan-ref }}
+        APP_NAME: ${{ inputs.app-name }}
+      run: |
+        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(beta|rc)[.0-9]*'
+        FINDINGS=()
+
+        # ----------------- go.mod -----------------
+        if [ -f "$SCAN_DIR/go.mod" ]; then
+          while IFS= read -r match; do
+            FINDINGS+=("go.mod|$match")
+          done < <(grep -nE "v${PRERELEASE_PATTERN}" "$SCAN_DIR/go.mod" || true)
+        fi
+
+        # ----------------- package.json -----------------
+        if [ -f "$SCAN_DIR/package.json" ]; then
+          while IFS= read -r match; do
+            FINDINGS+=("package.json|$match")
+          done < <(grep -nE "\"${PRERELEASE_PATTERN}\"" "$SCAN_DIR/package.json" || true)
+        fi
+
+        # ----------------- Dockerfile -----------------
+        for df in "$SCAN_DIR/Dockerfile" "$SCAN_DIR/"*.dockerfile "$SCAN_DIR/Dockerfile."*; do
+          [ -f "$df" ] || continue
+          fname=$(basename "$df")
+          while IFS= read -r match; do
+            FINDINGS+=("${fname}|$match")
+          done < <(grep -nE ":${PRERELEASE_PATTERN}" "$df" || true)
+        done
+
+        COUNT=${#FINDINGS[@]}
+        echo "findings_count=$COUNT" >> "$GITHUB_OUTPUT"
+
+        if [ "$COUNT" -gt 0 ]; then
+          echo "has_findings=true" >> "$GITHUB_OUTPUT"
+
+          LABEL=""
+          [ -n "$APP_NAME" ] && LABEL=" ($APP_NAME)"
+
+          echo "::error::Found $COUNT pre-release version pin(s)${LABEL}. Production code must not depend on beta or release candidate versions."
+
+          {
+            echo "### :warning: Pre-release Version Pins${LABEL}"
+            echo ""
+            echo "| File | Line | Content |"
+            echo "|------|------|---------|"
+            for f in "${FINDINGS[@]}"; do
+              FILE="${f%%|*}"
+              REST="${f#*|}"
+              LINE="${REST%%:*}"
+              CONTENT="${REST#*:}"
+              CONTENT=$(echo "$CONTENT" | sed 's/^[[:space:]]*//' | sed 's/|/\\|/g')
+              echo "| \`${FILE}\` | ${LINE} | \`${CONTENT}\` |"
+            done
+            echo ""
+            echo "> Replace \`-beta.*\` and \`-rc.*\` versions with stable releases."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for f in "${FINDINGS[@]}"; do
+            FILE="${f%%|*}"
+            REST="${f#*|}"
+            LINE="${REST%%:*}"
+            CONTENT="${REST#*:}"
+            echo "::warning file=${SCAN_DIR}/${FILE},line=${LINE}::Pre-release version pin: $(echo "$CONTENT" | sed 's/^[[:space:]]*//')"
+          done
+        else
+          echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          echo "No pre-release version pins found."
+        fi


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds two new security capabilities to the `pr-security-scan` reusable workflow:

- **CodeQL static analysis** — opt-in via `enable_codeql` + `codeql_languages` inputs. Runs as a separate `codeql_scan` job in parallel with the existing `security_scan` job. Scopes analysis to changed paths using `codeql-config`, then runs init → autobuild → analyze → reporter. Results are posted as a PR comment and uploaded to the GitHub Security tab.
- **Pre-release version gate** — enabled by default (`enable_prerelease_check: true`). New `prerelease-check` composite scans `go.mod`, `package.json`, and `Dockerfile` for version pins containing `-beta` or `-rc` suffixes. Findings are reported via GitHub annotations and step summary, and the workflow fails if any are found.

Additional changes:
- Bumped all LerianStudio composite refs from `@v1.18.0` to `@v1.23.1`
- Removed commented-out SARIF upload code (replaced by proper CodeQL integration)
- Updated `notify` job to aggregate CodeQL scan results
- Updated `docs/pr-security-scan-workflow.md` with new inputs, job descriptions, and usage examples

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. CodeQL is opt-in (`enable_codeql: false` by default). Pre-release check is enabled by default but can be disabled via `enable_prerelease_check: false`.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Pending — composite refs point to `@feat/pr-security-scan-codeql-prerelease` for testing from caller repos.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CodeQL static analysis with configurable languages, fail-on-findings behavior, and optional SARIF upload; results reported on PRs
  * Pre-release dependency gate detecting unstable version pins, producing artifacted findings and optionally failing PRs on configured branches
  * PR reporter now includes a Pre-release Version Check section

* **Updates**
  * Workflow inputs, permissions, job wiring, and notifications expanded so CodeQL and pre-release results are reflected in PR comments and alerts

* **Documentation**
  * Docs and examples updated for CodeQL, pre-release gate, reporter behavior, and usage guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->