### PR TITLE
chore(release): skip release on self-* workflow changes

### DIFF
--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -17,6 +17,7 @@ on:
       # The deployment matrix is resolved from main at runtime by callers, so
       # matrix-only changes propagate without a new release tag.
       - 'config/deployment-matrix.yml'
+      - '.github/workflows/self-*.yml'
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds `.github/workflows/self-*.yml` to the `paths-ignore` filter of the `self-release.yml` push trigger. `self-*` workflows are internal entrypoints for this repo only and are not consumed by external callers — changes to them don't alter the public contract of reusable workflows or composites, so they shouldn't trigger a new release/tag.

Affected workflow: `.github/workflows/self-release.yml`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — change only narrows the trigger filter on this repo's release entrypoint.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow configuration to prevent self-triggering on workflow file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->