### PR TITLE
fix(update-major-tag): guard major tag push against concurrent rewinds

### DIFF
--- a/src/config/update-major-tag/action.yml
+++ b/src/config/update-major-tag/action.yml
@@ -64,7 +64,13 @@ runs:
 
         echo "Moving $MAJOR → $LATEST ($SHA)"
         git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
-        git push origin "refs/tags/$MAJOR:refs/tags/$MAJOR" --force
+
+        # Use --force-with-lease to avoid rewinding $MAJOR if a concurrent
+        # release already advanced it between our fetch and our push.
+        REMOTE_MAJOR_SHA=$(git ls-remote --refs --tags origin "refs/tags/$MAJOR" | awk '{print $1}')
+        LEASE_SHA="${REMOTE_MAJOR_SHA:-0000000000000000000000000000000000000000}"
+        git push origin "refs/tags/$MAJOR:refs/tags/$MAJOR" \
+          --force-with-lease="refs/tags/$MAJOR:$LEASE_SHA"
 
         {
           echo "skip=false"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fixes a TOCTOU race flagged by CodeRabbit on PR #233 for the floating-major-tag update composite (`src/config/update-major-tag/action.yml`).

### Problem

`self-release.yml` and `release.yml` do not define a `concurrency:` block, so two release runs on `main` (e.g. back-to-back merges) can overlap. If run A resolves `LATEST=v1.26.0` while run B resolves `LATEST=v1.27.0` and finishes its push first (moving `v1 → def`), run A's subsequent `git push --force` would silently rewind `v1` back to `abc` (`v1.26.0`). Consumers pinning to `@v1` would regress until the next release.

### Fix

Replace the unconditional `--force` with `--force-with-lease`, reading the current remote SHA via `git ls-remote` first:

```bash
REMOTE_MAJOR_SHA=$(git ls-remote --refs --tags origin "refs/tags/$MAJOR" | awk '{print $1}')
LEASE_SHA="${REMOTE_MAJOR_SHA:-0000000000000000000000000000000000000000}"
git push origin "refs/tags/$MAJOR:refs/tags/$MAJOR" \
  --force-with-lease="refs/tags/$MAJOR:$LEASE_SHA"
```

If another run advanced `$MAJOR` between the lease read and the push, the push fails loudly instead of rewinding the tag. The zero-SHA fallback handles the first-ever push (tag not yet present on remote).

Affected file:
- `src/config/update-major-tag/action.yml`

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The lease-based push succeeds in every case the previous unconditional `--force` did, except when a concurrent run has already advanced the tag — which is exactly the scenario we want to detect and abort.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Next `main` release in this repo will exercise the composite end-to-end (self-release.yml is the only caller).

## Related Issues

Related to #233 — surfaced by CodeRabbit review on that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the safety of the major tag update workflow by replacing unconditional force push with a lease-based mechanism that validates remote state before pushing, reducing the risk of concurrent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->