### PR TITLE
refactor(self-routine): tighten triggers per routine

### DIFF
--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -85,8 +85,8 @@ jobs:
     secrets: inherit
 
   # ----------------- Labels Sync -----------------
-  # Push-to-main fires when a merge to main changes `.github/labels.yml`.
-  # Other merges (to develop or any branch) do not trigger labels_sync.
+  # Push-to-main fires when `.github/labels.yml` changes (merge commit or direct push).
+  # Pushes/merges to non-main branches do not trigger labels_sync.
 
   labels_sync:
     name: Sync labels

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -53,7 +53,6 @@ jobs:
     name: Clean stale branches
     if: |
       (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1')
-      || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
     uses: ./.github/workflows/branch-cleanup.yml
     with:
@@ -67,7 +66,6 @@ jobs:
     name: Close stale PRs
     if: |
       (github.event_name == 'schedule' && github.event.schedule == '0 4 * * *')
-      || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
     uses: ./.github/workflows/stale-pr.yml
     with:
@@ -80,7 +78,6 @@ jobs:
     name: Close stale issues
     if: |
       (github.event_name == 'schedule' && github.event.schedule == '30 4 * * 3')
-      || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
     uses: ./.github/workflows/stale-issue.yml
     with:
@@ -88,13 +85,14 @@ jobs:
     secrets: inherit
 
   # ----------------- Labels Sync -----------------
+  # Push-to-main fires when a merge to main changes `.github/labels.yml`.
+  # Other merges (to develop or any branch) do not trigger labels_sync.
 
   labels_sync:
     name: Sync labels
     if: |
       github.event_name == 'push'
       || (github.event_name == 'schedule' && github.event.schedule == '0 5 * * 0')
-      || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
     uses: ./.github/workflows/labels-sync.yml
     with:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Reshape the `self-routine.yml` trigger matrix so each routine only runs when it genuinely needs to. Previously every merged PR fired the stale scans and labels sync — wasteful, noisy, and for labels_sync it was firing on every develop merge too.

### New matrix

| Job | Schedule | `pull_request.closed` | `push` main | Dispatch |
|---|:---:|:---:|:---:|:---:|
| `branch_cleanup_merged` | — | ✅ delete source branch | — | — |
| `branch_cleanup_stale` | Mon 03:00 UTC | — | — | ✅ |
| `stale_pr` | daily 04:00 UTC | — | — | ✅ |
| `stale_issue` | Wed 04:30 UTC | — | — | ✅ |
| `labels_sync` | Sun 05:00 UTC | — | ✅ (labels.yml changed) | ✅ |
| `workflow_runs_cleanup` | monthly 1st 06:00 UTC | — | — | ✅ |

After every merge only `branch_cleanup_merged` auto-fires; everything else is scheduled (cron) or manual (dispatch). `labels_sync` keeps its push-to-main trigger scoped to `.github/labels.yml` — a label change merged to `main` syncs immediately, develop merges don't.

Any routine can still be triggered on demand after a specific merge via `workflow_dispatch` with the `routine` selector.

## Type of Change

- [ ] `feat`
- [ ] `fix`
- [ ] `perf`
- [x] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. This workflow is a `self-*` entrypoint (internal only) — no external callers.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** will be validated via a dispatch of `routine=all dry_run=true` after merge; merge behavior is observable from the next PR that merges (only `branch_cleanup_merged` should fire).

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted routine automation trigger conditions in CI workflows.
  * Removed merged-PR-based triggers from several maintenance jobs.
  * Clarified that label synchronization runs in response to updates to the label configuration (pushes), not merged PR events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->