### PR TITLE
feat(matrix): register plugin-bc-correios in deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -49,6 +49,7 @@ apps:
     - plugin-br-pix-indirect-btg
     - plugin-br-bank-transfer     # generic build (firmino + clotilde)
     - plugin-br-bank-transfer-jd  # JD-specific build (anacleto only)
+    - plugin-bc-correios
 
     # Clotilde-exclusive Lerian platform suite
     - backoffice-console
@@ -72,6 +73,7 @@ clusters:
       - plugin-br-pix-direct-jd
       - plugin-br-pix-indirect-btg
       - plugin-br-bank-transfer
+      - plugin-bc-correios
 
   clotilde:
     apps:
@@ -87,6 +89,7 @@ clusters:
       - plugin-br-pix-direct-jd
       - plugin-br-pix-indirect-btg
       - plugin-br-bank-transfer
+      - plugin-bc-correios
       - backoffice-console
       - cs-platform
       - forge


### PR DESCRIPTION
## Summary

- Add `plugin-bc-correios` to `apps.registry`
- Add to `firmino` cluster (deploy_in_firmino: true in app build.yml)
- Add to `clotilde` cluster (deploy_in_clotilde: true in app build.yml)

## Context

The plugin-bc-correios v1.2.0 build succeeded but the gitops-update workflow
failed with `App 'plugin-bc-correios' is not registered in any cluster of the
deployment matrix`. This PR fixes the registration so future releases auto-deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Correios plugin is now available for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->