### PR TITLE
fix(codeql-reporter): filter dismissed and fixed alerts from PR comment

### DIFF
--- a/src/security/codeql-reporter/README.md
+++ b/src/security/codeql-reporter/README.md
@@ -7,6 +7,8 @@
 
 Composite action that reads CodeQL SARIF output and posts a formatted security report as a PR comment. Uses an idempotent comment strategy (updates existing comment on re-runs). Designed to run after [`codeql-analyze`](../codeql-analyze/).
 
+Findings parsed from SARIF are cross-referenced with the Code Scanning REST API (`listAlertsForRepo` on `refs/pull/<pr>/merge`) so alerts that were **dismissed** via the Security tab or are already **fixed** on the merge ref do not show up in the PR comment. A footer notes the number of hidden findings so reviewers know the comment omitted some. If the API call fails (e.g. missing permissions), the action degrades gracefully to the SARIF-only view and emits a warning.
+
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -54,7 +56,9 @@ steps:
 ```yaml
 permissions:
   contents: read
-  security-events: write
+  security-events: write   # required for alert-state enrichment; `read` is enough on its own
   pull-requests: write
   actions: read
 ```
+
+> `security-events: write` (already required by [`codeql-analyze`](../codeql-analyze/)) covers the `listAlertsForRepo` call used to filter dismissed/fixed alerts. If only `read` is granted the enrichment still works; if the permission is missing entirely the action falls back to the raw SARIF view with a warning.

--- a/src/security/codeql-reporter/action.yml
+++ b/src/security/codeql-reporter/action.yml
@@ -129,8 +129,72 @@ runs:
           // unpinned-tag is handled by our own pinned-actions lint check with org-aware logic
           const SUPPRESSED_RULES = ['actions/unpinned-tag'];
 
+          // ── Enrich findings with Code Scanning alert states ──
+          // SARIF is structural: it re-reports the same locations on every run, even after
+          // a reviewer dismisses the alert via the Security tab. Cross-reference the REST
+          // API so dismissed/fixed alerts stop showing up in the PR comment.
+          async function filterByAlertStates(rawFindings) {
+            const prNumber = context.payload.pull_request?.number || context.issue?.number;
+            if (!prNumber) {
+              return { findings: rawFindings, hidden: 0, enriched: false };
+            }
+
+            let alerts;
+            try {
+              alerts = await github.paginate(
+                github.rest.codeScanning.listAlertsForRepo,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/pull/${prNumber}/merge`,
+                  per_page: 100,
+                }
+              );
+            } catch (e) {
+              core.warning(
+                `Could not fetch Code Scanning alert states (falling back to SARIF-only view): ${e.message}`
+              );
+              return { findings: rawFindings, hidden: 0, enriched: false };
+            }
+
+            // Bucket alert states by (ruleId, path, startLine). A single location can carry
+            // multiple alert rows across history; if any are currently open, we must not
+            // suppress it — only suppress when every alert at that location is dismissed/fixed.
+            const statesByKey = new Map();
+            for (const alert of alerts) {
+              const ruleId = alert.rule?.id;
+              const loc = alert.most_recent_instance?.location;
+              const alertPath = loc?.path;
+              if (!ruleId || !alertPath) continue;
+              const key = `${ruleId}\u0000${alertPath}\u0000${loc?.start_line ?? 0}`;
+              if (!statesByKey.has(key)) statesByKey.set(key, []);
+              statesByKey.get(key).push(alert.state);
+            }
+
+            const suppressedKeys = new Set();
+            for (const [key, states] of statesByKey) {
+              if (states.includes('open')) continue;
+              if (states.some(s => s === 'dismissed' || s === 'fixed')) {
+                suppressedKeys.add(key);
+              }
+            }
+
+            const kept = [];
+            let hidden = 0;
+            for (const f of rawFindings) {
+              const key = `${f.rule}\u0000${f.file}\u0000${f.line || 0}`;
+              if (suppressedKeys.has(key)) {
+                hidden++;
+              } else {
+                kept.push(f);
+              }
+            }
+            return { findings: kept, hidden, enriched: true };
+          }
+
           // ── Build Report ──
-          const findings = readSarifFiles().filter(f => !SUPPRESSED_RULES.includes(f.rule));
+          const rawFindings = readSarifFiles().filter(f => !SUPPRESSED_RULES.includes(f.rule));
+          const { findings, hidden: hiddenCount, enriched } = await filterByAlertStates(rawFindings);
           findingsCount = findings.length;
 
           body += `## \u{1F6E1}\uFE0F CodeQL Analysis Results\n\n`;
@@ -142,6 +206,9 @@ runs:
             body += `\u26A0\uFE0F Some SARIF files could not be parsed and no findings were recovered. Check the analysis step logs.\n\n`;
           } else if (findings.length === 0) {
             body += `\u2705 No security issues found.\n\n`;
+            if (enriched && hiddenCount > 0) {
+              body += `_${hiddenCount} finding(s) hidden (dismissed or fixed). See the Security tab for the full list._\n\n`;
+            }
           } else {
             hasFindings = true;
 
@@ -179,6 +246,10 @@ runs:
             }
 
             body += '\n';
+
+            if (enriched && hiddenCount > 0) {
+              body += `_${hiddenCount} finding(s) hidden (dismissed or fixed). See the Security tab for the full list._\n\n`;
+            }
           }
 
           // ── Useful Links ──

--- a/src/security/codeql-reporter/action.yml
+++ b/src/security/codeql-reporter/action.yml
@@ -73,6 +73,18 @@ runs:
           const truncate = (str, max) =>
             str.length > max ? str.substring(0, max - 3) + '...' : str;
 
+          // Normalize file paths to repo-relative form. SARIF can emit absolute
+          // file:// URIs (e.g. file:///github/workspace/src/foo.js) or leading
+          // ./ prefixes, while the Code Scanning API always returns clean
+          // repo-relative paths — normalizing both sides keeps the (rule, path,
+          // line) lookup key aligned.
+          const normalizePath = (p) =>
+            String(p ?? '')
+              .replace(/^file:\/\/\/github\/workspace\//, '')
+              .replace(/^file:\/\//, '')
+              .replace(/^\.\//, '')
+              .replace(/^\//, '');
+
           // ── Read SARIF files ──
           function readSarifFiles() {
             const findings = [];
@@ -109,7 +121,7 @@ runs:
                       rule: result.ruleId || 'unknown',
                       severity: result.level || 'warning',
                       message: result.message?.text || rule.shortDescription?.text || 'No description',
-                      file: location?.artifactLocation?.uri || 'unknown',
+                      file: normalizePath(location?.artifactLocation?.uri) || 'unknown',
                       line: location?.region?.startLine || 0,
                       description: rule.fullDescription?.text || rule.shortDescription?.text || '',
                       tags: rule.properties?.tags || [],
@@ -164,7 +176,7 @@ runs:
             for (const alert of alerts) {
               const ruleId = alert.rule?.id;
               const loc = alert.most_recent_instance?.location;
-              const alertPath = loc?.path;
+              const alertPath = normalizePath(loc?.path);
               if (!ruleId || !alertPath) continue;
               const key = `${ruleId}\u0000${alertPath}\u0000${loc?.start_line ?? 0}`;
               if (!statesByKey.has(key)) statesByKey.set(key, []);


### PR DESCRIPTION
## Description

The `codeql-reporter` composite action rendered its PR comment straight from
the SARIF output, with no cross-reference to Code Scanning alert state. Alerts
that reviewers had already **dismissed** via the Security tab, and alerts that
the API reported as **fixed** on the merge ref, kept showing up on every
re-scan — driving pressure to disable rules globally and creating disagreement
between the authoritative Security tab and the PR comment.

### What changed

- `src/security/codeql-reporter/action.yml`: after parsing SARIF, enrich each
  finding with the current alert state via
  `github.rest.codeScanning.listAlertsForRepo({ ref: 'refs/pull/<pr>/merge' })`
  (paginated). Build a lookup keyed by `(ruleId, path, startLine)`. Suppress
  a finding only when **every** alert at that location is `dismissed` or
  `fixed`; if any alert at the same location is still `open`, the finding is
  kept. The `hasFindings` / `findingsCount` outputs reflect the filtered count,
  so the security gate no longer fails on triaged alerts.
- **Graceful degradation**: if the REST call fails (missing permissions,
  outage, no PR context), the action logs a warning and falls back to the raw
  SARIF view — no behavior regression.
- **Footer note**: when any findings are hidden, a line is appended —
  `_N finding(s) hidden (dismissed or fixed). See the Security tab for the full list._`
  so reviewers know the comment isn't lying by omission.
- `src/security/codeql-reporter/README.md`: documented the new enrichment
  behavior and clarified that the already-required `security-events: write`
  covers the `listAlertsForRepo` call — no new permission needed.

### Workflows affected

Only the `src/security/codeql-reporter` composite action. Callers consuming
it through `pr-security-scan.yml` / `self-pr-validation.yml` (pinned to
`@v1.24.1`) are unaffected until a new release is cut.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Inputs, outputs, and behavior on the happy path (all alerts open) are
unchanged. The only observable difference is that dismissed/fixed alerts stop
appearing in the PR comment.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Will validate on the next run of
`self-pr-validation.yml` against this branch; prior evidence of the bug
documented in issue #213 (triaged during PR #212).

## Related Issues

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR comments now suppress SARIF findings that are all dismissed/fixed for the PR merge ref, and show a footer with the count of hidden findings.
  * File path normalization improves matching so findings align with alert data.

* **Bug Fixes**
  * Fallback to unfiltered SARIF view with a warning if enrichment/permissions fail.

* **Documentation**
  * Clarified permissions guidance for security-event access and enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->