### PR TITLE
chore(ci): pin internal composites to floating major tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Get changed paths (monorepo)
         if: inputs.filter_paths != ''
         id: changed-paths
-        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
           filter-paths: ${{ inputs.filter_paths }}
           shared-paths: ${{ inputs.shared_paths }}

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Get changed paths (monorepo)
         if: inputs.components_json == '' && inputs.filter_paths != ''
         id: changed-paths
-        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
           filter-paths: ${{ inputs.filter_paths }}
           shared-paths: ${{ inputs.shared_paths }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Build and push Docker image
         id: docker-build
-        uses: LerianStudio/github-actions-shared-workflows/src/build/docker-build-ts@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/build/docker-build-ts@v1
         with:
           enable-dockerhub: ${{ inputs.enable_dockerhub }}
           enable-ghcr: ${{ inputs.enable_ghcr }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Aligns internal composite action references in `build.yml` and `typescript-build.yml` with the repository's pinning policy enforced by `src/lint/pinned-actions`:

> Internal composites (path contains `/src/`) must use a floating major tag `@vN` (or `develop`/`main` for testing). Exact version pins like `@v1.18.0` on composites trigger lint warnings.

Reusable workflow references (`/.github/workflows/*.yml`) remain pinned to exact versions as required by the same policy — no changes there.

**Changes (3 references):**
- `.github/workflows/build.yml:155` — `changed-paths@v1.18.0` → `@v1`
- `.github/workflows/typescript-build.yml:165` — `changed-paths@v1.18.0` → `@v1`
- `.github/workflows/typescript-build.yml:267` — `docker-build-ts@v1.18.0` → `@v1`

These were surfaced as warnings on the lint analysis of PR #241.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The floating major tag `@v1` resolves to the latest `v1.x.x` release of this repo, which is equivalent to or newer than `v1.18.0` — no behavior regression expected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — to be validated after merge via normal caller runs._

## Related Issues

Follow-up from lint warnings on #241.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use the latest major tag for shared GitHub Actions, including the change-paths and Docker build steps, ensuring workflow actions follow the moving v1 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->