### PR TITLE
fix(branch-cleanup): list protected branches via ?protected filter (no admin scope)

### DIFF
--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -104,8 +104,16 @@ runs:
         protected_set=""
         proto_page=1
         while :; do
-          proto_chunk=$(gh api "repos/${GH_REPO}/branches?protected=true&per_page=100&page=${proto_page}" \
-            --jq '.[].name' 2>/dev/null)
+          # Don't suppress stderr — a transient gh failure must not look like
+          # the natural end-of-pagination case (exit 0 + empty stdout). If
+          # the call fails we must abort, not silently leave protected_set
+          # empty: that would let `is_protected_by_rule` return false for
+          # every branch and rule-protected branches would be deleted.
+          if ! proto_chunk=$(gh api "repos/${GH_REPO}/branches?protected=true&per_page=100&page=${proto_page}" \
+              --jq '.[].name'); then
+            echo "::error::Failed to list rule-protected branches (page ${proto_page}); aborting to avoid unsafe deletions."
+            exit 1
+          fi
           [[ -z "$proto_chunk" ]] && break
           protected_set+="${proto_chunk}"$'\n'
           proto_page=$((proto_page + 1))

--- a/src/config/branch-cleanup/action.yml
+++ b/src/config/branch-cleanup/action.yml
@@ -91,9 +91,31 @@ runs:
         deleted=0
         skipped=0
         protected_count=0
-        protection_failures=0
         has_pr=0
         page=1
+
+        # Pre-fetch the list of protected branch names once. The
+        # `?protected=true` filter on /branches returns only names that have
+        # branch-protection rules and only requires `contents: read` — unlike
+        # /branches/{branch}/protection, which needs the `administration`
+        # scope (not exposable via the workflow `permissions:` block on
+        # GITHUB_TOKEN). Membership lookups against this set replace the
+        # per-branch protection probe.
+        protected_set=""
+        proto_page=1
+        while :; do
+          proto_chunk=$(gh api "repos/${GH_REPO}/branches?protected=true&per_page=100&page=${proto_page}" \
+            --jq '.[].name' 2>/dev/null)
+          [[ -z "$proto_chunk" ]] && break
+          protected_set+="${proto_chunk}"$'\n'
+          proto_page=$((proto_page + 1))
+        done
+
+        is_protected_by_rule() {
+          local branch="$1"
+          [[ -z "$protected_set" ]] && return 1
+          grep -Fxq -- "$branch" <<< "$protected_set"
+        }
 
         while :; do
           branches=$(gh api "repos/${GH_REPO}/branches?per_page=100&page=${page}" \
@@ -106,38 +128,11 @@ runs:
               continue
             fi
 
-            # Check GitHub branch protection rules — parse HTTP status to
-            # distinguish 200 (protected) / 404 (unprotected) / other (abort branch).
-            # Stderr is merged so network/auth errors are visible in the log, but we
-            # only trust the numeric code from a proper `HTTP/X.X NNN` status line.
-            protection_response=$(gh api -i "repos/${GH_REPO}/branches/${branch}/protection" 2>&1 || true)
-            protection_status=""
-            while IFS= read -r response_line; do
-              if [[ "$response_line" =~ ^HTTP/[^[:space:]]+[[:space:]]+([0-9]{3}) ]]; then
-                protection_status="${BASH_REMATCH[1]}"
-                break
-              fi
-            done <<< "$protection_response"
-
-            case "$protection_status" in
-              200)
-                protected_count=$((protected_count + 1))
-                [[ "$DRY_RUN" == "true" ]] && echo "  [protected-rule] $branch"
-                continue
-                ;;
-              404)
-                ;;
-              "")
-                echo "::warning::Unable to parse protection status for '$branch' — skipping"
-                protection_failures=$((protection_failures + 1))
-                continue
-                ;;
-              *)
-                echo "::warning::Unexpected HTTP '$protection_status' checking protection for '$branch' — skipping"
-                protection_failures=$((protection_failures + 1))
-                continue
-                ;;
-            esac
+            if is_protected_by_rule "$branch"; then
+              protected_count=$((protected_count + 1))
+              [[ "$DRY_RUN" == "true" ]] && echo "  [protected-rule] $branch"
+              continue
+            fi
 
             # Get last commit date
             last_commit_date=$(gh api "repos/${GH_REPO}/commits?sha=${branch}&per_page=1" \
@@ -182,10 +177,9 @@ runs:
 
         echo ""
         echo "--- Summary ---"
-        echo "Protected         : $protected_count"
-        echo "Active            : $skipped"
-        echo "Has PR            : $has_pr"
-        echo "Protection errors : $protection_failures"
+        echo "Protected : $protected_count"
+        echo "Active    : $skipped"
+        echo "Has PR    : $has_pr"
         if [[ "$DRY_RUN" == "true" ]]; then
           echo "To delete : $deleted"
           echo "::notice::DRY RUN complete — $deleted branch(es) would be deleted"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Replaces the per-branch protection probe in the `branch-cleanup` composite with a single up-front listing of rule-protected branches. Closes the loop on the 403 errors observed in production runs and supersedes #277, which proposed adding `administration: read` to the workflow permissions — actionlint correctly rejects that scope (the GITHUB_TOKEN permission set doesn't include `administration`).

### Before

```bash
gh api -i "repos/${GH_REPO}/branches/${branch}/protection"
```

This endpoint requires the `administration` scope. Workflow `permissions:` only exposes the documented set (`actions`, `contents`, `pull-requests`, etc.) — `administration` is not on the list, so the probe always returns 403 against the workflow's GITHUB_TOKEN, and every branch is skipped via the `Unexpected HTTP '403'` warning.

### After

```bash
gh api "repos/${GH_REPO}/branches?protected=true & per_page=100 & page=${page}"
```

The `/branches` endpoint with `?protected=true` returns the names of all rule-protected branches and only requires `contents: read`. We page through it once, build a set, and check membership in the per-branch loop:

```bash
is_protected_by_rule() {
  local branch="$1"
  [[ -z "$protected_set" ]] && return 1
  grep -Fxq -- "$branch" <<< "$protected_set"
}
```

The `protection_failures` counter and its summary line are removed — the failure case it tracked can no longer happen.

## Type of Change

- [ ] `feat`
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated by next `self-routine` dispatch. Expected: no 403/`Unexpected HTTP` warnings; `Protected` summary count includes both pattern-matched branches and rule-protected branches; deletion path runs against the real candidates.

## Related Issues

Supersedes #277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Branch protection detection now fetches protected branch names once and reuses them, reducing per-branch checks.

* **Changes**
  * Workflow fails immediately if the protected-branch listing cannot be retrieved.
  * Removed the protection-errors counter and its summary line from output.
  * Adjusted spacing of labels in the summary metrics display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->