### PR TITLE
fix(actions): rename deprecated app-id input to client-id

### DIFF
--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -255,7 +255,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -102,7 +102,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Extract payload

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Description

Silences the deprecation warning emitted by `actions/create-github-app-token`:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

The action renamed the input for naming clarity (aligning with OAuth terminology)
but accepts both values interchangeably. Verified in the action source at the
pinned SHA (`1b10c78c` / v3.1.1):

```javascript
// main.js:22
const clientId = core.getInput("client-id") || core.getInput("app-id");
// ...
const auth = createAppAuth({ appId: clientId, ... });
```

The input value is forwarded to `@octokit/auth-app`'s `appId` parameter, which
accepts both numeric App IDs and string Client IDs. **No new secret is needed**
— the existing `*_APP_ID` secrets continue to work when passed via `client-id:`.

### Files touched

| File | Before | After |
|------|--------|-------|
| `.github/workflows/release.yml:109` | `app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}` | `client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}` |
| `.github/workflows/gptchangelog.yml:258` | same | same |
| `.github/workflows/typescript-release.yml:120` | same | same |
| `.github/workflows/helm-update-chart.yml:105` | `app-id: ${{ secrets.APP_ID }}` | `client-id: ${{ secrets.APP_ID }}` |
| `.github/workflows/release-notification.yml:120` | same | same |

### Zero-impact for callers

Secret **names** are unchanged. External caller repos (midaz, etc.) — whether
they use `secrets: inherit` or explicit mappings — require **no changes**.

**Workflows affected:** 5 reusable workflows.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Secret names and caller API remain unchanged; only the action input name
was updated.

## Testing

- [x] YAML syntax validated locally (all 5 files)
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values (input is forwarded unchanged)
- [ ] Confirmed no secrets or tokens are printed in logs
- [ ] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Will validate on the next self-release run
(warning must disappear). Ref run showing the warning before this fix:
<https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/24564886080>

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub authentication configuration across multiple build and release automation workflows to ensure consistent token generation across all deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->