### PR TITLE
chore(security): pin actions/github-script by SHA in go-pr-analysis

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -632,7 +632,7 @@ jobs:
 
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           script: |


### PR DESCRIPTION
## Summary

Pins `actions/github-script@v8` to its immutable commit SHA in the `go-pr-analysis` reusable workflow.

- Before: `actions/github-script@v8`
- After: `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0`

## Why

Tag references in third-party GitHub Actions are mutable — the tag can be repointed (by the upstream maintainer, a compromised maintainer account, or a repo takeover) to point at different code without the consumer noticing. Pinning by the full commit SHA (keeping the tag as a comment for readability) is the hardening GitHub recommends for supply-chain security.

The SHA above is the commit that `v8.0.0` / `v8` currently point to in `actions/github-script`.

## Scope

This PR only pins the single `actions/github-script@v8` usage in `.github/workflows/go-pr-analysis.yml` (the one that posts the coverage comment on PRs). Other `uses:` references in the file are out of scope for this change.

Requested by: @bedatty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for improved reliability.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->