### PR TITLE
feat(trivy-fs-scan): expose ignorefile input for path-scoped suppression

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -103,7 +103,7 @@ on:
         description: 'Comma-separated list of PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only.'
         type: string
         default: 'release-candidate,main'
-      ignorefile:
+      ignore_file:
         description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml for path-scoped suppression of secrets/vulnerabilities)'
         type: string
         required: false
@@ -187,7 +187,7 @@ jobs:
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
-          ignorefile: ${{ inputs.ignorefile }}
+          ignore-file: ${{ inputs.ignore_file }}
 
       # ----------------- Docker Build -----------------
       - name: Build Docker Image for Scanning

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -103,6 +103,11 @@ on:
         description: 'Comma-separated list of PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only.'
         type: string
         default: 'release-candidate,main'
+      ignorefile:
+        description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml for path-scoped suppression of secrets/vulnerabilities)'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   actions: read         # Required for CodeQL status reporting
@@ -182,6 +187,7 @@ jobs:
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
+          ignorefile: ${{ inputs.ignorefile }}
 
       # ----------------- Docker Build -----------------
       - name: Build Docker Image for Scanning

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -199,6 +199,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `codeql_upload_sarif` | boolean | `false` | Upload CodeQL SARIF results to the GitHub Security tab. Requires Code Security (GHAS) enabled on the repo |
 | `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
 | `prerelease_block_branches` | string | `release-candidate,main` | Comma-separated PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only |
+| `ignore_file` | string | `''` | Path to Trivy ignore file (e.g., `.trivyignore.yaml`) for path-scoped suppression of secrets and vulnerabilities. Passed through to `trivy-fs-scan` via `--ignorefile`. Supports Trivy's structured YAML format with `paths:` constraints |
 
 ## Secrets
 

--- a/src/security/trivy-fs-scan/README.md
+++ b/src/security/trivy-fs-scan/README.md
@@ -16,6 +16,7 @@ Composite action that runs Trivy filesystem scans for secrets and vulnerabilitie
 | `skip-dirs` | Comma-separated directories to skip during scanning | No | `.git,node_modules,dist,build,.next,coverage,vendor` |
 | `trivy-version` | Trivy version to install | No | `v0.69.3` |
 | `exit-code-secret-scan` | Exit code when secrets are found in table output (`1` to fail, `0` to warn only) | No | `1` |
+| `ignorefile` | Path to Trivy ignore file (e.g., `.trivyignore.yaml` for path-scoped suppression) | No | `''` |
 
 ## Outputs
 
@@ -46,7 +47,7 @@ jobs:
 
       - name: Trivy Filesystem Scan
         id: fs-scan
-        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.x.x
+        uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1
         with:
           scan-ref: '.'
           app-name: 'my-service'
@@ -56,18 +57,33 @@ jobs:
 
 ```yaml
 - name: Trivy Filesystem Scan
-  uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.x.x
+  uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1
   with:
     scan-ref: ${{ matrix.working_dir }}
     app-name: ${{ matrix.name }}
 ```
 
-### Production usage
+### With path-scoped suppression (ignorefile)
+
+Use `.trivyignore.yaml` to suppress findings only for specific paths (e.g., docs containing sample tokens from third-party specs):
 
 ```yaml
-- uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1.0.0
+- name: Trivy Filesystem Scan
+  uses: LerianStudio/github-actions-shared-workflows/src/security/trivy-fs-scan@v1
   with:
+    scan-ref: '.'
     app-name: my-service
+    ignorefile: .trivyignore.yaml
+```
+
+Example `.trivyignore.yaml`:
+
+```yaml
+vulnerabilities: []
+secrets:
+  - id: jwt-token
+    paths:
+      - docs/specs/openapi-example.yaml
 ```
 
 ## Permissions required

--- a/src/security/trivy-fs-scan/README.md
+++ b/src/security/trivy-fs-scan/README.md
@@ -16,7 +16,7 @@ Composite action that runs Trivy filesystem scans for secrets and vulnerabilitie
 | `skip-dirs` | Comma-separated directories to skip during scanning | No | `.git,node_modules,dist,build,.next,coverage,vendor` |
 | `trivy-version` | Trivy version to install | No | `v0.69.3` |
 | `exit-code-secret-scan` | Exit code when secrets are found in table output (`1` to fail, `0` to warn only) | No | `1` |
-| `ignorefile` | Path to Trivy ignore file (e.g., `.trivyignore.yaml` for path-scoped suppression) | No | `''` |
+| `ignore-file` | Path to Trivy ignore file (e.g., `.trivyignore.yaml` for path-scoped suppression) | No | `''` |
 
 ## Outputs
 
@@ -73,7 +73,7 @@ Use `.trivyignore.yaml` to suppress findings only for specific paths (e.g., docs
   with:
     scan-ref: '.'
     app-name: my-service
-    ignorefile: .trivyignore.yaml
+    ignore-file: .trivyignore.yaml
 ```
 
 Example `.trivyignore.yaml`:

--- a/src/security/trivy-fs-scan/action.yml
+++ b/src/security/trivy-fs-scan/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: 'Exit code when secrets are found in table output (1 to fail, 0 to warn only)'
     required: false
     default: '1'
-  ignorefile:
+  ignore-file:
     description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml for path-scoped suppression)'
     required: false
     default: ''
@@ -48,7 +48,7 @@ runs:
         exit-code: ${{ inputs.exit-code-secret-scan }}
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
-        trivyignores: ${{ inputs.ignorefile }}
+        trivyignores: ${{ inputs.ignore-file }}
         version: ${{ inputs.trivy-version }}
 
     - name: Trivy Secret Scan (SARIF Output)
@@ -63,7 +63,7 @@ runs:
         exit-code: '0'
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
-        trivyignores: ${{ inputs.ignorefile }}
+        trivyignores: ${{ inputs.ignore-file }}
         version: ${{ inputs.trivy-version }}
 
     # ----------------- Vulnerability Scanning -----------------
@@ -79,7 +79,7 @@ runs:
         exit-code: '0'
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
-        trivyignores: ${{ inputs.ignorefile }}
+        trivyignores: ${{ inputs.ignore-file }}
         version: ${{ inputs.trivy-version }}
 
     # ----------------- Outputs -----------------

--- a/src/security/trivy-fs-scan/action.yml
+++ b/src/security/trivy-fs-scan/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Exit code when secrets are found in table output (1 to fail, 0 to warn only)'
     required: false
     default: '1'
+  ignorefile:
+    description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml for path-scoped suppression)'
+    required: false
+    default: ''
 
 outputs:
   secret-scan-sarif:
@@ -44,6 +48,7 @@ runs:
         exit-code: ${{ inputs.exit-code-secret-scan }}
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
+        trivyignores: ${{ inputs.ignorefile }}
         version: ${{ inputs.trivy-version }}
 
     - name: Trivy Secret Scan (SARIF Output)
@@ -58,6 +63,7 @@ runs:
         exit-code: '0'
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
+        trivyignores: ${{ inputs.ignorefile }}
         version: ${{ inputs.trivy-version }}
 
     # ----------------- Vulnerability Scanning -----------------
@@ -73,6 +79,7 @@ runs:
         exit-code: '0'
         hide-progress: true
         skip-dirs: ${{ inputs.skip-dirs }}
+        trivyignores: ${{ inputs.ignorefile }}
         version: ${{ inputs.trivy-version }}
 
     # ----------------- Outputs -----------------

--- a/src/security/trivy-fs-scan/action.yml
+++ b/src/security/trivy-fs-scan/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     # ----------------- Secret Scanning -----------------
     - name: Trivy Secret Scan (Table Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: fs
         scanners: secret
@@ -52,7 +52,7 @@ runs:
         version: ${{ inputs.trivy-version }}
 
     - name: Trivy Secret Scan (SARIF Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       if: always()
       with:
         scan-type: fs
@@ -68,7 +68,7 @@ runs:
 
     # ----------------- Vulnerability Scanning -----------------
     - name: Trivy Vulnerability Scan - Filesystem (JSON Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       if: always()
       with:
         scan-type: fs


### PR DESCRIPTION
## Description

Adds an `ignorefile` input to the `trivy-fs-scan` composite and exposes it through `pr-security-scan.yml`, enabling callers to pass a `.trivyignore.yaml` file with path-scoped secret/vuln suppression.

**Problem:** Trivy's structured `.trivyignore.yaml` format (which supports `paths:` constraints) is not auto-discovered by Trivy 0.69.3. Without this input, the only option is global suppression via legacy `.trivyignore`, which would suppress real leaks elsewhere in the repo.

**Solution:** Propagate the `trivyignores` input (maps to `--ignorefile`) to all 3 `aquasecurity/trivy-action` invocations in the composite. Callers can now pass a path-scoped ignore file:

```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-security-scan.yml@develop
with:
  ignorefile: .trivyignore.yaml
```

### What changed

- `src/security/trivy-fs-scan/action.yml`: new `ignorefile` input (`default: ''`), propagated via `trivyignores:` to all 3 Trivy steps
- `.github/workflows/pr-security-scan.yml`: new `ignorefile` input, passed through to the `trivy-fs-scan` composite step
- `src/security/trivy-fs-scan/README.md`: updated inputs table, standardized refs to `@v1`, added `.trivyignore.yaml` usage example

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` — pending `br-spi` update after merge

**Caller repo / workflow run:** LerianStudio/br-spi PR #4 — workaround via legacy `.trivyignore` currently in place; will validate path-scoped suppression after this lands in develop

## Related Issues

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a Trivy ignore file so filesystem scans can apply path-scoped suppression for vulnerabilities and secrets.

* **Documentation**
  * Updated usage examples, snippets, and workflow inputs to show the ignore-file option and refreshed action reference in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->