### PR TITLE
fix(composites): labels-sync input rename + workflow-runs-cleanup default pattern

### DIFF
--- a/.github/workflows/workflow-runs-cleanup.yml
+++ b/.github/workflows/workflow-runs-cleanup.yml
@@ -14,10 +14,10 @@ on:
         type: number
         default: 10
       delete_workflow_pattern:
-        description: Glob pattern matching workflow filenames to target (default all)
+        description: Workflow name or filename to target (empty = all workflows)
         required: false
         type: string
-        default: "*"
+        default: ""
       delete_run_by_conclusion_pattern:
         description: Comma-separated run conclusions to target, or ALL
         required: false

--- a/docs/workflow-runs-cleanup.md
+++ b/docs/workflow-runs-cleanup.md
@@ -13,7 +13,7 @@ Reusable workflow that deletes old GitHub Actions workflow runs. Wraps the [`wor
 |---|---|:---:|---|
 | `retention_days` | Delete runs older than this many days | No | `90` |
 | `keep_minimum_runs` | Minimum runs to retain per workflow | No | `10` |
-| `delete_workflow_pattern` | Workflow name or filename to target (empty = all) | No | `""` |
+| `delete_workflow_pattern` | Workflow name or filename to target (empty = all; literal substring match, wildcards do not expand) | No | `""` |
 | `delete_run_by_conclusion_pattern` | Comma-separated conclusions to target, or `ALL` | No | `ALL` |
 | `delete_workflow_by_state_pattern` | Comma-separated states to target, or `ALL` | No | `ALL` |
 | `dry_run` | Preview deletions without applying them | No | `false` |

--- a/docs/workflow-runs-cleanup.md
+++ b/docs/workflow-runs-cleanup.md
@@ -13,7 +13,7 @@ Reusable workflow that deletes old GitHub Actions workflow runs. Wraps the [`wor
 |---|---|:---:|---|
 | `retention_days` | Delete runs older than this many days | No | `90` |
 | `keep_minimum_runs` | Minimum runs to retain per workflow | No | `10` |
-| `delete_workflow_pattern` | Glob pattern matching workflow filenames | No | `*` |
+| `delete_workflow_pattern` | Workflow name or filename to target (empty = all) | No | `""` |
 | `delete_run_by_conclusion_pattern` | Comma-separated conclusions to target, or `ALL` | No | `ALL` |
 | `delete_workflow_by_state_pattern` | Comma-separated states to target, or `ALL` | No | `ALL` |
 | `dry_run` | Preview deletions without applying them | No | `false` |

--- a/src/config/labels-sync/action.yml
+++ b/src/config/labels-sync/action.yml
@@ -25,9 +25,9 @@ runs:
       uses: actions/checkout@v6
 
     - name: Sync labels
-      uses: crazy-max/ghaction-github-labeler@v5
+      uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
       with:
         github-token: ${{ inputs.github-token }}
-        config: ${{ inputs.config }}
+        yaml-file: ${{ inputs.config }}
         dry-run: ${{ inputs.dry-run }}
         skip-delete: ${{ inputs.skip-delete }}

--- a/src/config/labels-sync/action.yml
+++ b/src/config/labels-sync/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Sync labels
       uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0

--- a/src/config/workflow-runs-cleanup/README.md
+++ b/src/config/workflow-runs-cleanup/README.md
@@ -14,7 +14,7 @@ Composite action that deletes old GitHub Actions workflow runs to keep the repos
 | `github-token` | GitHub token with `actions:write` | Yes | — |
 | `retention-days` | Delete runs older than this many days | No | `90` |
 | `keep-minimum-runs` | Minimum runs to retain per workflow | No | `10` |
-| `delete-workflow-pattern` | Workflow name or filename to target (empty = all) | No | `""` |
+| `delete-workflow-pattern` | Workflow name or filename to target (empty = all; literal substring match, wildcards do not expand) | No | `""` |
 | `delete-run-by-conclusion-pattern` | Comma-separated conclusions to target, or `ALL` | No | `ALL` |
 | `delete-workflow-by-state-pattern` | Comma-separated states to target, or `ALL` | No | `ALL` |
 | `dry-run` | Preview deletions without applying them | No | `false` |

--- a/src/config/workflow-runs-cleanup/README.md
+++ b/src/config/workflow-runs-cleanup/README.md
@@ -14,7 +14,7 @@ Composite action that deletes old GitHub Actions workflow runs to keep the repos
 | `github-token` | GitHub token with `actions:write` | Yes | — |
 | `retention-days` | Delete runs older than this many days | No | `90` |
 | `keep-minimum-runs` | Minimum runs to retain per workflow | No | `10` |
-| `delete-workflow-pattern` | Glob pattern matching workflow filenames | No | `*` |
+| `delete-workflow-pattern` | Workflow name or filename to target (empty = all) | No | `""` |
 | `delete-run-by-conclusion-pattern` | Comma-separated conclusions to target, or `ALL` | No | `ALL` |
 | `delete-workflow-by-state-pattern` | Comma-separated states to target, or `ALL` | No | `ALL` |
 | `dry-run` | Preview deletions without applying them | No | `false` |

--- a/src/config/workflow-runs-cleanup/action.yml
+++ b/src/config/workflow-runs-cleanup/action.yml
@@ -14,9 +14,12 @@ inputs:
     required: false
     default: "10"
   delete-workflow-pattern:
-    description: Glob pattern matching workflow file names to target (default all)
+    description: |
+      Workflow name or filename to target. Leave empty (default) to target all
+      workflows — the action treats any value, including `*`, as a literal
+      substring match, so wildcards do not expand.
     required: false
-    default: "*"
+    default: ""
   delete-run-by-conclusion-pattern:
     description: |
       Comma-separated run conclusions to target.


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Two composite bugs surfaced by the first real `self-routine` dispatch.

### 1. `labels-sync` — `config` input warning

The upstream `crazy-max/ghaction-github-labeler` renamed its input from `config` to `yaml-file` in v6. Every run was emitting:

> ⚠ `##[warning]Unexpected input(s) 'config', valid inputs are ['yaml-file', 'skip-delete', 'dry-run', 'exclude', 'github-token']`

Map the composite's public `config` input (kept for backward compat) to the action's `yaml-file` input. Also bumped the pin from mutable `@v5` to the v6.0.0 commit SHA (`548a7c3603594ec17c819e1239f281a3b801ab4d`), matching the repo's third-party pinning policy.

### 2. `workflow-runs-cleanup` — default pattern never matched

`Mattraks/delete-workflow-runs` treats `delete_workflow_pattern` as a **literal substring match**, not a glob. The previous default `"*"` matched zero workflow filenames — even with plenty of old runs to purge, the action reported:

> 💬 `found total of 0 workflow(s)`

Change the composite, the reusable, and the docs default to the empty string `""`, which the action interprets as "all workflows". Updated the description to document the substring-match semantics.

## Type of Change

- [ ] `feat`
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None for the public contract of either composite. The `labels-sync` composite still accepts `config` as input (internally mapped). The `workflow-runs-cleanup` composite's `delete-workflow-pattern` default changed from `"*"` to `""`, but the previous default silently matched zero workflows — any caller depending on that behavior was already broken.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** will be validated via the next `self-routine` dispatch after merge — expected outcome: no "Unexpected input(s) 'config'" warning and `workflow-runs-cleanup` reports the full workflow count, not zero.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow cleanup docs: input now targets a workflow by name or filename; empty value means “all.”

* **Updates**
  * Pattern matching changed from glob/wildcard to literal name/filename matching.
  * Default behavior: empty input targets all workflows (instead of using "*").
  * Improved stability by pinning action versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->