### PR TITLE
feat(pinned-actions): enforce composite vs reusable pinning policy

### DIFF
--- a/src/lint/pinned-actions/README.md
+++ b/src/lint/pinned-actions/README.md
@@ -5,35 +5,62 @@
   </tr>
 </table>
 
-Ensure all third-party GitHub Action references use pinned versions (`@vX.Y.Z` or `@sha`), not mutable refs like `@main` or `@master`.
+Enforces the repository pinning policy on every `uses:` reference in workflow and composite files. External actions must be pinned by commit SHA; internal (`LerianStudio/`) references are validated against the composite-vs-reusable policy below.
+
+## Policy
+
+| Ref kind | Detection | Required pin | Severity on violation |
+|---|---|---|---|
+| **External action** (anything outside the org) | `uses:` path does not match any `warn-patterns` prefix | Full commit SHA (40–64 hex chars) | ❌ **error** — fails the step |
+| **Internal composite** | `uses:` path contains `/src/` | Floating major tag (`@v1`, `@v2`, …) or testing branch (`@develop` / `@main`) | ⚠️ **warning** |
+| **Internal reusable workflow** | `uses:` path contains `/.github/workflows/` | Exact version tag (`@v1.2.3`, `@v1.2.3-beta.1`) or testing branch (`@develop` / `@main`) | ⚠️ **warning** |
+| **Internal, unknown shape** | matches `warn-patterns` but neither path pattern above | Any semver-like tag or testing branch (legacy tolerance) | ⚠️ **warning** |
+
+**Rationale**
+
+- Composites are small, low-risk building blocks. Floating `@v1` lets callers track the latest stable major without bumping per patch — the repo release pipeline moves `@v1` atomically on each stable release in `main`.
+- Reusable workflows orchestrate entire pipelines with broader blast radius. Exact pinning (`@v1.2.3`) forces explicit, auditable caller updates.
+- External actions use SHA pins because upstream tags are mutable — Dependabot keeps the SHAs fresh automatically.
 
 ## Inputs
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `files` | Space-separated list of workflow/composite files to check | No | `` |
-| `ignore-patterns` | Pipe-separated org/owner prefixes to skip (e.g. internal actions) | No | `LerianStudio/` |
+| `files` | Comma-separated list of workflow/composite files to check (empty = skip) | No | `""` |
+| `warn-patterns` | Pipe-separated org/owner prefixes treated as internal (warn-only) | No | `LerianStudio/` |
 
-## Usage as composite step
+## Usage
 
 ```yaml
-- name: Checkout
-  uses: actions/checkout@v4
-
 - name: Pinned Actions Check
-  uses: LerianStudio/github-actions-shared-workflows/src/lint/pinned-actions@v1.2.3
+  uses: LerianStudio/github-actions-shared-workflows/src/lint/pinned-actions@v1
   with:
-    files: ".github/workflows/ci.yml .github/workflows/deploy.yml"
-    ignore-patterns: "LerianStudio/|my-org/"
+    files: ".github/workflows/ci.yml,.github/workflows/deploy.yml"
 ```
 
-## Usage via reusable workflow
+## Examples
 
 ```yaml
-jobs:
-  lint:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-lint.yml@v1.2.3
-    secrets: inherit
+# ✅ External action — SHA pin (required)
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+# ❌ External action — tag pin (error)
+uses: actions/checkout@v6
+
+# ✅ Internal composite — floating major
+uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1
+
+# ⚠️ Internal composite — exact version (warning, should be @v1)
+uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.24.1
+
+# ✅ Internal reusable workflow — exact version
+uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.26.0
+
+# ⚠️ Internal reusable workflow — floating major (warning, should be @vX.Y.Z)
+uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1
+
+# ✅ Either kind — develop/main for testing a change
+uses: LerianStudio/github-actions-shared-workflows/src/config/labels-sync@develop
 ```
 
 ## Required permissions

--- a/src/lint/pinned-actions/action.yml
+++ b/src/lint/pinned-actions/action.yml
@@ -57,12 +57,32 @@ runs:
             done
 
             if [ "$is_internal" = true ]; then
-              # Internal: any semver ref passes — vX, vX.Y.Z, vX.Y.Z-beta.N, vX.Y.Z-rc.N, branches like develop/main
-              if printf '%s\n' "$ref" | grep -Eq '^v[0-9]+(\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)?$|^(develop|main)$'; then
-                continue
+              # Internal pinning policy:
+              #   - Composite actions (path contains /src/)           → floating major tag @vN
+              #   - Reusable workflows (path contains /.github/workflows/) → exact version tag @vN.M.P[-pre]
+              #   - Testing branches (develop|main) are always accepted for both
+              #   - Unknown internal ref shapes fall back to any semver ref (legacy tolerance)
+              target=${normalized%@*}
+
+              if printf '%s\n' "$target" | grep -Fq '/src/'; then
+                if printf '%s\n' "$ref" | grep -Eq '^v[0-9]+$|^(develop|main)$'; then
+                  continue
+                fi
+                echo "::warning file=${file},line=${line_num}::Internal composite must use floating major tag (e.g. @v1) or develop/main for testing: $normalized"
+                warnings=$((warnings + 1))
+              elif printf '%s\n' "$target" | grep -Fq '/.github/workflows/'; then
+                if printf '%s\n' "$ref" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$|^(develop|main)$'; then
+                  continue
+                fi
+                echo "::warning file=${file},line=${line_num}::Internal reusable workflow must use exact version tag (e.g. @v1.2.3) or develop/main for testing: $normalized"
+                warnings=$((warnings + 1))
+              else
+                if printf '%s\n' "$ref" | grep -Eq '^v[0-9]+(\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)?$|^(develop|main)$'; then
+                  continue
+                fi
+                echo "::warning file=${file},line=${line_num}::Internal action not pinned to a version: $normalized"
+                warnings=$((warnings + 1))
               fi
-              echo "::warning file=${file},line=${line_num}::Internal action not pinned to a version: $normalized"
-              warnings=$((warnings + 1))
             else
               # External: must be a commit SHA (40 or 64 hex chars)
               if printf '%s\n' "$ref" | grep -Eiq '^[0-9a-f]{40,64}$'; then


### PR DESCRIPTION
## Description

Extends the `pinned-actions` composite linter to materialize the
repository-wide pinning policy:

| Ref kind | Detection | Required pin | Severity |
|---|---|---|---|
| External action | outside `warn-patterns` | Full commit SHA | error |
| Internal composite | path contains `/src/` | `@vN` floating major (or `@develop`/`@main` for testing) | warning |
| Internal reusable workflow | path contains `/.github/workflows/` | `@vN.M.P[-pre]` exact pin (or `@develop`/`@main` for testing) | warning |
| Internal, unknown shape | matches `warn-patterns` but neither path pattern | any semver (legacy tolerance) | warning |

### Changes

- `src/lint/pinned-actions/action.yml`: split the internal-org branch into
  composite vs reusable-workflow logic. Each emits a distinct, actionable
  warning pointing at the expected pattern. External SHA enforcement is
  unchanged.
- `src/lint/pinned-actions/README.md`: rewrite to document the policy,
  fix the outdated `ignore-patterns` input (actual input is
  `warn-patterns`), and add correct/incorrect examples.

### Rationale

Composites are small building blocks — `@v1` lets callers track the
latest stable major without bumping per patch (the major tag is moved
atomically by `self-release.yml` on each stable release — see #230).
Reusable workflows orchestrate entire pipelines; exact pins force
explicit, auditable caller updates.

### Behavior on existing callers

Non-breaking. Callers currently using `@v1.24.1` for internal composites
will start seeing a warning line in `self-pr-validation.yml` output, but
the step does not fail. The bulk migration to `@v1` is scoped to a
follow-up PR.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Inputs (`files`, `warn-patterns`) and outputs are unchanged; external
enforcement is unchanged; internal policy moves from a single regex to a
split regex but still at WARNING severity — existing CI pipelines do not
fail.

## Testing

- [x] YAML syntax validated locally
- [x] Unit-tested the split regex logic locally against 10 crafted cases
      (composite OK / composite WARN / reusable OK / reusable WARN with
      branches, exact versions, major-only, and pre-release tags)
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Will be validated on the next push to
this branch via `self-pr-validation.yml` → `pinned-actions` job. Existing
`@v1.24.1` refs for internal composites will produce (non-blocking) warnings.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced pinned-actions linter documentation with refined rules for external actions, internal composites, and reusable workflows
  * Updated input parameters: `files` format now comma-separated; `warn-patterns` replaces `ignore-patterns`

* **Validation Updates**
  * Refined validation logic with category-specific version pinning requirements based on action reference type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->