### PR TITLE
feat(typescript-release): add backmerge PR fallback for divergent develop

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -167,9 +167,15 @@ jobs:
           npm install --save-dev \
             @semantic-release/exec@7.1.0
 
+      # ----------------- Snapshot tags before release -----------------
+      - name: Snapshot tags before release
+        id: pre-tags
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-snapshot@v1.26.1
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         id: semantic
+        continue-on-error: true
         with:
           ci: false
           dry_run: ${{ inputs.dry_run }}
@@ -184,6 +190,45 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+
+      # ----------------- Detect release via git tag -----------------
+      # semantic-release may report failure because of a post-release step
+      # (e.g. the backmerge plugin failing to push when develop has diverged
+      # from main) even though the release itself was published. Compare the
+      # latest semver tag against the snapshot taken before the run to tell
+      # the two scenarios apart.
+      - name: Detect if release was published
+        if: always() && steps.semantic.outcome == 'failure' && inputs.dry_run != true
+        id: detect-release
+        uses: LerianStudio/github-actions-shared-workflows/src/config/release-tag-check@v1.26.1
+        with:
+          previous-tag: ${{ steps.pre-tags.outputs.latest-tag }}
+
+      # ----------------- Backmerge Fallback -----------------
+      # When the release itself succeeded but the automatic backmerge push
+      # failed (typically because develop diverged from main), open a PR to
+      # backmerge the release commit into develop so it can be resolved
+      # manually instead of being silently lost.
+      - name: Backmerge PR fallback
+        if: |
+          always() && steps.semantic.outcome == 'failure' && inputs.dry_run != true && (
+            steps.semantic.outputs.new_release_published == 'true' ||
+            steps.detect-release.outputs.release-published == 'true'
+          )
+        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-pr@v1.26.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          source-branch: ${{ github.ref_name }}
+          version: ${{ steps.semantic.outputs.new_release_version || steps.detect-release.outputs.release-version }}
+
+      - name: Fail if release itself failed
+        if: |
+          always() && steps.semantic.outcome == 'failure' && inputs.dry_run != true &&
+          steps.semantic.outputs.new_release_published != 'true' &&
+          steps.detect-release.outputs.release-published != 'true'
+        run: |
+          echo "::error::Semantic release failed before publishing a new version"
+          exit 1
 
   # Slack notification
   notify:


### PR DESCRIPTION
## Summary

Brings the `typescript-release.yml` workflow to parity with `release.yml` for the "release succeeded, backmerge push failed because develop diverged" scenario.

Today, when `@saithodev/semantic-release-backmerge` can't fast-forward `main` → `develop` after a release, the whole job fails red, the backmerge commit is silently lost, and the fix becomes a manual `git merge` that nobody notices. Go consumers already have a fallback (added in `release.yml`); TypeScript consumers don't. This PR closes that gap.

## What changes

In `.github/workflows/typescript-release.yml`, inside the `publish_release` job:

1. **Snapshot** the latest semver tag before running semantic-release (`release-tag-snapshot`).
2. Mark the Semantic Release step `continue-on-error: true` so the tag check can run afterwards.
3. **Detect** whether a release was actually published after a failed run, by comparing the current latest tag to the snapshot (`release-tag-check`).
4. **Backmerge PR fallback**: if the release went out but the backmerge plugin failed, open (or reuse) a PR from the release source branch into `develop` using the shared `backmerge-pr` composite action.
5. **Preserve red builds** when the release itself failed (no new tag published).

All new steps are gated by `inputs.dry_run != true` so dry-run invocations don't trigger tag checks or open spurious PRs.

## Why this is safe

- Logic and wiring mirror `release.yml` exactly — same composite actions (`release-tag-snapshot`, `release-tag-check`, `backmerge-pr`), same `if:` gates, same app token, same GitHub App permissions.
- The `backmerge-pr` action already de-duplicates: if an open PR with the same `head` → `base` already exists, it exits with a `::notice::` and reuses it.
- Happy path (backmerge push succeeds normally) is unchanged: `steps.semantic.outcome` is `'success'`, all new conditionals evaluate false, no extra steps run.
- Failure path where the release *itself* failed still ends with `exit 1`, so real failures stay visible.

## Scope

Only `typescript-release.yml` is touched. `release.yml` (Go/Helm) already has this logic. `go-release.yml` uses GoReleaser and does not run semantic-release + backmerge, so it's not in scope.

Requested by: @bedatty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the release process with improved error handling and recovery mechanisms to ensure more reliable and resilient deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->