### PR TITLE
fix(helm-update-chart): skip sync PR Slack notification when bot token unset

### DIFF
--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -530,8 +530,32 @@ jobs:
             echo "$COMPONENTS" | jq -r '.[] | "| \(.name) | \(.version) | \(.env_vars | if . == {} then "-" else (. | keys | join(", ")) end) |"'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Send Slack notification
+      # Skip the sync PR Slack notification when the Slack bot token or
+      # channel are not configured. Consumers may enable `slack_notification`
+      # without supplying `SLACK_BOT_TOKEN_HELM` / `SLACK_CHANNEL_DEVOPS`;
+      # in that case we quietly skip instead of firing a curl with an empty
+      # bearer token and surfacing a noisy `::warning::`.
+      - name: Check Slack notification config
+        id: check_slack
         if: ${{ inputs.slack_notification && steps.commit.outputs.has_changes == 'true' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_HELM }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel || secrets.SLACK_CHANNEL_DEVOPS }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "::notice::slack_notification enabled but SLACK_BOT_TOKEN_HELM is not set — skipping Slack notification"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "$SLACK_CHANNEL" ]; then
+            echo "::notice::slack_notification enabled but no Slack channel resolved (inputs.slack_channel / SLACK_CHANNEL_DEVOPS) — skipping Slack notification"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        if: ${{ inputs.slack_notification && steps.commit.outputs.has_changes == 'true' && steps.check_slack.outputs.skip != 'true' }}
         env:
           CHART: ${{ steps.payload.outputs.chart }}
           HAS_NEW_ENV_VARS: ${{ steps.payload.outputs.has_new_env_vars }}


### PR DESCRIPTION
## Summary

The `Send Slack notification` step in `helm-update-chart.yml` fires a `chat.postMessage` call whenever `inputs.slack_notification` is true and a sync PR was opened — even when the Slack bot token and channel haven't actually been configured by the caller.

`SLACK_BOT_TOKEN_HELM` and `SLACK_CHANNEL_DEVOPS` are declared as **optional** secrets on this reusable workflow, so callers can legitimately set `slack_notification: true` without providing them (mid-migration to the shared workflow, forks, environments where the Helm bot isn't provisioned yet). Today that path runs `curl -H 'Authorization: Bearer '` against Slack, gets `invalid_auth`, and prints a `::warning::Failed to send Slack notification` with the raw API response — noise that nobody can act on.

## What changes

- New pre-step `Check Slack notification config` inspects the resolved bot token and channel. If either is empty, it emits a single `::notice::` explaining the skip and sets an output `skip=true`.
- Existing `Send Slack notification` step gates on `steps.check_slack.outputs.skip != 'true'` so it no-ops cleanly when the config is incomplete.

## Why this is safe

- Happy path (both secrets provided): `skip` is `false`, the existing curl runs unchanged.
- Both new conditionals extend — not replace — the current `inputs.slack_notification && has_changes == 'true'` gate, so the Slack path only runs when it used to, and additionally has the token/channel it needs.
- Output is a `::notice::`, not a `::warning::`, because "optional feature disabled by missing config" shouldn't look like a failure in the job summary.

## Scope

Only `helm-update-chart.yml`. `release-notification.yml` already guards on `env.SLACK_WEBHOOK_URL != ''`, and `slack-notify.yml` already guards via a `check_webhook` step — the helm sync PR was the odd one out.

Requested by: @bedatty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability by adding validation for Slack notification configuration, gracefully handling missing or incomplete credentials to prevent notification delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->