### PR TITLE
chore(routine): tighten stale thresholds and document routine

### DIFF
--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -57,7 +57,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
     uses: ./.github/workflows/branch-cleanup.yml
     with:
-      stale_days: 30
+      stale_days: 20
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 
@@ -70,6 +70,8 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
     uses: ./.github/workflows/stale-pr.yml
     with:
+      days_before_stale: 20
+      days_before_close: 7
       operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
@@ -83,6 +85,8 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
     uses: ./.github/workflows/stale-issue.yml
     with:
+      days_before_stale: 30
+      days_before_close: 7
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,66 @@ Releases follow [Semantic Versioning](https://semver.org/) via [semantic-release
 - Merges to `develop` → beta pre-release (`v1.2.3-beta.1`)
 - Merges to `main` → stable release (`v1.2.3`)
 
+## Repository Routines
+
+This repository runs a consolidated weekly routine (`.github/workflows/self-routine.yml`) that keeps issues, pull requests, branches, labels, and workflow runs tidy. All scheduled jobs run in a single workflow run on **Mondays at 03:00 UTC**.
+
+### Schedule
+
+| Trigger | When | What it runs |
+|---|---|---|
+| `schedule` | Mondays 03:00 UTC | Branch cleanup, stale PRs, stale issues, labels sync, workflow runs cleanup |
+| `pull_request: closed` | On every PR merge | Delete the merged feature branch |
+| `push` to `main` (`.github/labels.yml`) | On label config change | Sync labels to the repo |
+| `workflow_dispatch` | Manual | Run any single routine or all of them, with a `dry_run` toggle |
+
+### Jobs
+
+#### Branch cleanup (`branch_cleanup_stale`)
+Deletes branches with no commits for **20 days**. Protected patterns (`main`, `master`, `develop`, `release/*`, `hotfix/*`) are never touched. A separate job (`branch_cleanup_merged`) deletes feature branches the moment a PR is merged.
+
+#### Stale PRs (`stale_pr`)
+- A PR with no activity for **20 days** receives a comment and the `stale` label.
+- After **7 more days** of inactivity, it is closed with a closing comment.
+- Any new activity (commit, comment, edit) removes the `stale` label and resets the clock.
+- Exempt labels: `no-stale`, `security`, `work-in-progress`, `pinned`. Drafts are also exempt.
+
+#### Stale issues (`stale_issue`)
+- An issue with no activity for **30 days** receives a comment and the `stale` label.
+- After **7 more days** of inactivity, it is closed.
+- Exempt labels: `no-stale`, `security`, `pinned`.
+
+#### Labels sync (`labels_sync`)
+Reconciles the repository's labels against `.github/labels.yml`. Also fires immediately when that file changes on `main`.
+
+#### Workflow runs cleanup (`workflow_runs_cleanup`)
+Deletes workflow runs older than **90 days** to keep the Actions tab navigable.
+
+### Effective windows
+
+Because the cron runs weekly, items pass through the windows with up to one cron cycle of jitter. The 7-day close window aligns with the cron cadence so items are reliably picked up on the next run.
+
+| Item | Threshold | Effective time to close (best / worst) |
+|---|---|---|
+| PR | 20 stale + 7 close | 27 / 34 days |
+| Issue | 30 stale + 7 close | 37 / 44 days |
+| Branch | 20 days inactivity | 20 / 27 days |
+
+### Manual runs and dry_run
+
+```yaml
+# Actions → Self — Repository Routines → Run workflow
+# Pick a routine and toggle dry_run (default: true)
+routine: stale-pr | stale-issue | branch-cleanup-stale | labels-sync | workflow-runs-cleanup | all
+dry_run: true | false
+```
+
+In `dry_run: true` mode no labels, comments, branches, or runs are touched — the per-item log under *"actions/stale per-item log"* shows exactly what would happen on a real run.
+
+### Opting out
+
+Add the `no-stale` label to any issue or PR you want to keep open indefinitely. The routine skips it on every scan.
+
 ## AI Assistant Support
 
 Built-in guidance for AI assistants is included so they understand the architecture before making changes.


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Tightens this repository's routine thresholds and documents the consolidated weekly routine in the README.

**Threshold changes** — applied as overrides in `self-routine.yml` only; reusable workflow defaults are unchanged so external consumers of `stale-pr.yml` / `stale-issue.yml` / `branch-cleanup.yml` see no behavior change.

| Item | Before | After |
|---|---|---|
| PR stale | 30 days | 20 days |
| PR close (after stale) | 14 days | 7 days |
| Issue stale | 60 days | 30 days |
| Issue close (after stale) | 14 days | 7 days |
| Branch cleanup | 30 days | 20 days |

The 7-day close window aligns with the weekly cron cadence so items are reliably picked up on the next run (effective max time to close: PR 34d, Issue 44d, Branch 27d).

**README** — adds a "Repository Routines" section covering schedule, per-job description, effective windows table, manual run / `dry_run` usage, and opt-out via the `no-stale` label.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Threshold changes are scoped to `self-routine.yml` overrides only — reusable workflow defaults remain at the previous values for external callers.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — change is internal to this repo's `self-routine.yml` and README.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for the weekly automated repository maintenance workflow, including schedule, event triggers, and operational behavior.

* **Chores**
  * Tightened staleness thresholds for automated branch cleanup, pull requests, and issues to improve repository maintenance frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->