### PR TITLE
fix(self-release): generate changelog after stable release on main

### DIFF
--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -32,3 +32,14 @@ jobs:
     with:
       runner_type: ubuntu-latest
     secrets: inherit
+
+  # Only run after a stable release on main; develop/release-candidate produce
+  # beta/rc tags that the reusable skips anyway via stable_releases_only.
+  generate-changelog:
+    needs: publish-release
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/gptchangelog.yml
+    with:
+      runner_type: ubuntu-latest
+      stable_releases_only: true
+    secrets: inherit


### PR DESCRIPTION
## Description

Adds a `generate-changelog` job to `.github/workflows/self-release.yml` that
invokes the reusable `gptchangelog.yml` after `publish-release` succeeds,
gated to pushes on `main`.

Why: this repo publishes `gptchangelog.yml` but does not consume it itself.
`.releaserc.yml` references a `CHANGELOG.md` asset via `@semantic-release/git`,
but there is no generator plugin configured and no `CHANGELOG.md` at the repo
root — so changelog generation is currently a no-op. This change closes the
gap and starts dogfooding the workflow against this repo (which also validates
the contributors fix from #214 in production).

### Behavior by branch

- Push to `develop` → `publish-release` creates a `-beta.N` tag; the gate
  `github.ref == 'refs/heads/main'` makes `generate-changelog` skip.
- Push to `release-candidate` → same (skip).
- Push to `main` → stable `vX.Y.Z` tag is created; `generate-changelog` runs,
  finds the new tag, and opens a `chore(release): Update CHANGELOGs` PR on a
  `changelog/*` branch targeting `main`.

Defense in depth: even without the branch gate, `stable_releases_only: true`
already makes the reusable skip prerelease tags
(`gptchangelog.yml:127-132,159-165`). The `if:` saves a runner spin-up.

### No loop risk

- `self-release.yml` already has `paths-ignore: '**/*.md'`, so merging the
  generated `CHANGELOG.md` PR does not retrigger the workflow.
- `gptchangelog.yml` dedupes by open PR (`gptchangelog.yml:650`).

**Workflow affected:** `.github/workflows/self-release.yml`

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

> Note: although this touches a `self-*` workflow, the change *adds* a new
> self-CI job (invoking a reusable), which is closer to `feat` than `ci`
> (which is reserved for tweaks to existing self-CI). Marked `feat` to match
> the commit type.

## Breaking Changes

None. No input/output surface of any reusable workflow is touched; only the
self-CI caller is extended.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [ ] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [ ] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** This repo itself — will validate on the next
push to `develop` (changelog job must **skip**) and on the next release to
`main` (changelog job must **run** and open a PR).

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release workflow to improve changelog generation during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->