### PR TITLE
fix(build): remove major version tag alias

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,6 @@ jobs:
           images: ${{ steps.image-names.outputs.images }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
-            type=semver,pattern={{major}},value=${{ steps.version.outputs.version }},enable=${{ needs.prepare.outputs.is_release }}
 
       - name: Build and push Docker image
         id: build-push


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Removes the `type=semver,pattern={{major}}` tag from `docker/metadata-action` in `.github/workflows/build.yml`. This tag generated a rolling `vX` alias (e.g. `v1`) on every release, which conflicts with Docker registry immutability: each release tries to overwrite the existing major alias and fails, forcing maintainers to disable immutability on the registry.

Since the `vX` alias is not consumed anywhere in our pipelines, dropping it lets us keep immutability enabled and only publish the full semantic version tag (`vX.Y.Z`).

**Affected workflow:** `build.yml` (reusable).

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

Callers that relied on the floating `vX` tag (e.g. `lerianstudio/my-app:v1`) to always point at the latest `v1.*.*` release will no longer receive that alias. Pin to the full version (`v1.2.3`) instead.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be validated on next release build after merge_

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging configuration in the build workflow to simplify major version tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->