### PR TITLE
feat(go-pr-analysis): add system_packages input for CGO repository support

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -84,6 +84,11 @@ on:
         description: 'Number of times to run tests for determinism check'
         type: number
         default: 3
+      system_packages:
+        description: 'Space-separated list of apt packages to install before running Go commands (e.g., "libxml2-dev pkg-config"). Required for CGO repositories that depend on native system libraries.'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -238,6 +243,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -310,6 +323,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -384,6 +405,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -772,6 +801,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -833,6 +870,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -865,6 +910,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -248,8 +248,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -329,8 +330,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -411,8 +413,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -806,8 +809,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -875,8 +879,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -916,8 +921,9 @@ jobs:
         env:
           SYSTEM_PACKAGES: ${{ inputs.system_packages }}
         run: |
+          read -ra PACKAGES <<< "$SYSTEM_PACKAGES"
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends $SYSTEM_PACKAGES
+          sudo apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -113,6 +113,7 @@ jobs:
 | `integration_test_command` | Command to run integration tests | No | `make test-integration` |
 | `enable_test_determinism` | Enable test determinism check (runs tests multiple times with shuffle) | No | `false` |
 | `test_determinism_runs` | Number of times to run tests for determinism check | No | `3` |
+| `system_packages` | Space-separated list of apt packages to install before running Go commands (e.g., `"libxml2-dev pkg-config"`). Required for CGO repositories that depend on native system libraries. Installed in all Go jobs (lint, security, tests, build, integration-tests, test-determinism). | No | `''` |
 
 ### With Private Go Modules
 


### PR DESCRIPTION
## Description

Adds a `system_packages` input to `go-pr-analysis.yml` that installs apt packages before any Go command runs. This enables CGO-dependent repositories (e.g., `br-spi`, `br-spb`) to use the standard shared-workflow pattern instead of maintaining fully custom CI pipelines.

**Problem:** Repos using CGO with native system libraries (e.g., `libxml2-dev`) cannot use `go-pr-analysis.yml` because there is no hook to install system dependencies before `go build`, `golangci-lint`, or `go test` are invoked.

**Solution:** New optional `system_packages` input (default: `''`). When set, a guarded install step runs immediately after checkout in all 6 Go jobs:

```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-analysis.yml@develop
with:
  system_packages: "libxml2-dev pkg-config"
```

### What changed

- `.github/workflows/go-pr-analysis.yml`:
  - New `system_packages` input (`type: string`, `required: false`, `default: ''`)
  - `Install system dependencies` step added to `lint`, `security`, `tests`, `build`, `integration-tests`, and `test-determinism` jobs
  - Step is guarded by `if: inputs.system_packages != ''` — zero overhead for repos without CGO
  - Input value passed via `env: SYSTEM_PACKAGES` (not template interpolation) to prevent script injection
- `docs/go-pr-analysis-workflow.md`: new row in inputs table

### Jobs that do NOT receive the install step

- `detect-changes` — git operations only, no Go compilation
- `coverage` — downloads artifact and runs `go tool cover`, no CGO compilation

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@develop` — pending `br-spi` update after merge

**Caller repo / workflow run:** LerianStudio/br-spi — will validate CGO compilation with `libxml2-dev pkg-config` after this lands in develop

## Related Issues

Closes #297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable system dependencies installation to the Go PR analysis workflow. Developers can now specify space-separated apt packages to install before running Go commands using the new `system_packages` input parameter, supporting projects with CGO or native library requirements.

* **Documentation**
  * Added documentation for the new workflow input configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->