### PR TITLE
fix(pr-security-scan): forward ignore_file to Trivy Image Scan

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -215,6 +215,7 @@ jobs:
           image-ref: '${{ env.DOCKERHUB_ORG }}/${{ env.APP_NAME }}:pr-scan-${{ github.sha }}'
           app-name: ${{ env.APP_NAME }}
           enable-license-scan: ${{ inputs.enable_health_score }}
+          ignore-file: ${{ inputs.ignore_file }}
 
       # ----------------- Dockerfile Compliance Checks -----------------
       - name: Dockerfile Compliance Checks

--- a/src/security/trivy-image-scan/action.yml
+++ b/src/security/trivy-image-scan/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Trivy version to install'
     required: false
     default: 'v0.69.3'
+  ignore-file:
+    description: 'Path to Trivy ignore file (forwarded to trivy-action as trivyignores → Trivy --ignorefile). Leave empty to disable.'
+    required: false
+    default: ''
 
 outputs:
   vuln-scan-sarif:
@@ -55,6 +59,7 @@ runs:
         severity: ${{ inputs.severity-table }}
         exit-code: '0'
         version: ${{ inputs.trivy-version }}
+        trivyignores: ${{ inputs.ignore-file }}
 
     - name: Trivy Vulnerability Scan (SARIF Output)
       uses: aquasecurity/trivy-action@0.35.0
@@ -68,6 +73,7 @@ runs:
         severity: ${{ inputs.severity-sarif }}
         exit-code: '0'
         version: ${{ inputs.trivy-version }}
+        trivyignores: ${{ inputs.ignore-file }}
 
     # ----------------- License Scanning -----------------
     - name: Trivy License Scan (JSON Output)
@@ -80,6 +86,7 @@ runs:
         output: 'trivy-license-scan-docker-${{ inputs.app-name }}.json'
         exit-code: '0'
         version: ${{ inputs.trivy-version }}
+        trivyignores: ${{ inputs.ignore-file }}
 
     # ----------------- Outputs -----------------
     - name: Set output paths

--- a/src/security/trivy-image-scan/action.yml
+++ b/src/security/trivy-image-scan/action.yml
@@ -50,7 +50,7 @@ runs:
   steps:
     # ----------------- Vulnerability Scanning -----------------
     - name: Trivy Vulnerability Scan (Table Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: ${{ inputs.image-ref }}
         format: table
@@ -62,7 +62,7 @@ runs:
         trivyignores: ${{ inputs.ignore-file }}
 
     - name: Trivy Vulnerability Scan (SARIF Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       if: always()
       with:
         image-ref: ${{ inputs.image-ref }}
@@ -77,7 +77,7 @@ runs:
 
     # ----------------- License Scanning -----------------
     - name: Trivy License Scan (JSON Output)
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       if: always() && inputs.enable-license-scan == 'true'
       with:
         image-ref: ${{ inputs.image-ref }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`pr-security-scan.yml` accepted an `ignore_file` input but only wired it into the Filesystem Scan step. The Trivy **Image** Scan composite (`src/security/trivy-image-scan/action.yml`) had no ignore-file input at all, and the three underlying `aquasecurity/trivy-action@0.35.0` calls inside it never set `trivyignores`. Callers configuring a `.trivyignore.yaml` to suppress vulnerabilities in vendored binaries (e.g. bundled `k6` / `kubectl`) saw the file honored by the FS scan but silently dropped by the Image scan — blocking PRs on findings the caller had explicitly accepted with rationale and `expired_at`.

This PR plumbs the input the rest of the way:

- `src/security/trivy-image-scan/action.yml` — adds `ignore-file` (default `''`) and forwards it as `trivyignores` to all three trivy-action calls (Vuln Table, Vuln SARIF, License Scan).
- `.github/workflows/pr-security-scan.yml` — forwards `inputs.ignore_file` to the new `ignore-file` input on the image-scan step.

Closes #326.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. The new `ignore-file` input on `trivy-image-scan` defaults to `''`, which `aquasecurity/trivy-action` treats as "no ignore file" — identical to current behavior. Callers that already set `ignore_file` on `pr-security-scan.yml` start benefitting automatically; callers that don't see no change.

## Testing

- [x] YAML syntax validated locally (no schema/lint errors)
- [x] Diff inspected — empty `ignore-file` maps to `trivyignores: ''`, matching the prior implicit behavior
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` once a beta tag is cut

**Caller repo / workflow run that motivated this fix:** https://github.com/LerianStudio/ungoliant-controller/actions/runs/25574132910/job/75077020923 — `INPUT_TRIVYIGNORES: .trivyignore.yaml` on FS scan, but `INPUT_TRIVYIGNORES: ` (empty) on the three image-scan steps.

## Related Issues

Closes #326