### PR TITLE
fix(gptchangelog): resolve contributors via github api

### DIFF
--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -393,32 +393,31 @@ jobs:
             echo "📝 Commits for $APP_NAME:"
             echo "$COMMITS_TEXT"
 
-            # Get unique contributors (GitHub usernames) for this app
-            # Try to extract GitHub username from email (format: user@users.noreply.github.com or id+username@users.noreply.github.com)
+            # Resolve contributors via GitHub's commit->author.login mapping.
+            # Guessing handles from email local-parts is unreliable and has produced
+            # false @mentions of unrelated third parties when authors commit with a
+            # corporate/personal email instead of @users.noreply.github.com.
             if [ "$WORKING_DIR" != "." ]; then
-              RAW_EMAILS=$(git log "$SINCE".."$LAST_TAG" --format='%ae' -- "$WORKING_DIR" 2>/dev/null | sort -u)
+              SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' -- "$WORKING_DIR" 2>/dev/null)
             else
-              RAW_EMAILS=$(git log "$SINCE".."$LAST_TAG" --format='%ae' 2>/dev/null | sort -u)
+              SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' 2>/dev/null)
             fi
 
-            # Collect unique usernames (same user may have multiple emails)
             USERNAMES_FILE=$(mktemp)
-            for EMAIL in $RAW_EMAILS; do
-              # Skip service accounts used for automated commits
-              if [[ "$EMAIL" == *"srv.iam"* ]] || [[ "$EMAIL" == *"noreply"* && "$EMAIL" != *"users.noreply.github.com" ]]; then
-                continue
+            for SHA in $SHAS; do
+              LOGIN=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" \
+                --jq '.author.login // empty' 2>/dev/null || true)
+              # Skip bots and unresolved authors (null login).
+              if [[ -n "$LOGIN" && "$LOGIN" != *"[bot]" ]]; then
+                echo "$LOGIN" >> "$USERNAMES_FILE"
               fi
-              if [[ "$EMAIL" == *"@users.noreply.github.com" ]]; then
-                # Extract username from GitHub noreply email
-                USERNAME=$(echo "$EMAIL" | sed 's/@users.noreply.github.com//' | sed 's/.*+//')
-              else
-                # Use email prefix as fallback
-                USERNAME=$(echo "$EMAIL" | cut -d@ -f1)
-              fi
-              echo "$USERNAME" >> "$USERNAMES_FILE"
             done
-            # Deduplicate usernames and format as @username
-            CONTRIBUTORS=$(sort -u "$USERNAMES_FILE" | sed 's/^/@/' | tr '\n' ', ' | sed 's/, $//')
+
+            if [ -s "$USERNAMES_FILE" ]; then
+              CONTRIBUTORS=$(sort -u "$USERNAMES_FILE" | sed 's/^/@/' | tr '\n' ', ' | sed 's/, $//')
+            else
+              CONTRIBUTORS=""
+            fi
             rm -f "$USERNAMES_FILE"
             echo "👥 Contributors: $CONTRIBUTORS"
 


### PR DESCRIPTION
## Description

Replaces the email-local-part heuristic used to build the `Contributors:` line
in generated CHANGELOG entries with GitHub's authoritative
`commit.author.login`, fetched via `gh api repos/:owner/:repo/commits/:sha`.

The previous logic took the part before `@` of any non-`@users.noreply.github.com`
email and treated it as a GitHub handle. That produced:

- false `@mentions` that matched unrelated real accounts
  (e.g. `@fabi`, `@fred`, `@gandalf`, `@jota`), generating cross-notifications
  to third parties;
- duplicates for the same contributor committing under different emails
  (e.g. `@bedatty` + `@lucas.bedatty`);
- syntactically invalid handles containing `.` (e.g. `@gui.rodrigues`).

The new logic resolves each commit SHA to its `author.login` via the GitHub API
(the step already has `GH_TOKEN` in scope), skips bots and unresolved authors,
and deduplicates. Contributors who commit with a corporate or personal email
are now credited correctly using their real GitHub handle.

**Workflow affected:** `.github/workflows/gptchangelog.yml`

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Output format is unchanged (`Contributors: @user1, @user2, ...`).
Only the set of handles becomes accurate.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [ ] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [ ] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — will validate on next `midaz` release run._

## Related Issues

Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog generation workflow to improve contributor identification accuracy using GitHub author login resolution instead of email-based detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->