### PR TITLE
feat(self-release): force-update floating major tag on stable release

### DIFF
--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -77,38 +77,5 @@ jobs:
           git_user_signingkey: true
           git_tag_gpgsign: true
 
-      - name: Move major version tag to latest stable release
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -euo pipefail
-
-          git fetch --tags --force --prune
-
-          LATEST=$(git tag --list \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | sort -V \
-            | tail -n1 || true)
-
-          if [ -z "$LATEST" ]; then
-            echo "::notice::No stable release tag found — skipping major tag update."
-            exit 0
-          fi
-
-          VERSION="${LATEST#v}"
-          MAJOR="v${VERSION%%.*}"
-          SHA=$(git rev-list -n1 "$LATEST")
-
-          CURRENT_SHA=""
-          if git rev-parse --verify --quiet "refs/tags/$MAJOR" >/dev/null; then
-            CURRENT_SHA=$(git rev-list -n1 "$MAJOR")
-          fi
-
-          if [ "$CURRENT_SHA" = "$SHA" ]; then
-            echo "::notice::$MAJOR already points at $LATEST ($SHA) — nothing to do."
-            exit 0
-          fi
-
-          echo "Moving $MAJOR → $LATEST ($SHA)"
-          git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
-          git push origin "$MAJOR" --force
+      - name: Update floating major version tag
+        uses: ./src/config/update-major-tag

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -43,3 +43,72 @@ jobs:
       runner_type: ubuntu-latest
       stable_releases_only: true
     secrets: inherit
+
+  # Force-update the floating major version tag (e.g. v1) to point at the
+  # latest stable release. Enables downstream composites to pin to @v1 and
+  # always resolve to the latest stable v1.x.x release. Stable-only: gated to
+  # main so beta/rc releases from develop/release-candidate don't move v1.
+  update-major-tag:
+    needs: publish-release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
+          passphrase: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
+          git_committer_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          git_committer_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+
+      - name: Move major version tag to latest stable release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force --prune
+
+          LATEST=$(git tag --list \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -n1 || true)
+
+          if [ -z "$LATEST" ]; then
+            echo "::notice::No stable release tag found — skipping major tag update."
+            exit 0
+          fi
+
+          VERSION="${LATEST#v}"
+          MAJOR="v${VERSION%%.*}"
+          SHA=$(git rev-list -n1 "$LATEST")
+
+          CURRENT_SHA=""
+          if git rev-parse --verify --quiet "refs/tags/$MAJOR" >/dev/null; then
+            CURRENT_SHA=$(git rev-list -n1 "$MAJOR")
+          fi
+
+          if [ "$CURRENT_SHA" = "$SHA" ]; then
+            echo "::notice::$MAJOR already points at $LATEST ($SHA) — nothing to do."
+            exit 0
+          fi
+
+          echo "Moving $MAJOR → $LATEST ($SHA)"
+          git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
+          git push origin "$MAJOR" --force

--- a/src/config/update-major-tag/README.md
+++ b/src/config/update-major-tag/README.md
@@ -25,6 +25,15 @@ Force-update the floating major version tag (e.g. `v1`) to point at the latest s
 
 _None._ All behavior is derived from the repository's tag list.
 
+## Outputs
+
+| Output | Description |
+|---|---|
+| `skip` | `true` when no tag update was performed — either no stable tag was found, or the major tag already pointed at the latest stable commit |
+| `tag-updated` | `true` when the floating major tag was force-pushed to a new commit |
+| `major-tag` | The major tag name that was considered (e.g. `v1`). Empty when no stable tag was found |
+| `latest-tag` | The latest stable tag the major tag was aligned with (e.g. `v1.26.0`). Empty when no stable tag was found |
+
 ## Usage
 
 ```yaml

--- a/src/config/update-major-tag/README.md
+++ b/src/config/update-major-tag/README.md
@@ -1,0 +1,66 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>update-major-tag</h1></td>
+  </tr>
+</table>
+
+Force-update the floating major version tag (e.g. `v1`) to point at the latest stable `vX.Y.Z` tag in the repository. Intended to run after a successful stable release so callers can pin composite actions to `@v1` and always resolve to the latest stable release.
+
+### Behavior
+
+1. Fetches all tags from the remote.
+2. Finds the greatest stable tag matching `^v[0-9]+\.[0-9]+\.[0-9]+$` (pre-release tags like `-beta.N` / `-rc.N` are ignored).
+3. Derives the major prefix (`v1.26.0 → v1`).
+4. If the major tag already points at the resolved commit, exits with a notice — idempotent.
+5. Otherwise, creates/moves the major tag as an annotated tag and force-pushes it.
+
+### Assumptions
+
+- The caller has already checked out the repository with `fetch-depth: 0` (so all tags are reachable).
+- The checkout was authenticated with a token that has permission to push tags (typically via `actions/checkout@... with.token:`).
+- For signed tags, the caller has imported a GPG key and enabled `git_tag_gpgsign` (`git tag -a` will auto-sign when `tag.gpgSign=true` is set globally).
+
+## Inputs
+
+_None._ All behavior is derived from the repository's tag list.
+
+## Usage
+
+```yaml
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/create-github-app-token@<sha> # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@<sha> # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: crazy-max/ghaction-import-gpg@<sha> # v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: ${{ secrets.CI_USER_NAME }}
+          git_committer_email: ${{ secrets.CI_USER_EMAIL }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+
+      - uses: LerianStudio/github-actions-shared-workflows/src/config/update-major-tag@v1
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: write
+```

--- a/src/config/update-major-tag/action.yml
+++ b/src/config/update-major-tag/action.yml
@@ -44,11 +44,11 @@ runs:
 
         VERSION="${LATEST#v}"
         MAJOR="v${VERSION%%.*}"
-        SHA=$(git rev-list -n1 "$LATEST")
+        SHA=$(git rev-list -n1 "refs/tags/$LATEST")
 
         CURRENT_SHA=""
         if git rev-parse --verify --quiet "refs/tags/$MAJOR" >/dev/null; then
-          CURRENT_SHA=$(git rev-list -n1 "$MAJOR")
+          CURRENT_SHA=$(git rev-list -n1 "refs/tags/$MAJOR")
         fi
 
         if [ "$CURRENT_SHA" = "$SHA" ]; then
@@ -64,7 +64,7 @@ runs:
 
         echo "Moving $MAJOR → $LATEST ($SHA)"
         git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
-        git push origin "$MAJOR" --force
+        git push origin "refs/tags/$MAJOR:refs/tags/$MAJOR" --force
 
         {
           echo "skip=false"

--- a/src/config/update-major-tag/action.yml
+++ b/src/config/update-major-tag/action.yml
@@ -1,10 +1,25 @@
 name: Update Major Version Tag
 description: Force-update the floating major version tag (e.g. v1) to point at the latest stable semver tag (vX.Y.Z) found in the repository.
 
+outputs:
+  skip:
+    description: 'true when no tag update was performed (no stable tag found, or major already points at the latest stable commit)'
+    value: ${{ steps.update.outputs.skip }}
+  tag-updated:
+    description: 'true when the floating major tag was force-pushed to a new commit'
+    value: ${{ steps.update.outputs.tag-updated }}
+  major-tag:
+    description: 'The major tag name that was considered (e.g. v1). Empty when no stable tag was found.'
+    value: ${{ steps.update.outputs.major-tag }}
+  latest-tag:
+    description: 'The latest stable tag the major tag was aligned with (e.g. v1.26.0). Empty when no stable tag was found.'
+    value: ${{ steps.update.outputs.latest-tag }}
+
 runs:
   using: composite
   steps:
-    - name: Resolve and push major version tag
+    - id: update
+      name: Resolve and push major version tag
       shell: bash
       run: |
         set -euo pipefail
@@ -18,6 +33,12 @@ runs:
 
         if [ -z "$LATEST" ]; then
           echo "::notice::No stable release tag found — skipping major tag update."
+          {
+            echo "skip=true"
+            echo "tag-updated=false"
+            echo "major-tag="
+            echo "latest-tag="
+          } >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
@@ -32,9 +53,22 @@ runs:
 
         if [ "$CURRENT_SHA" = "$SHA" ]; then
           echo "::notice::$MAJOR already points at $LATEST ($SHA) — nothing to do."
+          {
+            echo "skip=true"
+            echo "tag-updated=false"
+            echo "major-tag=$MAJOR"
+            echo "latest-tag=$LATEST"
+          } >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
         echo "Moving $MAJOR → $LATEST ($SHA)"
         git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
         git push origin "$MAJOR" --force
+
+        {
+          echo "skip=false"
+          echo "tag-updated=true"
+          echo "major-tag=$MAJOR"
+          echo "latest-tag=$LATEST"
+        } >> "$GITHUB_OUTPUT"

--- a/src/config/update-major-tag/action.yml
+++ b/src/config/update-major-tag/action.yml
@@ -1,0 +1,40 @@
+name: Update Major Version Tag
+description: Force-update the floating major version tag (e.g. v1) to point at the latest stable semver tag (vX.Y.Z) found in the repository.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve and push major version tag
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        git fetch --tags --force --prune
+
+        LATEST=$(git tag --list \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          | sort -V \
+          | tail -n1 || true)
+
+        if [ -z "$LATEST" ]; then
+          echo "::notice::No stable release tag found — skipping major tag update."
+          exit 0
+        fi
+
+        VERSION="${LATEST#v}"
+        MAJOR="v${VERSION%%.*}"
+        SHA=$(git rev-list -n1 "$LATEST")
+
+        CURRENT_SHA=""
+        if git rev-parse --verify --quiet "refs/tags/$MAJOR" >/dev/null; then
+          CURRENT_SHA=$(git rev-list -n1 "$MAJOR")
+        fi
+
+        if [ "$CURRENT_SHA" = "$SHA" ]; then
+          echo "::notice::$MAJOR already points at $LATEST ($SHA) — nothing to do."
+          exit 0
+        fi
+
+        echo "Moving $MAJOR → $LATEST ($SHA)"
+        git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
+        git push origin "$MAJOR" --force


### PR DESCRIPTION
## Description

Adds a new job `update-major-tag` to `self-release.yml` that force-updates
the floating major version tag (`v1`) to point at the latest stable
`vX.Y.Z` release. This is the prerequisite infrastructure for pinning
internal composite actions to `@v1` across downstream callers (so they
resolve to the latest stable v1 release without needing a per-patch bump).

### How it works

- Runs **after** the reusable `release.yml` publishes, gated to
  `refs/heads/main` only — so beta/rc releases from `develop` and
  `release-candidate` never move `v1`.
- Uses the existing Lerian CI bot app-token + GPG identity for signed
  annotated tags (matches the convention already used by semantic-release
  in `release.yml`).
- Detects the latest stable tag via
  `git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1`,
  derives the major prefix, and force-pushes the tag.
- **Idempotent**: if the major tag already points at the resolved commit,
  the step logs a notice and exits 0. If there is no stable tag yet, the
  step logs a notice and exits 0.

### Why now

Part of a larger policy change — internal composites get floating-major
pinning (`@v1`), external actions keep SHA pinning, and reusable workflows
keep exact-version pinning (`@v1.26.0`). See follow-up PRs for the linter
adjustment and the bulk caller update.

### Scope

Only `self-release.yml` — the reusable `release.yml` is untouched so
downstream callers (midaz, etc.) see no behavior change until they opt in.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Only `self-release.yml` changes; the reusable `release.yml` API and
behavior are unchanged for downstream callers.

## Testing

- [x] YAML syntax validated locally
- [x] Validated the bash major-tag derivation locally against the repo's
      tag list (`v1.26.0 → v1`, idempotent re-run logic works)
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Will be validated by the next stable
release on `main` (tag move must land with the release).

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release step that runs after publishing to update floating major tags (e.g., "v1") to point to the latest stable release; skips when already aligned.
* **Documentation**
  * Added docs and a reusable release action that finds the latest stable semver tag, can create/update annotated (optionally signed) major tags, force-pushes updates when needed, and exposes outputs indicating skip/update and the tag names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->