### PR TITLE
fix(branch-cleanup): grant administration:read for protection lookup

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -41,6 +41,10 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  # Required so `gh api .../branches/{branch}/protection` returns 200/404
+  # instead of 403 — without this scope every branch is "skipped" with an
+  # `Unexpected HTTP '403'` warning and nothing is ever deleted.
+  administration: read
 
 jobs:
   cleanup:

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -36,6 +36,9 @@ permissions:
   pull-requests: write
   issues: write
   actions: write
+  # Branch cleanup reads `branches/{branch}/protection`; without
+  # `administration: read` the call returns 403 and every branch is skipped.
+  administration: read
 
 jobs:
   # ----------------- Branch Cleanup -----------------


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `branch_cleanup_stale` job is now succeeding, but every branch is being skipped with:

> `##[warning]Unexpected HTTP '403' checking protection for '<branch>' — skipping`

Root cause: `gh api .../branches/{branch}/protection` requires the GITHUB_TOKEN to have the **`administration`** scope (read is enough). The reusable workflow only declared `contents: write` + `pull-requests: read`, so every protection lookup hit a 403, the composite's HTTP-status switch landed on the `*` (unexpected) case, and the branch was preserved.

Add `administration: read` to:

- `.github/workflows/branch-cleanup.yml` — the reusable's permissions block, which is what the running token actually carries.
- `.github/workflows/self-routine.yml` — the self-* caller's block, so `secrets: inherit` propagates the scope to the reusable.

The composite's existing 200/404/* handling is unchanged; the `*` case will just stop firing under normal operation.

## Type of Change

- [ ] `feat`
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated via the next `self-routine` dispatch — expected outcome: no `Unexpected HTTP '403'` warnings; protected branches return 200, unprotected ones return 404, and the deletion path runs against the real candidates.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable branch cleanup operations across automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->