### PR TITLE
feat(stale): collapse actions/stale verbose log + add custom summary

### DIFF
--- a/src/config/stale/action.yml
+++ b/src/config/stale/action.yml
@@ -100,19 +100,13 @@ runs:
           echo "::notice title=Dry run::No labels or comments will be applied (debug-only mode)"
         fi
 
-        cat <<'NOTE'
-
-        Reading the per-item log below:
-          • actions/stale uses the unified /issues API, so every item is
-            announced as "Issue #N" — even pull requests.
-          • Internally the tool checks isPullRequest and routes each item
-            to the matching rule set (days-before-pr-* vs days-before-issue-*).
-          • Items of a type whose days-before-*-stale is -1 are listed but
-            never marked, commented on, or closed.
-
-        NOTE
+        # Open a collapsible group around the verbose actions/stale per-item
+        # output that follows. The group is closed in the post-run summary
+        # step. Readers see the noisy log collapsed by default in the UI.
+        echo "::group::actions/stale per-item log (verbose; expand to inspect)"
 
     - name: Flag and close stale PRs and issues
+      id: stale
       uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:
         repo-token: ${{ inputs.github-token }}
@@ -139,3 +133,32 @@ runs:
           Closing this PR due to prolonged inactivity. Reopen if work resumes.
         close-issue-message: >-
           Closing this issue due to prolonged inactivity. Reopen if it is still relevant.
+
+    # ----------------- Post-run Summary -----------------
+    # Closes the collapsible group opened in the pre-flight step and emits
+    # a clean, deduplicated summary derived from the action's outputs so
+    # readers don't have to scan the verbose log to know what happened.
+    - name: Summarize stale scan outcome
+      if: always()
+      shell: bash
+      env:
+        STALED: ${{ steps.stale.outputs.staled-issues-prs }}
+        CLOSED: ${{ steps.stale.outputs.closed-issues-prs }}
+      run: |
+        echo "::endgroup::"
+        echo ""
+
+        count_csv() {
+          local csv="$1"
+          [ -z "$csv" ] && { echo 0; return; }
+          # Items are comma-separated; awk avoids subshell + tr cost.
+          awk -v s="$csv" 'BEGIN { n = split(s, a, ","); print n }'
+        }
+
+        staled_count=$(count_csv "$STALED")
+        closed_count=$(count_csv "$CLOSED")
+
+        echo "::notice title=Stale scan summary::Marked stale: ${staled_count} | Closed: ${closed_count}"
+        [ -n "$STALED" ] && echo "  Marked stale: ${STALED}"
+        [ -n "$CLOSED" ] && echo "  Closed: ${CLOSED}"
+        echo ""

--- a/src/config/stale/action.yml
+++ b/src/config/stale/action.yml
@@ -142,11 +142,20 @@ runs:
       if: always()
       shell: bash
       env:
+        STALE_OUTCOME: ${{ steps.stale.outcome }}
         STALED: ${{ steps.stale.outputs.staled-issues-prs }}
         CLOSED: ${{ steps.stale.outputs.closed-issues-prs }}
       run: |
         echo "::endgroup::"
         echo ""
+
+        # When actions/stale didn't succeed, its outputs are empty for the
+        # wrong reason — reporting 0 marked / 0 closed would lie about the
+        # state of the run. Surface the real outcome instead.
+        if [ "$STALE_OUTCOME" != "success" ]; then
+          echo "::warning title=Stale scan summary unavailable::actions/stale outcome=${STALE_OUTCOME}; counts are not reliable."
+          exit 0
+        fi
 
         count_csv() {
           local csv="$1"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`actions/stale` emits a verbose per-item log that labels every item as `Issue #N` even when the item is a pull request — the GitHub API treats PRs as a subtype of issue, and the action mirrors that in its log. Our pre-flight banner already announces scope and counts, but the noisy section that follows still required reading to know the actual outcome.

Wrap the action's output in a collapsible `::group::` and add a clean post-run summary:

- **Pre-flight step** opens `::group::actions/stale per-item log (verbose; expand to inspect)` after emitting the scope/count notices.
- **`actions/stale` step** runs unchanged (just adds an `id: stale`).
- **Post-run summary step** runs with `if: always()`, closes the group, and emits a single `::notice title=Stale scan summary::Marked stale: N | Closed: N` derived from the action's `staled-issues-prs` / `closed-issues-prs` outputs. If non-empty, the affected item lists are echoed below the notice.

### Net log shape

```
::notice title=Stale scan scope::pull requests only (issues disabled via days-before-issue-stale=-1)
::notice title=Open items in <repo>::0 pull request(s), 11 issue(s)
::notice title=Dry run::No labels or comments will be applied (debug-only mode)

▶ actions/stale per-item log (verbose; expand to inspect)        ← collapsed by default

::notice title=Stale scan summary::Marked stale: 0 | Closed: 0
```

The verbose log isn't deleted — just collapsed. One click to expand for debugging.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`
- [ ] `perf`
- [ ] `refactor`
- [ ] `docs`
- [ ] `ci`
- [ ] `chore`
- [ ] `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None — purely cosmetic improvement to log output. `actions/stale` invocation and inputs are unchanged.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated via the next `self-routine` dispatch — expected: scope/count notices at top, verbose section collapsed, summary notice at bottom with marked/closed counts.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workflow output for stale checks now uses collapsible groups for cleaner logs.
  * Added a consolidated summary that reports "Marked stale" and "Closed" totals and optionally shows detailed lists.
  * Runs a final step that always executes, emits a warning on failure, and exits early when the stale check did not succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->