### PR TITLE
fix(gitops-update): correct kustomize download URL

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -193,9 +193,14 @@ jobs:
           KUSTOMIZE_VERSION: ${{ inputs.kustomize_version }}
         run: |
           set -euo pipefail
-          VERSION_NO_V="${KUSTOMIZE_VERSION#v}"
-          URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${VERSION_NO_V}/kustomize_${VERSION_NO_V}_linux_amd64.tar.gz"
-          curl -sSL "$URL" -o /tmp/kustomize.tar.gz
+          # The kustomize release tag is "kustomize/vX.Y.Z" — the "/" must be
+          # URL-encoded as %2F, and the asset filename keeps the "v" prefix.
+          # Stripping "v" or leaving the slash unencoded produces a 404 page,
+          # which then fails extraction with "gzip: stdin: not in gzip format".
+          VERSION="${KUSTOMIZE_VERSION#v}"
+          VERSION="v${VERSION}"
+          URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "$URL" -o /tmp/kustomize.tar.gz
           tar -xzf /tmp/kustomize.tar.gz -C /tmp
           sudo install -m 755 /tmp/kustomize /usr/local/bin/kustomize
           kustomize version


### PR DESCRIPTION
## Description

Fixes the `Install kustomize` step in `.github/workflows/gitops-update.yml` so it actually downloads a valid tarball instead of a 404 HTML page.

The kustomize release tag is `kustomize/vX.Y.Z` — the `/` must be URL-encoded as `%2F`, and the asset filename keeps the `v` prefix. The previous code stripped `v` and left the slash unencoded:

```bash
# Before (broken):
VERSION_NO_V="${KUSTOMIZE_VERSION#v}"
URL=".../kustomize/${VERSION_NO_V}/kustomize_${VERSION_NO_V}_linux_amd64.tar.gz"
# → https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/5.4.3/kustomize_5.4.3_linux_amd64.tar.gz
# → HTTP/2 404 → "gzip: stdin: not in gzip format" → exit 2

# After (fixed):
VERSION="v${KUSTOMIZE_VERSION#v}"
URL=".../kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz"
# → https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.3/kustomize_v5.4.3_linux_amd64.tar.gz
# → HTTP/2 302 (redirects to release-assets CDN)
```

Also adds `curl -f` so HTTP errors fail fast instead of silently writing the 404 body to disk, and normalizes the input so both `v5.4.3` and `5.4.3` work.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. The default `kustomize_version` (`v5.4.3`) and the `5.4.3` form both resolve to the same valid URL.

## Testing

- [x] YAML syntax validated locally
- [x] URL verified directly:
  - Broken form → `HTTP/2 404`
  - Fixed form → `HTTP/2 302` (redirects to GitHub release CDN, content-disposition `kustomize_v5.4.3_linux_amd64.tar.gz`)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Failure that motivated this fix — `LerianStudio/ungoliant-controller` build for tag `v1.0.0`: https://github.com/LerianStudio/ungoliant-controller/actions/runs/25563461718/job/75041865633 (look for `gzip: stdin: not in gzip format`).

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to improve kustomize installation with enhanced version tag handling and optimized artifact download URL construction for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->