### PR TITLE
refactor(self-routine): collapse to a single weekly cron firing all jobs

### DIFF
--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -70,6 +70,11 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
     uses: ./.github/workflows/stale-pr.yml
     with:
+      # Schedule is weekly here, so we raise the per-run budget from the
+      # reusable's daily-sized default (60) to roughly a week's worth (420)
+      # — keeps stale/close throughput equivalent to the pre-unified-cron
+      # cadence even if the open-PR backlog grows past 60 items.
+      operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 
@@ -82,6 +87,10 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
     uses: ./.github/workflows/stale-issue.yml
     with:
+      # Same rationale as stale_pr — bump the weekly-scheduled budget to
+      # match the pre-refactor daily refresh, so issue throughput isn't
+      # gated by the 60-op default when running once a week.
+      operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -70,10 +70,6 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
     uses: ./.github/workflows/stale-pr.yml
     with:
-      # Schedule is weekly here, so we raise the per-run budget from the
-      # reusable's daily-sized default (60) to roughly a week's worth (420)
-      # — keeps stale/close throughput equivalent to the pre-unified-cron
-      # cadence even if the open-PR backlog grows past 60 items.
       operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
@@ -87,10 +83,6 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
     uses: ./.github/workflows/stale-issue.yml
     with:
-      # Same rationale as stale_pr — bump the weekly-scheduled budget to
-      # match the pre-refactor daily refresh, so issue throughput isn't
-      # gated by the 60-op default when running once a week.
-      operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -2,11 +2,12 @@ name: Self — Repository Routines
 
 on:
   schedule:
-    - cron: "0 3 * * 1"   # weekly Mon 03:00 UTC  — branch cleanup (stale scan)
-    - cron: "0 4 * * *"   # daily 04:00 UTC        — stale PRs
-    - cron: "30 4 * * 3"  # weekly Wed 04:30 UTC   — stale issues
-    - cron: "0 5 * * 0"   # weekly Sun 05:00 UTC   — labels sync (reconciliation)
-    - cron: "0 6 1 * *"   # monthly 1st 06:00 UTC  — workflow runs cleanup
+    # Single weekly cron — every Monday at 03:00 UTC fires every routine in
+    # the same workflow run. Stale/cleanup actions are idempotent: any item
+    # that doesn't meet the threshold is logged and skipped, so running them
+    # together once a week is the simplest mental model with no real cost
+    # over staggered cadences.
+    - cron: "0 3 * * 1"
   pull_request:
     types: [closed]
   push:
@@ -52,7 +53,7 @@ jobs:
   branch_cleanup_stale:
     name: Clean stale branches
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1')
+      github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
     uses: ./.github/workflows/branch-cleanup.yml
     with:
@@ -65,7 +66,7 @@ jobs:
   stale_pr:
     name: Close stale PRs
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '0 4 * * *')
+      github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
     uses: ./.github/workflows/stale-pr.yml
     with:
@@ -77,7 +78,7 @@ jobs:
   stale_issue:
     name: Close stale issues
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '30 4 * * 3')
+      github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
     uses: ./.github/workflows/stale-issue.yml
     with:
@@ -92,7 +93,7 @@ jobs:
     name: Sync labels
     if: |
       github.event_name == 'push'
-      || (github.event_name == 'schedule' && github.event.schedule == '0 5 * * 0')
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
     uses: ./.github/workflows/labels-sync.yml
     with:
@@ -104,7 +105,7 @@ jobs:
   workflow_runs_cleanup:
     name: Delete old workflow runs
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '0 6 1 * *')
+      github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
     uses: ./.github/workflows/workflow-runs-cleanup.yml
     with:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Each routine had its own cron expression, producing fragmented runs scattered across the Actions tab — branch cleanup at Mon 03:00, stale PRs daily at 04:00, stale issues Wed 04:30, labels sync Sun 05:00, workflow runs cleanup monthly at 06:00. Hard to skim.

Collapse to a single weekly cron — `0 3 * * 1` (Monday 03:00 UTC) — that fires the entire workflow once a week. Every job's schedule gate becomes just `github.event_name == 'schedule'`, so all routines now run together in the same run.

### Why this is fine

- `actions/stale` and the cleanup composites are idempotent. Items that don't meet the threshold are listed and skipped — no side effect from running more often than strictly needed.
- A weekly cadence for stale-pr (vs. daily) is acceptable for this repo's volume. If a faster PR cycle is needed later, add a second cron with a job-level `if` gating only `stale_pr`.
- All other triggers are unchanged: `branch_cleanup_merged` still runs on every merged PR, `labels_sync` still runs on `push` to main when `.github/labels.yml` changes, and every job is still dispatchable individually via `workflow_dispatch.routine`.

## Type of Change

- [ ] `feat`
- [ ] `fix`
- [ ] `perf`
- [x] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. Self-* file, internal-only.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated via the next scheduled Monday 03:00 UTC firing — expected: a single workflow run that contains every routine job side-by-side.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated maintenance workflow to a single weekly Monday schedule for more consistent runs.
  * Scheduled jobs now execute on any schedule-triggered workflow run rather than matching an exact cron string.
  * Increased capacity for scheduled maintenance runs while preserving non-schedule triggers and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->