### PR TITLE
fix(branch-cleanup): avoid SIGPIPE when checking branch protection

### DIFF
--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -91,6 +91,7 @@ runs:
         deleted=0
         skipped=0
         protected_count=0
+        protection_failures=0
         has_pr=0
         page=1
 
@@ -119,7 +120,7 @@ runs:
                 ;;
               *)
                 echo "::warning::Unexpected HTTP '$protection_status' checking protection for '$branch' — skipping"
-                skipped=$((skipped + 1))
+                protection_failures=$((protection_failures + 1))
                 continue
                 ;;
             esac
@@ -167,9 +168,10 @@ runs:
 
         echo ""
         echo "--- Summary ---"
-        echo "Protected : $protected_count"
-        echo "Active    : $skipped"
-        echo "Has PR    : $has_pr"
+        echo "Protected         : $protected_count"
+        echo "Active            : $skipped"
+        echo "Has PR            : $has_pr"
+        echo "Protection errors : $protection_failures"
         if [[ "$DRY_RUN" == "true" ]]; then
           echo "To delete : $deleted"
           echo "::notice::DRY RUN complete — $deleted branch(es) would be deleted"

--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -103,9 +103,8 @@ runs:
             fi
 
             # Check if branch has GitHub branch protection rules
-            status_code=$(gh api -i "repos/${{ github.repository }}/branches/${branch}/protection" \
-              2>/dev/null | head -1 | awk '{print $2}')
-            if [[ "$status_code" == "200" ]]; then
+            if gh api "repos/${{ github.repository }}/branches/${branch}/protection" \
+                 --silent >/dev/null 2>&1; then
               protected_count=$((protected_count + 1))
               [[ "$DRY_RUN" == "true" ]] && echo "  [protected-rule] $branch"
               continue

--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -108,8 +108,17 @@ runs:
 
             # Check GitHub branch protection rules — parse HTTP status to
             # distinguish 200 (protected) / 404 (unprotected) / other (abort branch).
+            # Stderr is merged so network/auth errors are visible in the log, but we
+            # only trust the numeric code from a proper `HTTP/X.X NNN` status line.
             protection_response=$(gh api -i "repos/${GH_REPO}/branches/${branch}/protection" 2>&1 || true)
-            read -r _ protection_status _ <<< "${protection_response%%$'\n'*}"
+            protection_status=""
+            while IFS= read -r response_line; do
+              if [[ "$response_line" =~ ^HTTP/[^[:space:]]+[[:space:]]+([0-9]{3}) ]]; then
+                protection_status="${BASH_REMATCH[1]}"
+                break
+              fi
+            done <<< "$protection_response"
+
             case "$protection_status" in
               200)
                 protected_count=$((protected_count + 1))
@@ -117,6 +126,11 @@ runs:
                 continue
                 ;;
               404)
+                ;;
+              "")
+                echo "::warning::Unable to parse protection status for '$branch' — skipping"
+                protection_failures=$((protection_failures + 1))
+                continue
                 ;;
               *)
                 echo "::warning::Unexpected HTTP '$protection_status' checking protection for '$branch' — skipping"

--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -31,6 +31,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
         MERGED_BRANCH: ${{ inputs.merged-branch }}
         DRY_RUN: ${{ inputs.dry-run }}
         PROTECTED_BRANCHES: ${{ inputs.protected-branches }}
@@ -57,7 +58,7 @@ runs:
         fi
 
         echo "Deleting merged branch '$MERGED_BRANCH'..."
-        gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${MERGED_BRANCH}" \
+        gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${MERGED_BRANCH}" \
           && echo "::notice::Deleted merged branch '$MERGED_BRANCH'" \
           || echo "::warning::Branch '$MERGED_BRANCH' not found or already deleted"
 
@@ -67,6 +68,8 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
+        REPO_OWNER: ${{ github.repository_owner }}
         STALE_DAYS: ${{ inputs.stale-days }}
         DRY_RUN: ${{ inputs.dry-run }}
         PROTECTED_BRANCHES: ${{ inputs.protected-branches }}
@@ -92,7 +95,7 @@ runs:
         page=1
 
         while :; do
-          branches=$(gh api "repos/${{ github.repository }}/branches?per_page=100&page=${page}" \
+          branches=$(gh api "repos/${GH_REPO}/branches?per_page=100&page=${page}" \
             --jq '.[].name' 2>/dev/null)
           [[ -z "$branches" ]] && break
 
@@ -102,16 +105,27 @@ runs:
               continue
             fi
 
-            # Check if branch has GitHub branch protection rules
-            if gh api "repos/${{ github.repository }}/branches/${branch}/protection" \
-                 --silent >/dev/null 2>&1; then
-              protected_count=$((protected_count + 1))
-              [[ "$DRY_RUN" == "true" ]] && echo "  [protected-rule] $branch"
-              continue
-            fi
+            # Check GitHub branch protection rules — parse HTTP status to
+            # distinguish 200 (protected) / 404 (unprotected) / other (abort branch).
+            protection_response=$(gh api -i "repos/${GH_REPO}/branches/${branch}/protection" 2>&1 || true)
+            read -r _ protection_status _ <<< "${protection_response%%$'\n'*}"
+            case "$protection_status" in
+              200)
+                protected_count=$((protected_count + 1))
+                [[ "$DRY_RUN" == "true" ]] && echo "  [protected-rule] $branch"
+                continue
+                ;;
+              404)
+                ;;
+              *)
+                echo "::warning::Unexpected HTTP '$protection_status' checking protection for '$branch' — skipping"
+                skipped=$((skipped + 1))
+                continue
+                ;;
+            esac
 
             # Get last commit date
-            last_commit_date=$(gh api "repos/${{ github.repository }}/commits?sha=${branch}&per_page=1" \
+            last_commit_date=$(gh api "repos/${GH_REPO}/commits?sha=${branch}&per_page=1" \
               --jq '.[0].commit.committer.date' 2>/dev/null)
 
             if [[ -z "$last_commit_date" ]]; then
@@ -126,7 +140,7 @@ runs:
             fi
 
             # Check for open PRs using this branch as head
-            open_prs=$(gh api "repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${branch}&per_page=1" \
+            open_prs=$(gh api "repos/${GH_REPO}/pulls?state=open&head=${REPO_OWNER}:${branch}&per_page=1" \
               --jq 'length' 2>/dev/null)
 
             if [[ "$open_prs" -gt 0 ]]; then
@@ -139,7 +153,7 @@ runs:
               echo "  [stale] $branch (last commit: $last_commit_date) — would delete"
               deleted=$((deleted + 1))
             else
-              if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null; then
+              if gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${branch}" 2>/dev/null; then
                 echo "  Deleted: $branch (last commit: $last_commit_date)"
                 deleted=$((deleted + 1))
               else


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Every scheduled run of `self-branch-cleanup.yml` since 2026-03-23 has failed with exit code 141 (SIGPIPE). The stale-branch scan in the `branch-cleanup` composite action checks branch protection via:

```bash
status_code=$(gh api -i ".../protection" 2>/dev/null | head -1 | awk '{print $2}')
```

GitHub Actions runs bash with `--noprofile --norc -e -o pipefail`. On the first iterated branch, `head -1` closes the pipe early, `gh api` receives SIGPIPE and exits 141, `pipefail` propagates it, and `set -e` kills the job — no branches ever get processed.

This PR replaces the pipeline with a direct exit-code test using `gh api --silent`, which returns 0 on 2xx and non-zero on 404, without any pipe. The merged-branch mode was not affected and is unchanged.

Affected:
- `src/config/branch-cleanup/action.yml` (stale-branch protection check)

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [ ] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** will be added after dispatching `self-branch-cleanup.yml` with `dry_run=true` against this branch post-merge (requires `branch-cleanup.yml` to bump the composite ref to a release that includes this fix).

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved branch protection checks to more reliably detect protected vs unprotected branches and to skip branches when protection checks fail, emitting warnings.
  * Standardized repository reference handling across automation requests for consistent behavior.
  * Revised summary reporting to include "Protection errors" alongside protected/active/has-PR counts for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->