### PR TITLE
fix(typescript-release): add backmerge PR fallback for divergent develop

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Get changed paths (monorepo)
         if: inputs.filter_paths != ''
         id: changed-paths
-        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
           filter-paths: ${{ inputs.filter_paths }}
           shared-paths: ${{ inputs.shared_paths }}

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -167,9 +167,16 @@ jobs:
           npm install --save-dev \
             @semantic-release/exec@7.1.0
 
+      # ----------------- Snapshot tags before release -----------------
+      - name: Snapshot tags before release
+        if: ${{ !inputs.dry_run }}
+        id: pre-tags
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-snapshot@v1
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         id: semantic
+        continue-on-error: ${{ !inputs.dry_run }}
         with:
           ci: false
           dry_run: ${{ inputs.dry_run }}
@@ -184,6 +191,36 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+
+      # ----------------- Detect release via git tag -----------------
+      - name: Detect if release was published
+        if: ${{ !inputs.dry_run && always() && steps.semantic.outcome == 'failure' }}
+        id: detect-release
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-check@v1
+        with:
+          previous-tag: ${{ steps.pre-tags.outputs.latest-tag }}
+
+      # ----------------- Backmerge Fallback -----------------
+      - name: Backmerge PR fallback
+        if: |
+          !inputs.dry_run && always() && steps.semantic.outcome == 'failure' && (
+            steps.semantic.outputs.new_release_published == 'true' ||
+            steps.detect-release.outputs.release-published == 'true'
+          )
+        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-pr@v1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          source-branch: ${{ github.ref_name }}
+          version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release-version }}
+
+      - name: Fail if release itself failed
+        if: |
+          !inputs.dry_run && always() && steps.semantic.outcome == 'failure' &&
+          steps.semantic.outputs.new_release_published != 'true' &&
+          steps.detect-release.outputs.release-published != 'true'
+        run: |
+          echo "::error::Semantic release failed before publishing a new version"
+          exit 1
 
   # Slack notification
   notify:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Ports the backmerge-failure fallback pattern already present in `release.yml` to `typescript-release.yml`, closing the gap that caused issue #202 on TypeScript projects (e.g., `plugin-auth`).

**Problem:** The `@saithodev/semantic-release-backmerge@4.0.1` plugin pushes `HEAD` to `develop` after a successful release. When `develop` has diverged from `main` (common after a hotfix), the push is rejected as non-fast-forward and the entire workflow fails — even though the tag/release was already published.

**Fix:** Adopt the same 5-step guard used in `release.yml`:

1. `release-tag-snapshot` captures the latest tag before the release attempt.
2. `Semantic Release` runs with `continue-on-error: true` (only when not in `dry_run`).
3. `release-tag-check` detects whether a new tag was created even if the step failed.
4. `backmerge-pr` fallback opens a backmerge PR when the release was published but the push failed.
5. `Fail if release itself failed` preserves the original failure signal when no release actually happened.

All new steps are gated by `!inputs.dry_run` so `dry_run` semantics are unchanged.

Composite references use floating major tags (`@v1`) per the repo's internal pinning policy.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. All new behavior is additive and gated by the existing `dry_run` input; the happy path (successful push) is unchanged.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — to be validated after merge on `plugin-auth` (TypeScript) when the next release-with-divergence scenario occurs. Can be forced by pointing the caller at `@develop` and creating a deliberate divergence._

## Related Issues

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability with better error handling and detection to avoid missed or duplicated releases.
  * Added pre-release snapshotting and detection steps so the pipeline can recognize a published release even when the main release step fails.
  * Added a fallback to automatically backmerge when a release is detected despite release-step failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->