### PR TITLE
feat(stale): pre-flight scope banner before actions/stale per-item log

### DIFF
--- a/src/config/stale/action.yml
+++ b/src/config/stale/action.yml
@@ -85,9 +85,14 @@ runs:
         fi
 
         # Count items via dedicated endpoints so the numbers are precise.
-        pr_count=$(gh api "repos/${GH_REPO}/pulls?state=open&per_page=100" --jq 'length' 2>/dev/null || echo "?")
-        issue_count=$(gh api "repos/${GH_REPO}/issues?state=open&per_page=100" \
-          --jq '[.[] | select(.pull_request == null)] | length' 2>/dev/null || echo "?")
+        # `--paginate --slurp` returns an array of pages; aggregate across
+        # all pages so the count isn't capped at 100 on large repos.
+        pr_count=$(gh api --paginate --slurp \
+          "repos/${GH_REPO}/pulls?state=open&per_page=100" \
+          --jq 'map(length) | add' 2>/dev/null || echo "?")
+        issue_count=$(gh api --paginate --slurp \
+          "repos/${GH_REPO}/issues?state=open&per_page=100" \
+          --jq '[.[][] | select(.pull_request == null)] | length' 2>/dev/null || echo "?")
 
         echo "::notice title=Stale scan scope::${scope}"
         echo "::notice title=Open items in ${GH_REPO}::${pr_count} pull request(s), ${issue_count} issue(s)"

--- a/src/config/stale/action.yml
+++ b/src/config/stale/action.yml
@@ -53,6 +53,60 @@ inputs:
 runs:
   using: composite
   steps:
+    # ----------------- Pre-flight Scope Banner -----------------
+    # actions/stale logs every item as "Issue #N" because it iterates the
+    # unified `/issues` API, where pull requests are a subtype of issue.
+    # That terminology can mislead a reader of the log into thinking the
+    # PR-only or issue-only job is acting on the wrong type. This banner
+    # states the actual scope (decided by the `-1` toggles) and the real
+    # repo counts before actions/stale runs, so the per-item logs that
+    # follow can be read in context.
+    - name: Announce stale scan scope
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ github.repository }}
+        DAYS_BEFORE_PR_STALE: ${{ inputs.days-before-pr-stale }}
+        DAYS_BEFORE_ISSUE_STALE: ${{ inputs.days-before-issue-stale }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        pr_disabled="false"; issue_disabled="false"
+        [ "$DAYS_BEFORE_PR_STALE" = "-1" ] && pr_disabled="true"
+        [ "$DAYS_BEFORE_ISSUE_STALE" = "-1" ] && issue_disabled="true"
+
+        if [ "$pr_disabled" = "true" ] && [ "$issue_disabled" = "true" ]; then
+          scope="nothing — both sides disabled"
+        elif [ "$pr_disabled" = "true" ]; then
+          scope="issues only (PRs disabled via days-before-pr-stale=-1)"
+        elif [ "$issue_disabled" = "true" ]; then
+          scope="pull requests only (issues disabled via days-before-issue-stale=-1)"
+        else
+          scope="pull requests AND issues"
+        fi
+
+        # Count items via dedicated endpoints so the numbers are precise.
+        pr_count=$(gh api "repos/${GH_REPO}/pulls?state=open&per_page=100" --jq 'length' 2>/dev/null || echo "?")
+        issue_count=$(gh api "repos/${GH_REPO}/issues?state=open&per_page=100" \
+          --jq '[.[] | select(.pull_request == null)] | length' 2>/dev/null || echo "?")
+
+        echo "::notice title=Stale scan scope::${scope}"
+        echo "::notice title=Open items in ${GH_REPO}::${pr_count} pull request(s), ${issue_count} issue(s)"
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "::notice title=Dry run::No labels or comments will be applied (debug-only mode)"
+        fi
+
+        cat <<'NOTE'
+
+        Reading the per-item log below:
+          • actions/stale uses the unified /issues API, so every item is
+            announced as "Issue #N" — even pull requests.
+          • Internally the tool checks isPullRequest and routes each item
+            to the matching rule set (days-before-pr-* vs days-before-issue-*).
+          • Items of a type whose days-before-*-stale is -1 are listed but
+            never marked, commented on, or closed.
+
+        NOTE
+
     - name: Flag and close stale PRs and issues
       uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `stale_pr` and `stale_issue` jobs are routed correctly — the `-1` toggles ensure each one only acts on its own type. But `actions/stale` logs every item as `Issue #N` (pull requests included, since the GitHub `/issues` API treats PRs as a subtype of issue), which makes a quick read of the run logs look like the PR job is touching issues and vice versa.

Add a pre-flight banner inside the `stale` composite that emits a few `::notice::` annotations before `actions/stale` runs:

- **Scope** — derived from the `-1` toggles: "pull requests only", "issues only", "both", or "nothing".
- **Real open-item counts** — pulled from dedicated endpoints (`/pulls` and `/issues` filtered to non-PR), so the run shows up front whether there is anything of the relevant type in the repo.
- **A short note** explaining why the per-item log that follows says `Issue #N` for everything — so the rest of the output reads correctly in context.

### Example annotation output

```
::notice title=Stale scan scope::pull requests only (issues disabled via days-before-issue-stale=-1)
::notice title=Open items in LerianStudio/github-actions-shared-workflows::0 pull request(s), 11 issue(s)
::notice title=Dry run::No labels or comments will be applied (debug-only mode)
```

After this, the user reading the run sees: "stale-pr scope is PRs only, repo has 0 open PRs — nothing will be processed", instead of needing to mentally translate every `Issue #N` line.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. Purely additive — the new step runs once before `actions/stale` and only produces log output.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated via the next `self-routine` dispatch — expected: stale-pr run shows scope `"pull requests only"` and counts `0 PR / 11 issue`, with the explanatory note above the per-item log.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-flight checks that compute the effective stale scan scope from configured thresholds and report counts of matching open PRs and issues.
  * Outputs clear workflow notices summarizing scope, repository item counts, dry-run status, and a note explaining how disabled item types are listed (not acted on) and why some items appear as “Issue #N.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->