### PR TITLE
feat(matrix): register ungoliant-controller on anacleto

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -110,6 +110,7 @@ clusters:
       - plugin-br-pix-direct-jd
       - plugin-br-pix-indirect-btg
       - plugin-br-bank-transfer-jd
+      - ungoliant-controller
 
   benedita:
     apps:

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -58,6 +58,9 @@ apps:
     - lerian-map
     - tenant-manager
 
+    # Anacleto-exclusive
+    - ungoliant-controller
+
 clusters:
   firmino:
     apps:


### PR DESCRIPTION
## Summary

Adds `ungoliant-controller` to `clusters.anacleto.apps` in `config/deployment-matrix.yml` so the GitOps update job in [`LerianStudio/ungoliant-controller`](https://github.com/LerianStudio/ungoliant-controller) actually targets the anacleto cluster.

## Why

The reusable `gitops-update.yml` resolves target clusters from this manifest. Without an entry, `resolve_clusters` returns empty, `has_clusters=false`, and the kustomize update step is silently skipped.

The kustomize layout support landed in `v1.28.3-beta.1` (issue #312). The consumer is configured against `environments/anacleto/kustomize/ungoliant-controller/kustomization.yaml` in `midaz-firmino-gitops`, with `argocd_app_name_template: "{server}-{app}"` (no env split — single tooling namespace).

## Test plan

- [ ] After merge, tag a beta on `ungoliant-controller` and verify the `update_gitops` job runs `kustomize edit set image` against the anacleto kustomize folder.
- [ ] Verify ArgoCD app `anacleto-ungoliant-controller` syncs to the new tag.

Refs #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment configuration updated to add a new application component to the system infrastructure.
  * The new component was added specifically to the Anacleto deployment target so it will be included in that cluster’s application set going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->