### PR TITLE
feat(routine): expose protected_branches input and pin sub-refs to @v1

### DIFF
--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -58,6 +58,16 @@ on:
         required: false
         type: number
         default: 45
+      protected_branches:
+        description: Comma-separated branch patterns to never delete (full override of default)
+        required: false
+        type: string
+        default: "main,master,develop,release-candidate,hotfix/*"
+      extra_protected_branches:
+        description: Comma-separated branch patterns appended to protected_branches
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -71,9 +81,10 @@ jobs:
   branch_cleanup_merged:
     name: Delete merged branch
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && inputs.merged_branch != ''
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1
     with:
       merged_branch: ${{ inputs.merged_branch }}
+      protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
       dry_run: false
     secrets: inherit
 
@@ -82,9 +93,10 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1
     with:
       stale_days: ${{ inputs.branch_stale_days }}
+      protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
 
@@ -95,7 +107,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1
     with:
       days_before_stale: ${{ inputs.pr_days_before_stale }}
       days_before_close: ${{ inputs.pr_days_before_close }}
@@ -110,7 +122,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1
     with:
       days_before_stale: ${{ inputs.issue_days_before_stale }}
       days_before_close: ${{ inputs.issue_days_before_close }}
@@ -125,7 +137,7 @@ jobs:
       github.event_name == 'push'
       || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1
     with:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
@@ -137,7 +149,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@v1
     with:
       retention_days: ${{ inputs.workflow_runs_retention_days }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -81,7 +81,7 @@ jobs:
   branch_cleanup_merged:
     name: Delete merged branch
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && inputs.merged_branch != ''
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.4
     with:
       merged_branch: ${{ inputs.merged_branch }}
       protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
@@ -93,7 +93,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.4
     with:
       stale_days: ${{ inputs.branch_stale_days }}
       protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
@@ -107,7 +107,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1.28.4
     with:
       days_before_stale: ${{ inputs.pr_days_before_stale }}
       days_before_close: ${{ inputs.pr_days_before_close }}
@@ -122,7 +122,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1.28.4
     with:
       days_before_stale: ${{ inputs.issue_days_before_stale }}
       days_before_close: ${{ inputs.issue_days_before_close }}
@@ -137,7 +137,7 @@ jobs:
       github.event_name == 'push'
       || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.28.4
     with:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
@@ -149,7 +149,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@v1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@v1.28.4
     with:
       retention_days: ${{ inputs.workflow_runs_retention_days }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/self-routine.yml
+++ b/.github/workflows/self-routine.yml
@@ -26,6 +26,14 @@ on:
         description: Preview changes without applying them
         type: boolean
         default: true
+      protected_branches:
+        description: Comma-separated branch patterns to never delete (full override of default)
+        type: string
+        default: "main,master,develop,release-candidate,hotfix/*"
+      extra_protected_branches:
+        description: Comma-separated branch patterns appended to protected_branches
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -40,4 +48,6 @@ jobs:
       routine: ${{ inputs.routine || 'all' }}
       dry_run: ${{ inputs.dry_run || false }}
       merged_branch: ${{ github.head_ref }}
+      protected_branches: ${{ inputs.protected_branches || 'main,master,develop,release-candidate,hotfix/*' }}
+      extra_protected_branches: ${{ inputs.extra_protected_branches || '' }}
     secrets: inherit

--- a/docs/routine.md
+++ b/docs/routine.md
@@ -37,6 +37,8 @@ The caller controls the triggers (schedule cron, push paths, pull_request types,
 | `issue_days_before_stale` | `number` | No | `30` | Days of issue inactivity before the stale label is applied |
 | `issue_days_before_close` | `number` | No | `7` | Days after an issue is marked stale before it is closed |
 | `workflow_runs_retention_days` | `number` | No | `45` | Delete workflow runs older than this many days |
+| `protected_branches` | `string` | No | `main,master,develop,release-candidate,hotfix/*` | Branch patterns the cleanup never deletes — full override |
+| `extra_protected_branches` | `string` | No | `""` | Branch patterns appended to `protected_branches` (use this when you only want to add patterns) |
 
 ## Secrets
 
@@ -122,6 +124,32 @@ jobs:
       pr_days_before_close: 14
       issue_days_before_stale: 60
       workflow_runs_retention_days: 90
+      merged_branch: ${{ github.head_ref }}
+    secrets: inherit
+```
+
+### Adding extra protected branches
+
+Use `extra_protected_branches` when you only want to add patterns to the default and keep the rest:
+
+```yaml
+jobs:
+  routine:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1
+    with:
+      extra_protected_branches: "develop-*,feature-stable"
+      merged_branch: ${{ github.head_ref }}
+    secrets: inherit
+```
+
+Use `protected_branches` to fully override the default (not recommended unless you really need to drop one of the standard patterns):
+
+```yaml
+jobs:
+  routine:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/routine.yml@v1
+    with:
+      protected_branches: "main,trunk,prod-*"
       merged_branch: ${{ github.head_ref }}
     secrets: inherit
 ```

--- a/instructions/repository-routines.md
+++ b/instructions/repository-routines.md
@@ -53,12 +53,12 @@ Two cases:
 
 **Post-merge deletion.** When a PR is merged, the head branch is deleted immediately. This is the same behavior as GitHub's "Automatically delete head branches" setting — we run it as part of the routine so it works consistently across repos. Your code is preserved in the merge commit; nothing is lost.
 
-**Stale branch sweep.** Branches with no commits in 20+ days **and** no open PR are deleted in the weekly run. Protected branches (`main`, `master`, `develop`, `release/*`, `hotfix/*`) and any branch with GitHub branch protection rules are never touched.
+**Stale branch sweep.** Branches with no commits in 20+ days **and** no open PR are deleted in the weekly run. Protected branches (`main`, `master`, `develop`, `release-candidate`, `hotfix/*`) and any branch with GitHub branch protection rules are never touched. Repositories can extend this list — for example, a repo that uses domain-prefixed integration branches like `develop-fetcher` typically passes `extra_protected_branches: "develop-*"` when calling the routine.
 
 If you need a long-lived working branch:
 
 - Open a draft PR pointing to it — the open PR keeps it alive.
-- Or add it to your repository's protected-branch patterns (ask the maintainers).
+- Or ask the maintainers to add the pattern to the repo's `extra_protected_branches` (or `protected_branches`) input on the routine.
 
 If a branch you needed was deleted, the commits are not gone — they're still reachable from any PR, fork, or local clone. Restore it with `git push origin <sha>:<branch-name>`.
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds `protected_branches` and `extra_protected_branches` as `workflow_call` inputs on `routine.yml` (with matching `workflow_dispatch` inputs on `self-routine.yml`), forwarded to both `branch_cleanup_merged` and `branch_cleanup_stale`. Resolves the issue where consumer repos with non-standard long-lived branches (`release-candidate`, `develop-*`, etc.) had to bypass the wrapper and replicate the routine fan-out locally just to override the default.

Default value updated to `main,master,develop,release-candidate,hotfix/*` — drops the legacy `release/*` pattern (no Lerian repo uses it as a long-lived branch today) and adds `release-candidate`. `extra_protected_branches` exists so callers that just need to add a few patterns don't have to copy the full default.

Pins all sub-workflow `uses:` inside `routine.yml` from `@develop` to `@v1`. Consumers calling `routine.yml@v1.X.Y` now get a reproducible composition instead of resolving the floating `develop` branch at runtime.

Files:

- **`.github/workflows/routine.yml`** — 2 new inputs, forward via `format()` concatenation, sub-`uses` flipped to `@v1`.
- **`.github/workflows/self-routine.yml`** — 2 new dispatch inputs, forwarded.
- **`docs/routine.md`** — input table updated, new "Adding extra protected branches" usage section.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

Default `protected_branches` changes from `main,master,develop,release/*,hotfix/*` to `main,master,develop,release-candidate,hotfix/*`. Any repo currently relying on `release/*` being protected must now pass `extra_protected_branches: "release/*"` (or a full `protected_branches` override). At the time of this change, no Lerian repo uses `release/*` as a long-lived branch, so the practical impact is zero — but it is a default change worth flagging.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be added — will dispatch `self-routine.yml` from this branch with custom `extra_protected_branches`_

## Related Issues

Closes #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch-cleanup workflows now accept an extra protected-branches input to extend default protected patterns, and these inputs are exposed when running repository routines.

* **Documentation**
  * Docs and contributor guide updated with input descriptions, examples for appending vs overriding protected branch patterns, and guidance on long-lived/draft branches.

* **Chores**
  * Reusable workflow calls pinned to a stable release to ensure consistent routine behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->