### PR TITLE
fix(ci): support golangci-lint v2 module path in installer

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -255,11 +255,17 @@ jobs:
         env:
           GOLANGCI_LINT_VERSION: ${{ inputs.golangci_lint_version }}
         run: |
-          if [[ ! "$GOLANGCI_LINT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$GOLANGCI_LINT_VERSION" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid golangci-lint version: $GOLANGCI_LINT_VERSION (expected format vMAJOR.MINOR.PATCH)"
             exit 1
           fi
-          go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
+          MAJOR="${BASH_REMATCH[1]}"
+          if [[ "$MAJOR" -ge 2 ]]; then
+            MODULE_PATH="github.com/golangci/golangci-lint/v${MAJOR}/cmd/golangci-lint"
+          else
+            MODULE_PATH="github.com/golangci/golangci-lint/cmd/golangci-lint"
+          fi
+          go install "${MODULE_PATH}@${GOLANGCI_LINT_VERSION}"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Detect Makefile lint target


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Corrige regressão no step `Install golangci-lint` de `go-pr-analysis.yml` que impede o uso de `golangci-lint` v2.x pelos consumidores.

No commit `de0d891` (`fix(ci): harden installer and quote refs per CodeRabbit review`) o step foi trocado do installer oficial via `curl ... install.sh` para `go install github.com/golangci/golangci-lint/cmd/golangci-lint@${VERSION}`. Esse path de módulo funciona apenas para `v1.x.x`: a partir de `v2.0.0`, o projeto passou a usar submódulo Go e o path correto é `github.com/golangci/golangci-lint/v2/cmd/golangci-lint`.

Consumidores usando `golangci_lint_version: "v2.x.x"` (e.g. `plugin-br-pix-indirect-btg` em `v2.6.2`) estão falhando com:

```
go: github.com/golangci/golangci-lint/cmd/golangci-lint@v2.6.2: invalid version: unknown revision cmd/golangci-lint/v2.6.2
```

Esta PR extrai o major version da string validada pelo regex (via `BASH_REMATCH`) e escolhe dinamicamente o path do módulo:

- `v1.x.x` → `github.com/golangci/golangci-lint/cmd/golangci-lint`
- `v2.x.x+` → `github.com/golangci/golangci-lint/v${MAJOR}/cmd/golangci-lint`

Mantém todo o hardening anterior (validação regex, env var para mitigar injection).

**Workflow afetado:** `.github/workflows/go-pr-analysis.yml`

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. Versões `v1.x.x` continuam usando o path original; apenas adiciona suporte a `v2.x.x+`.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** falha reproduzida em https://github.com/LerianStudio/plugin-br-pix-indirect-btg/actions/runs/24748299628/job/72411343550?pr=525 (PR #525 usando `@v1.26.2` com `golangci_lint_version: v2.6.2`). Após merge e release, será validado atualizando essa PR para consumir a nova tag.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline's linting installation logic to better support major-version module paths, ensuring proper tool installation across different versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->