### PR TITLE
feat(build): expose cosign retry tuning and gitops continuation on signing failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,18 @@ on:
         description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
         type: boolean
         default: true
+      cosign_max_attempts:
+        description: 'Maximum cosign signing attempts per image reference. Increase to absorb transient OIDC/Fulcio rate limits.'
+        type: string
+        default: '3'
+      cosign_initial_delay:
+        description: 'Initial delay (seconds) between cosign retries. Grows exponentially (×3) after each failed attempt.'
+        type: string
+        default: '5'
+      continue_gitops_on_signing_failure:
+        description: 'When true, continue to GitOps artifact upload even if cosign signing fails after all retries. Image stays in registry unsigned and a warning is emitted; manual signing is required afterwards.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -342,9 +354,35 @@ jobs:
 
       - name: Sign container images with cosign
         if: inputs.enable_cosign_sign
+        id: cosign-sign
+        continue-on-error: ${{ inputs.continue_gitops_on_signing_failure }}
         uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: ${{ steps.cosign-refs.outputs.refs }}
+          max-attempts: ${{ inputs.cosign_max_attempts }}
+          initial-delay: ${{ inputs.cosign_initial_delay }}
+
+      - name: Report cosign signing status
+        if: inputs.enable_cosign_sign && steps.cosign-sign.outcome == 'failure'
+        env:
+          REFS: ${{ steps.cosign-refs.outputs.refs }}
+          DIGEST: ${{ steps.build-push.outputs.digest }}
+          APP_NAME: ${{ matrix.app.name }}
+        run: |
+          echo "::warning::Cosign signing FAILED for ${APP_NAME} after all retries — image is unsigned in the registry."
+          {
+            echo "### ⚠️ Unsigned image — manual action required"
+            echo ""
+            echo "- **App:** \`${APP_NAME}\`"
+            echo "- **Digest:** \`${DIGEST}\`"
+            echo "- **Refs:**"
+            echo '```'
+            echo "${REFS}"
+            echo '```'
+            echo ""
+            echo "GitOps artifact upload was allowed to continue (\`continue_gitops_on_signing_failure: true\`)."
+            echo "The image is immutable and present in the registry but **not signed**. Run \`cosign sign\` manually against the digest above before promoting to production."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ----------------- GitOps Artifacts -----------------
       - name: Create GitOps tag artifact

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -108,6 +108,9 @@ jobs:
 | `enable_gitops_artifacts` | boolean | `false` | Upload artifacts for gitops-update workflow |
 | `force_multiplatform` | boolean | `false` | Force multi-platform build (amd64+arm64) even for beta/rc tags |
 | `enable_cosign_sign` | boolean | `true` | Sign images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller |
+| `cosign_max_attempts` | string | `3` | Max cosign signing attempts per image. Increase to absorb transient OIDC/Fulcio rate limits |
+| `cosign_initial_delay` | string | `5` | Initial delay (seconds) between cosign retries. Grows ×3 each failed attempt |
+| `continue_gitops_on_signing_failure` | boolean | `false` | Allow GitOps artifact upload to continue when cosign signing fails after all retries. Image stays unsigned in registry; manual `cosign sign` required |
 
 ## Secrets
 
@@ -260,6 +263,41 @@ jobs:
       enable_cosign_sign: false
     secrets: inherit
 ```
+
+### Resilience: retries and GitOps continuation
+
+Cosign signing depends on the Sigstore OIDC/Fulcio infrastructure, which can hit transient rate limits or 5xx responses. Two layers protect releases:
+
+1. **Retry with exponential backoff** — controlled by `cosign_max_attempts` (default `3`) and `cosign_initial_delay` (default `5`s, grows ×3 between attempts). Increase both for releases that consistently brush against rate limits.
+
+2. **Optional GitOps continuation** — when `continue_gitops_on_signing_failure: true`, signing failure does not block the GitOps artifact upload. The image is already pushed and immutable in the registry; this prevents a transient signing failure from leaving the release in a broken half-state where the image exists but no GitOps PR was opened.
+
+```yaml
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.28.5
+    with:
+      enable_cosign_sign: true
+      cosign_max_attempts: 5
+      cosign_initial_delay: 15
+      continue_gitops_on_signing_failure: true
+    secrets: inherit
+```
+
+When continuation kicks in, the workflow:
+
+- Logs a `::warning::` with the unsigned digest
+- Writes a "manual action required" block to the GitHub Actions step summary listing the digest and image refs
+- Lets the `dispatch-helm` / GitOps job proceed normally
+
+**Manual recovery** — sign the digest after the fact, then verify:
+
+```bash
+cosign sign --yes <registry>/<org>/<app>@<sha256-digest>
+cosign verify --certificate-identity-regexp '...' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' <ref>
+```
+
+Treat any release with a "Unsigned image" summary block as **not production-ready** until the manual sign step is completed.
 
 ### Verifying signatures
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Improves resilience of the Docker build → cosign sign → GitOps artifact pipeline when cosign hits transient OIDC/Fulcio failures (rate limits, 5xx). Three additive inputs in `build.yml`:

- **`cosign_max_attempts`** (default `3`) — surfaces the existing `max-attempts` knob from the `cosign-sign` composite so callers can tune retry count.
- **`cosign_initial_delay`** (default `5`) — surfaces the existing `initial-delay` knob (×3 exponential backoff between attempts).
- **`continue_gitops_on_signing_failure`** (default `false`) — when `true`, the cosign step uses `continue-on-error` so a signing failure after all retries no longer blocks the GitOps artifact upload. The image is already immutable in the registry; this prevents the broken half-state described in #324 where the image exists but no GitOps PR is opened.

When continuation is engaged, the workflow:
- Emits a `::warning::` with the unsigned image digest.
- Writes a "manual action required" block to `$GITHUB_STEP_SUMMARY` listing the digest and refs so operators can sign the image manually.
- Lets downstream jobs (e.g. `dispatch-helm`) proceed.

Defaults preserve current behavior — callers must opt in to the new mode.

Updates `docs/build-workflow.md` with a new "Resilience: retries and GitOps continuation" subsection covering the new inputs, the manual recovery flow, and the warning that releases with an "Unsigned image" summary block must not be promoted to production until manually signed.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. All three new inputs default to values that reproduce the current behavior:

- `cosign_max_attempts: '3'` — same as composite default.
- `cosign_initial_delay: '5'` — same as composite default.
- `continue_gitops_on_signing_failure: false` — cosign failure still aborts the job, identical to today.

## Testing

- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Pending — recommend a beta validation against `LerianStudio/product-console` (the repo that hit the original failure in #324) using `@feat/cosign-retry-gitops-continuation` with `continue_gitops_on_signing_failure: true` to confirm the recovery path.

## Related Issues

Closes #324