### PR TITLE
chore(routine): reduce workflow runs retention to 45 days

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ None.
 <!-- Shared workflows can't be unit-tested locally. Describe how you validated the change. -->
 
 - [ ] YAML syntax validated locally
-- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
+- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
 - [ ] Verified all existing inputs still work with default values
 - [ ] Confirmed no secrets or tokens are printed in logs
 - [ ] Checked that unrelated workflows are not affected

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -114,6 +114,6 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
     uses: ./.github/workflows/workflow-runs-cleanup.yml
     with:
-      retention_days: 90
+      retention_days: 45
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ Deletes branches with no commits for **20 days**. Protected patterns (`main`, `m
 Reconciles the repository's labels against `.github/labels.yml`. Also fires immediately when that file changes on `main`.
 
 #### Workflow runs cleanup (`workflow_runs_cleanup`)
-Deletes workflow runs older than **90 days** to keep the Actions tab navigable.
+Deletes old workflow runs from the Actions tab to keep history navigable. Two guards must both be satisfied for a run to be deleted:
+
+- The run is older than **45 days** (`retention_days`).
+- After deletion, the workflow still has at least **10 runs** retained (`keep_minimum_runs`).
+
+The minimum-runs floor protects rarely-triggered workflows (e.g. release backmerges) from having their entire history wiped. By default all workflows, all conclusions (`success`, `failure`, `cancelled`), and all states (active, disabled) are eligible — adjust via `delete_workflow_pattern`, `delete_run_by_conclusion_pattern`, and `delete_workflow_by_state_pattern` if you call the reusable workflow directly.
 
 ### Effective windows
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Reduces workflow runs retention from 90 to 45 days for this repository, and expands the README documentation for the cleanup job to cover its safeguards and defaults.

**Threshold change** — applied as override in `self-routine.yml` only; the `workflow-runs-cleanup.yml` reusable workflow default remains at 90 for external callers.

| Item | Before | After |
|---|---|---|
| Workflow runs retention | 90 days | 45 days |

The `keep_minimum_runs: 10` floor still applies — rarely-triggered workflows (e.g. release backmerges) are not affected even with the shorter retention.

**README** — expands the "Workflow runs cleanup" entry with:
- Two-guard deletion logic (age threshold AND minimum-runs floor)
- Why the minimum-runs floor matters
- Default filter behavior (all workflows, all conclusions, all states)
- Pointers to the reusable workflow inputs for callers wanting different filters

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The retention change is scoped to `self-routine.yml` overrides — the reusable `workflow-runs-cleanup.yml` default remains 90 days for external callers.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — change is internal to this repo's `self-routine.yml` and README.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced workflow run cleanup retention from 90 to 45 days.
  * Updated PR template guidance to instruct using the current feature branch for testing.

* **Documentation**
  * Clarified retention policy to require both age-based eligibility (>45 days) and a minimum preserved-run floor (≥10) to prevent wiping rarely used workflow history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->