### PR TITLE
fix(cosign-sign): retry signing on transient OIDC/Fulcio failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
 
       - name: Sign container images with cosign
         if: inputs.enable_cosign_sign
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.23.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: ${{ steps.cosign-refs.outputs.refs }}
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Sign container images with cosign
         if: inputs.enable_cosign_sign
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.23.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: ${{ steps.cosign-refs.outputs.refs }}
 

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Sign container images with cosign
         if: inputs.enable_cosign_sign && !inputs.dry_run && steps.cosign-refs.outputs.refs != ''
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.23.0
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: ${{ steps.cosign-refs.outputs.refs }}
 

--- a/src/security/cosign-sign/README.md
+++ b/src/security/cosign-sign/README.md
@@ -14,6 +14,8 @@ Composite action that signs container images using [Sigstore cosign](https://git
 | `image-refs` | Newline-separated fully qualified image references to sign (e.g., `docker.io/org/app@sha256:abc...`) | Yes | — |
 | `cosign-version` | Cosign version to install | No | `v2.5.0` |
 | `dry-run` | Log what would be signed without actually signing | No | `false` |
+| `max-attempts` | Maximum number of signing attempts per image reference (retry on transient OIDC/Fulcio failures) | No | `3` |
+| `initial-delay` | Initial delay in seconds between retry attempts. Delay grows exponentially (×3) after each failed attempt. | No | `5` |
 
 ## Outputs
 
@@ -44,7 +46,7 @@ jobs:
           tags: myorg/myapp:1.0.0
 
       - name: Sign container image
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.x.x
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: docker.io/myorg/myapp@${{ steps.build-push.outputs.digest }}
 ```
@@ -53,7 +55,7 @@ jobs:
 
 ```yaml
       - name: Sign container images
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1.x.x
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: |
             docker.io/myorg/myapp@${{ steps.build-push.outputs.digest }}
@@ -78,3 +80,18 @@ permissions:
 ```
 
 > **Note:** The calling job must have `id-token: write` permission for keyless signing to work. Without it, cosign cannot obtain an OIDC token and the signing step will fail.
+
+## Retry behavior
+
+The signing step retries automatically on transient failures (e.g., malformed OIDC responses from Fulcio, token endpoint flakiness). By default it attempts up to **3 times** with exponential backoff starting at **5s** and growing ×3 per retry (5s → 15s → 45s).
+
+Tune via `max-attempts` and `initial-delay` if your environment needs a different policy:
+
+```yaml
+      - name: Sign container image
+        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
+        with:
+          image-refs: docker.io/myorg/myapp@${{ steps.build-push.outputs.digest }}
+          max-attempts: "5"
+          initial-delay: "10"
+```

--- a/src/security/cosign-sign/action.yml
+++ b/src/security/cosign-sign/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: Log what would be signed without actually signing
     required: false
     default: "false"
+  max-attempts:
+    description: Maximum number of signing attempts per image reference (retry on transient OIDC/Fulcio failures)
+    required: false
+    default: "3"
+  initial-delay:
+    description: Initial delay in seconds between retry attempts. Delay grows exponentially (×3) after each failed attempt.
+    required: false
+    default: "5"
 
 outputs:
   signed-refs:
@@ -85,13 +93,35 @@ runs:
       env:
         IMAGE_REFS: ${{ inputs.image-refs }}
         VALID_COUNT: ${{ steps.validate.outputs.count }}
+        MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        INITIAL_DELAY: ${{ inputs.initial-delay }}
       run: |
+        sign_with_retry() {
+          local ref="$1"
+          local attempt
+          local delay="$INITIAL_DELAY"
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "Signing (attempt $attempt/$MAX_ATTEMPTS): $ref"
+            if cosign sign --yes "$ref"; then
+              return 0
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "::warning::cosign sign failed (attempt $attempt/$MAX_ATTEMPTS) — retrying in ${delay}s…"
+              sleep "$delay"
+              delay=$((delay * 3))
+            fi
+          done
+
+          echo "::error::cosign sign failed after $MAX_ATTEMPTS attempts: $ref"
+          return 1
+        }
+
         SIGNED=""
         while IFS= read -r ref; do
           ref=$(echo "$ref" | xargs)
           [ -z "$ref" ] && continue
-          echo "Signing: $ref"
-          cosign sign --yes "$ref"
+          sign_with_retry "$ref"
           if [ -n "$SIGNED" ]; then
             SIGNED="${SIGNED}"$'\n'"${ref}"
           else


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds retry with exponential backoff to the `cosign sign --yes` call in `src/security/cosign-sign/action.yml` to tolerate transient OIDC/Fulcio failures (e.g., malformed token responses) that previously caused entire pipelines to fail on a first flaky attempt.

**Changes:**
- `src/security/cosign-sign/action.yml`: new optional inputs `max-attempts` (default `3`) and `initial-delay` (default `5`); signing now retries with exponential backoff (×3 per attempt → 5s → 15s → 45s by default). A `::warning::` is emitted between retries and a final `::error::` if all attempts fail.
- `src/security/cosign-sign/README.md`: documents the new inputs and a dedicated "Retry behavior" section with a tuning example.
- `.github/workflows/build.yml`, `typescript-build.yml`, `go-release.yml`: pin the composite to the floating major tag `@v1` (previously `@v1.23.0`), so future patch/minor releases of the composite are picked up automatically by the reusable workflows.

Defaults preserve existing behavior when the first attempt succeeds (the common path logs a single `Signing (attempt 1/3): <ref>` line and no warning). No breaking changes for callers.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. New inputs are optional with defaults that preserve current behavior on first-attempt success. Existing callers require no changes.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — to be validated by a caller repo (e.g. tracer) pointing at `@develop` after merge._

## Related Issues

Closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry logic for cosign image signing with configurable maximum attempts and initial exponential backoff delay to handle transient failures.

* **Chores**
  * Updated cosign signing workflow references to use flexible major version tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->