### PR TITLE
fix(build): disable automatic latest tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,6 +290,8 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ steps.image-names.outputs.images }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`docker/metadata-action` defaults to `flavor: latest=auto`, which automatically stamps `:latest` on the image whenever the current semver is the highest one seen. With registry immutability enabled, every release after the first fails with:

```
denied: requested access to the resource is denied - tag latest is already
assigned to an image in this repository and cannot be updated due to
immutability settings.
```

This PR sets `flavor: latest=false` so only the explicit semver tag (`v1.2.3`) is produced, matching the previous cleanup of the `{{major}}` alias in #254.

**Affected workflow:** `build.yml` (reusable) — Docker metadata step.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

Callers that relied on the floating `:latest` tag (e.g. `lerianstudio/my-app:latest` always pointing at the newest release) will no longer receive it. Pin to the full semver tag (`vX.Y.Z`) instead.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be validated on the next release build after merge_

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image metadata generation to prevent automatic `latest` tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->