### PR TITLE
fix(stale): use external refs for reusable workflow composition

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   stale-pr:
     name: Stale PRs
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@develop
     with:
       days_before_stale: ${{ inputs.days_before_pr_stale }}
       days_before_close: ${{ inputs.days_before_pr_close }}
@@ -62,7 +62,7 @@ jobs:
 
   stale-issue:
     name: Stale issues
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@develop
     with:
       days_before_stale: ${{ inputs.days_before_issue_stale }}
       days_before_close: ${{ inputs.days_before_issue_close }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   stale-pr:
     name: Stale PRs
-    uses: ./.github/workflows/stale-pr.yml
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1
     with:
       days_before_stale: ${{ inputs.days_before_pr_stale }}
       days_before_close: ${{ inputs.days_before_pr_close }}
@@ -62,7 +62,7 @@ jobs:
 
   stale-issue:
     name: Stale issues
-    uses: ./.github/workflows/stale-issue.yml
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1
     with:
       days_before_stale: ${{ inputs.days_before_issue_stale }}
       days_before_close: ${{ inputs.days_before_issue_close }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Critical fix flagged on the develop → main release PR #265. `stale.yml` is a reusable workflow (`workflow_call`) consumed externally. Its inner jobs were using local sibling paths:

```yaml
uses: ./.github/workflows/stale-pr.yml
uses: ./.github/workflows/stale-issue.yml
```

Local `./` paths in a reusable workflow resolve to the **caller's** workspace, not this repo. External consumers of `stale.yml` (released in v1.26.4) would fail because those sibling files don't exist in their own repos.

Swap to external refs pinned to the floating major tag:

```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1
```

Matches the convention documented in `/gha` and the pattern already used by every other reusable in this repo. The inverse suggestion (asking for local refs) was rejected in PR #261 for exactly this reason.

## Type of Change

- [ ] `feat`
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None — fixes an already-broken external consumption path.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** the fix will be validated end-to-end when the release containing `stale-pr.yml` / `stale-issue.yml` / updated `stale.yml` is promoted to the `v1` floating tag.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated stale pull request and issue management to use externally maintained reusable workflows (now pinned to the develop ref), preserving existing inputs and secret inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->