### PR TITLE
fix(update-major-tag): freeze lease from post-fetch local ref

### DIFF
--- a/src/config/update-major-tag/action.yml
+++ b/src/config/update-major-tag/action.yml
@@ -47,8 +47,14 @@ runs:
         SHA=$(git rev-list -n1 "refs/tags/$LATEST")
 
         CURRENT_SHA=""
+        # Ref snapshot taken right after the initial fetch: using this as the
+        # lease ensures the push aborts if another run advances $MAJOR between
+        # our fetch and our push (re-reading the remote later would defeat the
+        # lease, since it would reflect the other run's update).
+        CURRENT_MAJOR_REF=""
         if git rev-parse --verify --quiet "refs/tags/$MAJOR" >/dev/null; then
           CURRENT_SHA=$(git rev-list -n1 "refs/tags/$MAJOR")
+          CURRENT_MAJOR_REF=$(git rev-parse "refs/tags/$MAJOR")
         fi
 
         if [ "$CURRENT_SHA" = "$SHA" ]; then
@@ -65,10 +71,7 @@ runs:
         echo "Moving $MAJOR → $LATEST ($SHA)"
         git tag -f -a "$MAJOR" "$SHA" -m "Release $MAJOR ($LATEST)"
 
-        # Use --force-with-lease to avoid rewinding $MAJOR if a concurrent
-        # release already advanced it between our fetch and our push.
-        REMOTE_MAJOR_SHA=$(git ls-remote --refs --tags origin "refs/tags/$MAJOR" | awk '{print $1}')
-        LEASE_SHA="${REMOTE_MAJOR_SHA:-0000000000000000000000000000000000000000}"
+        LEASE_SHA="${CURRENT_MAJOR_REF:-0000000000000000000000000000000000000000}"
         git push origin "refs/tags/$MAJOR:refs/tags/$MAJOR" \
           --force-with-lease="refs/tags/$MAJOR:$LEASE_SHA"
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Follow-up to PR #235. CodeRabbit flagged a critical flaw in that first lease implementation (comment on PR #233, line 73): reading the lease from `git ls-remote` immediately before the push defeats the protection.

### The race the old code allowed

1. Run A fetches tags, decides `LATEST=v1.26.0`, reaches the push step.
2. Run B fetches, decides `LATEST=v1.27.0`, and force-pushes `v1 → SHA_NEW` first.
3. Run A then calls `git ls-remote` for `refs/tags/v1` and reads back `SHA_NEW` (B's value).
4. Run A uses `SHA_NEW` as its lease — which matches the server — so the server accepts A's push, **rewinding `v1` to `SHA_OLD`**.

The fix anterior só "parecia" proteger; o lease sempre convergia com o valor servidor no momento do push.

### Fix

Capture the lease once, right after the initial `git fetch --tags --force --prune`, from the local ref via `git rev-parse "refs/tags/$MAJOR"`. This freezes the lease to the state we observed when making the decision to push. If any other run updates `$MAJOR` between our fetch and our push, the server's value no longer matches our frozen lease and the push aborts — exactly the desired semantics.

Also switched from `git rev-list -n1` (commit SHA) to `git rev-parse` (ref SHA) for the lease, since `--force-with-lease` compares ref values — for annotated tags those differ.

Affected file:
- `src/config/update-major-tag/action.yml`

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The zero-SHA fallback for the first-ever tag creation is preserved.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Next `main` release on this repo will exercise the composite end-to-end.

## Related Issues

Corrects #235 — surfaced by CodeRabbit critical-severity review on PR #233.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized tag update workflow for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->