### PR TITLE
docs(build): document helm dispatch production-only policy

### DIFF
--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -171,6 +171,47 @@ When `enable_gitops_artifacts: true`:
 
 **Artifact pattern:** `gitops-tags-{app_name}`
 
+## Helm Dispatch
+
+When `enable_helm_dispatch: true`, the workflow dispatches a chart update to the configured Helm repository (default: `LerianStudio/helm`) after a successful build.
+
+### Default policy: production releases only
+
+By default, Helm dispatch runs **only on production release tags** (non-`-rc`, non-`-beta`). This is enforced by:
+
+- `helm_dispatch_on_rc` → `default: false`
+- `helm_dispatch_on_beta` → `default: false`
+
+This is intentional. RC and beta tags are pre-release artifacts — dispatching them to the Helm repo creates noisy PRs in `LerianStudio/helm` for charts that should not roll forward to staging or production.
+
+### Opt-in for RC/beta dispatch (use sparingly)
+
+Only enable `helm_dispatch_on_rc` or `helm_dispatch_on_beta` when there is a deliberate reason — for example, a chart that must be staged from RC builds in a specific environment. Document the reason in the caller workflow.
+
+```yaml
+# ✅ Correct — production-only dispatch (recommended)
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.28.5
+    with:
+      enable_helm_dispatch: true
+      helm_chart: my-chart
+      # helm_dispatch_on_rc and helm_dispatch_on_beta default to false
+    secrets: inherit
+```
+
+```yaml
+# ⚠️ Opt-in — only when intentional, document why
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.28.5
+    with:
+      enable_helm_dispatch: true
+      helm_chart: my-chart
+      helm_dispatch_on_rc: true   # staging environment promotes from RC tags
+    secrets: inherit
+```
+
 ## Slack Notifications
 
 Automatically sends notifications on completion:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds a new `## Helm Dispatch` section to `docs/build-workflow.md` that documents the existing Helm dispatch behavior in the `build.yml` reusable workflow.

The defaults already enforce the desired policy (`helm_dispatch_on_rc: false`, `helm_dispatch_on_beta: false`), but this was not documented anywhere. The new section makes it explicit that:

- Helm dispatch runs **only on production release tags** by default
- `helm_dispatch_on_rc` and `helm_dispatch_on_beta` are deliberate opt-ins and should be justified in the caller workflow
- Includes a correct usage example and an opt-in example with a documented reason

No workflow code changes — defaults and gating logic in `build.yml` were already correct.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — documentation-only change, no behavior modified.

## Related Issues

Refs #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build workflow documentation with a new Helm Dispatch section covering optional post-build chart update behavior. Includes configurable settings for controlling dispatch across production, RC, and beta releases, with production-only dispatch as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->