### PR TITLE
feat(routine): add reusable repository-routine workflow

### DIFF
--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -1,0 +1,144 @@
+name: Repository Routines
+
+on:
+  workflow_call:
+    inputs:
+      routine:
+        description: Routine to run (all, branch-cleanup-stale, stale-pr, stale-issue, labels-sync, workflow-runs-cleanup)
+        required: false
+        type: string
+        default: all
+      dry_run:
+        description: Preview changes without applying them
+        required: false
+        type: boolean
+        default: false
+      merged_branch:
+        description: Branch name to delete in merged-PR mode (typically github.head_ref)
+        required: false
+        type: string
+        default: ""
+      branch_stale_days:
+        description: Days without commits before a branch is considered stale
+        required: false
+        type: number
+        default: 20
+      pr_days_before_stale:
+        description: Days of PR inactivity before the stale label is applied
+        required: false
+        type: number
+        default: 20
+      pr_days_before_close:
+        description: Days after a PR is marked stale before it is closed
+        required: false
+        type: number
+        default: 7
+      pr_operations_per_run:
+        description: Maximum API operations per run for stale PR scan
+        required: false
+        type: number
+        default: 60
+      pr_operations_per_run_schedule:
+        description: Maximum API operations per run for stale PR scan when triggered by schedule
+        required: false
+        type: number
+        default: 420
+      issue_days_before_stale:
+        description: Days of issue inactivity before the stale label is applied
+        required: false
+        type: number
+        default: 30
+      issue_days_before_close:
+        description: Days after an issue is marked stale before it is closed
+        required: false
+        type: number
+        default: 7
+      workflow_runs_retention_days:
+        description: Delete workflow runs older than this many days
+        required: false
+        type: number
+        default: 45
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+jobs:
+  # ----------------- Branch Cleanup -----------------
+
+  branch_cleanup_merged:
+    name: Delete merged branch
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && inputs.merged_branch != ''
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@develop
+    with:
+      merged_branch: ${{ inputs.merged_branch }}
+      dry_run: false
+    secrets: inherit
+
+  branch_cleanup_stale:
+    name: Clean stale branches
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@develop
+    with:
+      stale_days: ${{ inputs.branch_stale_days }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  # ----------------- Stale PRs -----------------
+
+  stale_pr:
+    name: Close stale PRs
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@develop
+    with:
+      days_before_stale: ${{ inputs.pr_days_before_stale }}
+      days_before_close: ${{ inputs.pr_days_before_close }}
+      operations_per_run: ${{ github.event_name == 'schedule' && inputs.pr_operations_per_run_schedule || inputs.pr_operations_per_run }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  # ----------------- Stale Issues -----------------
+
+  stale_issue:
+    name: Close stale issues
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@develop
+    with:
+      days_before_stale: ${{ inputs.issue_days_before_stale }}
+      days_before_close: ${{ inputs.issue_days_before_close }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  # ----------------- Labels Sync -----------------
+
+  labels_sync:
+    name: Sync labels
+    if: |
+      github.event_name == 'push'
+      || github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@develop
+    with:
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  # ----------------- Workflow Runs Cleanup -----------------
+
+  workflow_runs_cleanup:
+    name: Delete old workflow runs
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@develop
+    with:
+      retention_days: ${{ inputs.workflow_runs_retention_days }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -2,11 +2,6 @@ name: Self — Repository Routines
 
 on:
   schedule:
-    # Single weekly cron — every Monday at 03:00 UTC fires every routine in
-    # the same workflow run. Stale/cleanup actions are idempotent: any item
-    # that doesn't meet the threshold is logged and skipped, so running them
-    # together once a week is the simplest mental model with no real cost
-    # over staggered cadences.
     - cron: "0 3 * * 1"
   pull_request:
     types: [closed]
@@ -39,81 +34,10 @@ permissions:
   actions: write
 
 jobs:
-  # ----------------- Branch Cleanup -----------------
-
-  branch_cleanup_merged:
-    name: Delete merged branch
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    uses: ./.github/workflows/branch-cleanup.yml
+  routine:
+    uses: ./.github/workflows/routine.yml
     with:
+      routine: ${{ inputs.routine || 'all' }}
+      dry_run: ${{ inputs.dry_run || false }}
       merged_branch: ${{ github.head_ref }}
-      dry_run: false
-    secrets: inherit
-
-  branch_cleanup_stale:
-    name: Clean stale branches
-    if: |
-      github.event_name == 'schedule'
-      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
-    uses: ./.github/workflows/branch-cleanup.yml
-    with:
-      stale_days: 20
-      dry_run: ${{ inputs.dry_run || false }}
-    secrets: inherit
-
-  # ----------------- Stale PRs -----------------
-
-  stale_pr:
-    name: Close stale PRs
-    if: |
-      github.event_name == 'schedule'
-      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
-    uses: ./.github/workflows/stale-pr.yml
-    with:
-      days_before_stale: 20
-      days_before_close: 7
-      operations_per_run: ${{ github.event_name == 'schedule' && 420 || 60 }}
-      dry_run: ${{ inputs.dry_run || false }}
-    secrets: inherit
-
-  # ----------------- Stale Issues -----------------
-
-  stale_issue:
-    name: Close stale issues
-    if: |
-      github.event_name == 'schedule'
-      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
-    uses: ./.github/workflows/stale-issue.yml
-    with:
-      days_before_stale: 30
-      days_before_close: 7
-      dry_run: ${{ inputs.dry_run || false }}
-    secrets: inherit
-
-  # ----------------- Labels Sync -----------------
-  # Push-to-main fires when `.github/labels.yml` changes (merge commit or direct push).
-  # Pushes/merges to non-main branches do not trigger labels_sync.
-
-  labels_sync:
-    name: Sync labels
-    if: |
-      github.event_name == 'push'
-      || github.event_name == 'schedule'
-      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
-    uses: ./.github/workflows/labels-sync.yml
-    with:
-      dry_run: ${{ inputs.dry_run || false }}
-    secrets: inherit
-
-  # ----------------- Workflow Runs Cleanup -----------------
-
-  workflow_runs_cleanup:
-    name: Delete old workflow runs
-    if: |
-      github.event_name == 'schedule'
-      || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
-    uses: ./.github/workflows/workflow-runs-cleanup.yml
-    with:
-      retention_days: 45
-      dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit

--- a/docs/routine.md
+++ b/docs/routine.md
@@ -1,0 +1,146 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>routine</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that orchestrates standard repository maintenance routines: branch cleanup (stale and post-merge), stale PR/issue triage, label synchronization, and workflow runs cleanup.
+
+This is an aggregator — it does not contain logic itself, but dispatches to the underlying reusable workflows based on the caller event and the `routine` input. Use it as the single integration point in consumer repositories instead of wiring each routine workflow individually.
+
+## What it does
+
+| Job | Triggered when | Calls |
+|---|---|---|
+| `branch_cleanup_merged` | `pull_request` closed and merged | `branch-cleanup.yml` (merged mode, `dry_run: false`) |
+| `branch_cleanup_stale` | `schedule` or dispatch with `routine: all\|branch-cleanup-stale` | `branch-cleanup.yml` (stale mode) |
+| `stale_pr` | `schedule` or dispatch with `routine: all\|stale-pr` | `stale-pr.yml` |
+| `stale_issue` | `schedule` or dispatch with `routine: all\|stale-issue` | `stale-issue.yml` |
+| `labels_sync` | `push`, `schedule`, or dispatch with `routine: all\|labels-sync` | `labels-sync.yml` |
+| `workflow_runs_cleanup` | `schedule` or dispatch with `routine: all\|workflow-runs-cleanup` | `workflow-runs-cleanup.yml` |
+
+The caller controls the triggers (schedule cron, push paths, pull_request types, workflow_dispatch inputs). `routine.yml` decides which jobs run based on `github.event_name` and the `routine` input.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|:---:|---|---|
+| `routine` | `string` | No | `all` | Routine to run: `all`, `branch-cleanup-stale`, `stale-pr`, `stale-issue`, `labels-sync`, `workflow-runs-cleanup` |
+| `dry_run` | `boolean` | No | `false` | Preview changes without applying them |
+| `merged_branch` | `string` | No | `""` | Branch to delete in merged-PR mode — typically `${{ github.head_ref }}` |
+| `branch_stale_days` | `number` | No | `20` | Days without commits before a branch is stale |
+| `pr_days_before_stale` | `number` | No | `20` | Days of PR inactivity before the stale label is applied |
+| `pr_days_before_close` | `number` | No | `7` | Days after a PR is marked stale before it is closed |
+| `pr_operations_per_run` | `number` | No | `60` | Maximum API operations per stale PR run (non-schedule events) |
+| `pr_operations_per_run_schedule` | `number` | No | `420` | Maximum API operations per stale PR run on `schedule` |
+| `issue_days_before_stale` | `number` | No | `30` | Days of issue inactivity before the stale label is applied |
+| `issue_days_before_close` | `number` | No | `7` | Days after an issue is marked stale before it is closed |
+| `workflow_runs_retention_days` | `number` | No | `45` | Delete workflow runs older than this many days |
+
+## Secrets
+
+Pass `secrets: inherit` from the caller. Underlying workflows use:
+
+| Secret | Required | Description |
+|---|---|---|
+| `GITHUB_TOKEN` | No | Auto-injected; covers branch cleanup, label sync, workflow runs cleanup |
+| `MANAGE_TOKEN` | No | Preferred for stale PR/issue scans so the bot identity attributes the labels and comments. Falls back to `GITHUB_TOKEN` when absent. |
+
+## Permissions
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+```
+
+## Usage
+
+### Standard caller — full routine setup
+
+Drop this in any consumer repository as `.github/workflows/self-routine.yml`:
+
+```yaml
+name: Self — Repository Routines
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  pull_request:
+    types: [closed]
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:
+    inputs:
+      routine:
+        description: Routine to run
+        type: choice
+        options:
+          - all
+          - branch-cleanup-stale
+          - stale-pr
+          - stale-issue
+          - labels-sync
+          - workflow-runs-cleanup
+        default: all
+      dry_run:
+        description: Preview changes without applying them
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: write
+
+jobs:
+  routine:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1
+    with:
+      routine: ${{ inputs.routine || 'all' }}
+      dry_run: ${{ inputs.dry_run || false }}
+      merged_branch: ${{ github.head_ref }}
+    secrets: inherit
+```
+
+### Customizing thresholds
+
+```yaml
+jobs:
+  routine:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1
+    with:
+      routine: all
+      branch_stale_days: 45
+      pr_days_before_stale: 30
+      pr_days_before_close: 14
+      issue_days_before_stale: 60
+      workflow_runs_retention_days: 90
+      merged_branch: ${{ github.head_ref }}
+    secrets: inherit
+```
+
+### Testing on a feature branch
+
+```yaml
+jobs:
+  routine:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@develop
+    with:
+      routine: all
+      dry_run: true
+      merged_branch: ${{ github.head_ref }}
+    secrets: inherit
+```
+
+## Notes
+
+- The `pull_request` trigger must include `types: [closed]`. The merged-branch job filters for `github.event.pull_request.merged == true` internally.
+- The `push` trigger is intended for `branches: [main]` with `paths: [.github/labels.yml]`. Pushes to other branches do not trigger label sync.
+- Sub-workflows are referenced by major-version tag (`@v1`) so patch and minor updates flow automatically. To freeze, fork the entrypoint and pin to a specific `@vX.Y.Z`.

--- a/instructions/repository-routines.md
+++ b/instructions/repository-routines.md
@@ -86,7 +86,7 @@ If you operate this routine in your repository (or you're configuring it for a n
 - [`docs/labels-sync.md`](../docs/labels-sync.md) — labels sync reference
 - [`docs/workflow-runs-cleanup.md`](../docs/workflow-runs-cleanup.md) — workflow runs cleanup reference
 
-To customize the link the bot posts in stale comments, set the `docs_url` input on the `routine.yml` (or `stale-pr.yml` / `stale-issue.yml`) workflow call. Default points to this page on `main`.
+The link the bot posts in stale comments is set by the `docs-url` input on the `src/config/stale` composite, defaulting to this page on `main`. To customize per repository, expose `docs_url` as a `workflow_call` input on `stale-pr.yml` / `stale-issue.yml` / `routine.yml` and forward it to the composite.
 
 ---
 

--- a/instructions/repository-routines.md
+++ b/instructions/repository-routines.md
@@ -1,0 +1,102 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>Repository Routines — Contributor Guide</h1></td>
+  </tr>
+</table>
+
+> **You probably landed here from a comment on a PR or issue.** This page explains what the automation does, why your item was flagged, and what you can do about it.
+
+## What is "the routine"?
+
+Every Lerian repository runs a single weekly maintenance routine that takes care of housekeeping tasks no one wants to do manually:
+
+| Task | What it does |
+|---|---|
+| **Stale PR scan** | Flags PRs with no activity in 20 days, closes them 7 days later if still untouched |
+| **Stale issue scan** | Flags issues with no activity in 30 days, closes them 7 days later if still untouched |
+| **Branch cleanup (post-merge)** | Deletes the source branch immediately after a PR is merged |
+| **Branch cleanup (stale)** | Deletes branches with no commits for 20 days and no open PR attached |
+| **Labels sync** | Keeps repository labels aligned with `.github/labels.yml` |
+| **Workflow runs cleanup** | Deletes Actions runs older than 45 days |
+
+The routine runs every **Monday at 03:00 UTC**. Operators can tune the thresholds per repository — the values above are the shared defaults.
+
+---
+
+## Why was my PR or issue flagged as stale?
+
+Because nothing happened on it for the inactivity window (20 days for PRs, 30 days for issues). "Activity" means: a new commit, a comment, a label change, a re-request for review, or a reopen. The bot does not look at your calendar — only at the item's event timeline.
+
+### How to keep it open
+
+You have several options:
+
+1. **Just engage with it.** Push a commit, leave a comment, request a review. Any of these resets the inactivity counter and removes the `stale` label automatically.
+2. **Apply the `no-stale` label.** This permanently exempts the item from the routine. Use it for things that are intentionally long-lived: tracking issues, parent epics, planned-but-not-yet-prioritized work.
+3. **Apply one of the other exempt labels.** These also pause the routine:
+   - `security` — security-sensitive items that shouldn't be auto-closed under any circumstances
+   - `work-in-progress` (PRs only) — work explicitly paused, kept for context
+   - `pinned` (issues only) — issues kept on top of the backlog by intent
+
+If none of those fit and you want the item to close, do nothing — closure happens automatically after the second window expires.
+
+### My item was closed but it's still relevant
+
+Reopen it. Stale closure is a soft signal, not a verdict. When you reopen, add a comment explaining the next step (re-scoping, waiting on a dependency, etc.) and apply `no-stale` if it'll sit for a while.
+
+---
+
+## Why was my branch deleted?
+
+Two cases:
+
+**Post-merge deletion.** When a PR is merged, the head branch is deleted immediately. This is the same behavior as GitHub's "Automatically delete head branches" setting — we run it as part of the routine so it works consistently across repos. Your code is preserved in the merge commit; nothing is lost.
+
+**Stale branch sweep.** Branches with no commits in 20+ days **and** no open PR are deleted in the weekly run. Protected branches (`main`, `master`, `develop`, `release/*`, `hotfix/*`) and any branch with GitHub branch protection rules are never touched.
+
+If you need a long-lived working branch:
+
+- Open a draft PR pointing to it — the open PR keeps it alive.
+- Or add it to your repository's protected-branch patterns (ask the maintainers).
+
+If a branch you needed was deleted, the commits are not gone — they're still reachable from any PR, fork, or local clone. Restore it with `git push origin <sha>:<branch-name>`.
+
+---
+
+## Anatomy of a stale comment
+
+When the bot comments on your PR or issue, it tells you:
+
+- **The window that elapsed** — e.g., "no activity for 20 days"
+- **When it will be closed** — e.g., "in 7 days unless updated"
+- **How to keep it open** — applying `no-stale` or activity
+
+Reading the comment is enough to know what to do. This page exists for the broader context.
+
+---
+
+## For maintainers
+
+If you operate this routine in your repository (or you're configuring it for a new one), see the operator documentation:
+
+- [`docs/routine.md`](../docs/routine.md) — reusable workflow inputs, integration patterns, defaults
+- [`docs/stale-pr.md`](../docs/stale-pr.md), [`docs/stale-issue.md`](../docs/stale-issue.md) — individual stale workflow references
+- [`docs/branch-cleanup.md`](../docs/branch-cleanup.md) — branch cleanup reference
+- [`docs/labels-sync.md`](../docs/labels-sync.md) — labels sync reference
+- [`docs/workflow-runs-cleanup.md`](../docs/workflow-runs-cleanup.md) — workflow runs cleanup reference
+
+To customize the link the bot posts in stale comments, set the `docs_url` input on the `routine.yml` (or `stale-pr.yml` / `stale-issue.yml`) workflow call. Default points to this page on `main`.
+
+---
+
+## Summary cheat sheet
+
+| Want to… | Do this |
+|---|---|
+| Keep my PR/issue alive once | Comment, push, or re-request review |
+| Keep my PR/issue alive forever | Apply the `no-stale` label |
+| Keep a security item alive | Apply the `security` label |
+| Pause a PR while preserving it | Apply the `work-in-progress` label |
+| Keep a long-lived branch | Open a draft PR pointing to it |
+| Restore a deleted branch | `git push origin <sha>:<branch>` (commits aren't lost) |

--- a/src/config/stale/action.yml
+++ b/src/config/stale/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: Preview changes without applying them (debug-only mode)
     required: false
     default: "false"
+  docs-url:
+    description: URL appended to stale/close comments so contributors can read about the routine and exempt labels
+    required: false
+    default: "https://github.com/LerianStudio/github-actions-shared-workflows/blob/main/instructions/repository-routines.md"
 
 runs:
   using: composite
@@ -125,14 +129,26 @@ runs:
           This PR has had no activity for ${{ inputs.days-before-pr-stale }} days and is now marked stale.
           It will be closed in ${{ inputs.days-before-pr-close }} days unless updated.
           Add the `no-stale` label to keep it open indefinitely.
+
+
+          Learn more about the routine and exempt labels: ${{ inputs.docs-url }}
         stale-issue-message: >-
           This issue has had no activity for ${{ inputs.days-before-issue-stale }} days and is now marked stale.
           It will be closed in ${{ inputs.days-before-issue-close }} days unless updated.
           Add the `no-stale` label to keep it open indefinitely.
+
+
+          Learn more about the routine and exempt labels: ${{ inputs.docs-url }}
         close-pr-message: >-
           Closing this PR due to prolonged inactivity. Reopen if work resumes.
+
+
+          Learn more about the routine and exempt labels: ${{ inputs.docs-url }}
         close-issue-message: >-
           Closing this issue due to prolonged inactivity. Reopen if it is still relevant.
+
+
+          Learn more about the routine and exempt labels: ${{ inputs.docs-url }}
 
     # ----------------- Post-run Summary -----------------
     # Closes the collapsible group opened in the pre-flight step and emits


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Extracts the orchestration logic from `self-routine.yml` into a new reusable workflow `routine.yml` so consumer repositories can wire all maintenance routines (branch cleanup, stale PR/issue, labels sync, workflow runs cleanup) through a single integration point instead of importing each individual workflow.

Workflows changed:

- **`.github/workflows/routine.yml`** (new) — reusable aggregator with `workflow_call` only, all tunables exposed as inputs (`branch_stale_days`, `pr_days_before_stale`, `pr_days_before_close`, `pr_operations_per_run`, `pr_operations_per_run_schedule`, `issue_days_before_stale`, `issue_days_before_close`, `workflow_runs_retention_days`, `merged_branch`, `routine`, `dry_run`). Sub-workflows referenced via `LerianStudio/.../<name>.yml@develop` while this PR is open — must be flipped to `@v1` before merge.
- **`.github/workflows/self-routine.yml`** — refactored to a thin entrypoint: triggers preserved (schedule, pull_request closed, push to `main` on `.github/labels.yml`, workflow_dispatch), 6 jobs collapsed into a single delegating job that calls `./.github/workflows/routine.yml`.
- **`src/config/stale/action.yml`** — new optional input `docs-url` (default points to `instructions/repository-routines.md` on `main`). Link is appended to stale-PR, stale-issue, close-PR and close-issue comments so contributors learn about the routine and exempt labels directly from the bot's message.
- **`docs/routine.md`** (new) — operator-facing reference: inputs, integration patterns, defaults.
- **`instructions/repository-routines.md`** (new) — contributor-facing guide: what the routine does, how `no-stale` / `security` / `work-in-progress` / `pinned` work, branch deletion behavior and recovery, cheat sheet.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. All new inputs are optional with safe defaults; existing workflows (`stale-pr.yml`, `stale-issue.yml`, etc.) keep their public contract unchanged. Stale comment text gains a trailing link line — visible change but not a contract break.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be added — will dispatch `self-routine.yml` from this branch with `dry_run: true` for each routine option_

**Pre-merge checklist:** flip `routine.yml` sub-workflow refs from `@develop` to `@v1`.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable, centralized repository routines workflow to run and configure maintenance tasks (stale PRs/issues, branch cleanup, label sync, workflow-run cleanup) with a dry-run option and adjustable thresholds.

* **Documentation**
  * Added contributor and usage guides for the routines, scheduling, exemptions, and recovery.
  * Updated stale/close messages to include a "Learn more" documentation link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->