### PR TITLE
fix(routines): unpin branch-cleanup and labels-sync composites to @v1

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -47,11 +47,8 @@ jobs:
     name: Clean up branches
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Run branch cleanup
-        uses: LerianStudio/github-actions-shared-workflows/src/config/branch-cleanup@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/branch-cleanup@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           stale-days: ${{ inputs.stale_days }}

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Sync labels
-        uses: LerianStudio/github-actions-shared-workflows/src/config/labels-sync@v1.18.0
+        uses: LerianStudio/github-actions-shared-workflows/src/config/labels-sync@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: ${{ inputs.config || '.github/labels.yml' }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Two production-visible bugs persisted after their fixes shipped on `@v1.26.4` / `@v1.27.2` because the reusable workflows were still pinning the composites to the pre-fix `@v1.18.0` tag. This PR moves both pins to the floating `@v1` major tag so the latest composite code is consumed.

### Bug 1 — `branch_cleanup_stale` exit 141 (SIGPIPE)

`.github/workflows/branch-cleanup.yml` consumed `src/config/branch-cleanup@v1.18.0`. That tag predates PR #260 which fixed the SIGPIPE in the stale scan. Every scheduled run failed with:

> `##[error]Process completed with exit code 141.`

### Bug 2 — `labels_sync` "Unexpected input(s) 'config'"

`.github/workflows/labels-sync.yml` consumed `src/config/labels-sync@v1.18.0`. That tag predates PR #271 which mapped the composite's `config` input to the action's renamed `yaml-file` input. Every run logged:

> ⚠ `Unexpected input(s) 'config', valid inputs are ['yaml-file', 'skip-delete', 'dry-run', 'exclude', 'github-token']`

### Fix

Change both refs from `@v1.18.0` to `@v1` — the repo's documented convention for internal composite consumption and the pattern already used by `stale-pr.yml` / `stale-issue.yml` / `workflow-runs-cleanup.yml`. Also drop the now-redundant `actions/checkout` step from `branch-cleanup.yml` (API-only composite).

## Type of Change

- [ ] `feat`
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. Both reusables keep the same `workflow_call` contract. Only the internal composite pin changes.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** will be validated by the next `self-routine` dispatch after merge — expected outcome: `branch_cleanup_stale` completes without SIGPIPE, `labels_sync` no longer emits the `config` input warning.

## Related Issues

Closes #