### PR TITLE
feat(backmerge-sync): add composite for branch sync with direct/PR/fallback modes

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -126,6 +126,7 @@ jobs:
 
           if [ "$COUNT" -eq 0 ]; then
             echo "has_pairs=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
           else
             echo "has_pairs=true" >> "$GITHUB_OUTPUT"
             MATRIX=$(jq -nc --argjson p "$PAIRS" '{include: $p}')

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,186 @@
+name: Backmerge
+
+# Configurable backmerge orchestrator. Receives a list of source→target rules
+# (literal or glob), expands globs against the remote, and delegates each pair
+# to the `backmerge-sync` composite via matrix.
+
+on:
+  workflow_call:
+    inputs:
+      rules:
+        description: |
+          JSON array of backmerge rules. Each rule:
+            { "from": "develop", "to": "develop-*", "mode": "direct-with-pr-fallback" }
+          Fields:
+            from            (required)  Literal source branch.
+            to              (required)  Literal target branch or glob (e.g. develop-*).
+            mode            (optional)  direct | pr | direct-with-pr-fallback. Default: direct-with-pr-fallback.
+            commit_message  (optional)  Direct-merge commit message (${source}/${target} placeholders).
+            pr_title        (optional)  PR title template (${source}/${target} placeholders).
+            pr_labels       (optional)  Comma-separated labels overriding workflow-level pr_labels.
+        required: true
+        type: string
+      pr_labels:
+        description: Default comma-separated labels applied to PRs (overridden per rule when set)
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: Preview merges and PRs without applying changes
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ----------------- Expand Rules -----------------
+  expand:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      matrix: ${{ steps.expand.outputs.matrix }}
+      has_pairs: ${{ steps.expand.outputs.has_pairs }}
+    steps:
+      - name: Validate and expand rules
+        id: expand
+        env:
+          RULES: ${{ inputs.rules }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! echo "$RULES" | jq empty 2>/dev/null; then
+            echo "::error::rules input is not valid JSON"
+            exit 1
+          fi
+          if [ "$(echo "$RULES" | jq 'type')" != '"array"' ]; then
+            echo "::error::rules input must be a JSON array"
+            exit 1
+          fi
+
+          PAIRS='[]'
+          while IFS= read -r rule; do
+            FROM=$(echo "$rule" | jq -r '.from // ""')
+            TO=$(echo "$rule" | jq -r '.to // ""')
+            MODE=$(echo "$rule" | jq -r '.mode // "direct-with-pr-fallback"')
+            CMSG=$(echo "$rule" | jq -r '.commit_message // ""')
+            PTITLE=$(echo "$rule" | jq -r '.pr_title // ""')
+            PLABELS=$(echo "$rule" | jq -r '.pr_labels // ""')
+
+            if [ -z "$FROM" ] || [ -z "$TO" ]; then
+              echo "::error::rule missing required 'from' or 'to': $rule"
+              exit 1
+            fi
+
+            case "$MODE" in
+              direct|pr|direct-with-pr-fallback) ;;
+              *)
+                echo "::error::Invalid mode '$MODE' in rule (must be: direct, pr, direct-with-pr-fallback)"
+                exit 1
+                ;;
+            esac
+
+            if [[ "$TO" == *"*"* ]]; then
+              TARGETS=$(git ls-remote --heads "https://github.com/${REPO}.git" "$TO" | awk '{print $2}' | sed 's|refs/heads/||')
+              if [ -z "$TARGETS" ]; then
+                echo "::warning::No remote branches match pattern '$TO' — rule skipped"
+                continue
+              fi
+            else
+              TARGETS="$TO"
+            fi
+
+            while IFS= read -r T; do
+              [ -z "$T" ] && continue
+              [ "$T" = "$FROM" ] && continue
+              PAIR=$(jq -n \
+                --arg from "$FROM" --arg to "$T" --arg mode "$MODE" \
+                --arg commit_message "$CMSG" --arg pr_title "$PTITLE" --arg pr_labels "$PLABELS" \
+                '{from: $from, to: $to, mode: $mode, commit_message: $commit_message, pr_title: $pr_title, pr_labels: $pr_labels}')
+              PAIRS=$(echo "$PAIRS" | jq --argjson p "$PAIR" '. += [$p]')
+            done <<< "$TARGETS"
+          done < <(echo "$RULES" | jq -c '.[]')
+
+          COUNT=$(echo "$PAIRS" | jq 'length')
+          echo "Resolved $COUNT (from, to) pair(s):"
+          echo "$PAIRS" | jq .
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "has_pairs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pairs=true" >> "$GITHUB_OUTPUT"
+            MATRIX=$(jq -nc --argjson p "$PAIRS" '{include: $p}')
+            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ----------------- Sync Branches -----------------
+  sync:
+    needs: expand
+    if: needs.expand.outputs.has_pairs == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.expand.outputs.matrix) }}
+    outputs:
+      action: ${{ steps.sync.outputs.action }}
+      pr-url: ${{ steps.sync.outputs.pr-url }}
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
+          passphrase: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
+          git_committer_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          git_committer_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Backmerge ${{ matrix.from }} → ${{ matrix.to }}
+        id: sync
+        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@develop
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          source-branch: ${{ matrix.from }}
+          target-branch: ${{ matrix.to }}
+          mode: ${{ matrix.mode }}
+          commit-message: "${{ matrix.commit_message != '' && matrix.commit_message || 'chore(backmerge): sync ${source} into ${target} [skip ci]' }}"
+          pr-title: "${{ matrix.pr_title != '' && matrix.pr_title || 'chore(backmerge): sync ${source} → ${target}' }}"
+          pr-labels: ${{ matrix.pr_labels != '' && matrix.pr_labels || inputs.pr_labels }}
+          git-user-name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          git-user-email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          dry-run: ${{ inputs.dry_run }}
+
+      - name: Report
+        if: always()
+        env:
+          FROM: ${{ matrix.from }}
+          TO: ${{ matrix.to }}
+          ACTION: ${{ steps.sync.outputs.action }}
+          PR_URL: ${{ steps.sync.outputs.pr-url }}
+        run: |
+          {
+            echo "### \`${FROM}\` → \`${TO}\`"
+            echo ""
+            echo "- **action:** \`${ACTION:-failed}\`"
+            if [ -n "${PR_URL:-}" ]; then
+              echo "- **PR:** ${PR_URL}"
+            fi
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -141,9 +141,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.expand.outputs.matrix) }}
-    outputs:
-      action: ${{ steps.sync.outputs.action }}
-      pr-url: ${{ steps.sync.outputs.pr-url }}
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -84,7 +84,7 @@ jobs:
             esac
 
             if [[ "$TO" == *"*"* ]]; then
-              TARGETS=$(git ls-remote --heads "https://github.com/${REPO}.git" "$TO" | awk '{print $2}' | sed 's|refs/heads/||')
+              TARGETS=$(git ls-remote --heads "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$TO" | awk '{print $2}' | sed 's|refs/heads/||')
               if [ -z "$TARGETS" ]; then
                 echo "::warning::No remote branches match pattern '$TO' — rule skipped"
                 continue

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -6,6 +6,13 @@ name: Backmerge
 
 on:
   workflow_call:
+    outputs:
+      has_pairs:
+        description: Whether rule expansion resolved at least one source→target pair
+        value: ${{ jobs.expand.outputs.has_pairs }}
+      matrix:
+        description: JSON matrix of resolved pairs (empty when has_pairs is false)
+        value: ${{ jobs.expand.outputs.matrix }}
     inputs:
       rules:
         description: |
@@ -72,6 +79,15 @@ jobs:
 
             if [ -z "$FROM" ] || [ -z "$TO" ]; then
               echo "::error::rule missing required 'from' or 'to': $rule"
+              exit 1
+            fi
+
+            if ! git check-ref-format --branch "$FROM" >/dev/null 2>&1; then
+              echo "::error::Invalid 'from' branch ref: '$FROM'"
+              exit 1
+            fi
+            if [[ "$TO" != *"*"* ]] && ! git check-ref-format --branch "$TO" >/dev/null 2>&1; then
+              echo "::error::Invalid 'to' branch ref: '$TO'"
               exit 1
             fi
 

--- a/docs/backmerge.md
+++ b/docs/backmerge.md
@@ -1,0 +1,130 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>backmerge</h1></td>
+  </tr>
+</table>
+
+Configurable backmerge orchestrator. Receives a JSON list of source→target rules (literal or glob), expands globs against the remote, and delegates each resolved pair to the [`backmerge-sync`](../src/config/backmerge-sync/README.md) composite via matrix.
+
+Decouples backmerge from semantic-release events. Suited for fan-out scenarios like `develop → develop-*` (one source, many integration branches).
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `rules` | JSON array of backmerge rules. See [Rules schema](#rules-schema). | Yes | |
+| `pr_labels` | Default comma-separated labels for fallback PRs. Overridden per rule when `rules[].pr_labels` is set. | No | `""` |
+| `dry_run` | Preview merges and PRs without applying changes. | No | `false` |
+
+### Rules schema
+
+Each entry in `rules` is an object:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `from` | Yes | Literal source branch (e.g. `develop`). |
+| `to` | Yes | Literal target branch (e.g. `develop-fetcher`) **or** glob (`develop-*`). Globs are expanded against remote heads at runtime. |
+| `mode` | No | `direct`, `pr`, or `direct-with-pr-fallback`. Default: `direct-with-pr-fallback`. |
+| `commit_message` | No | Direct-merge commit message. Supports `${source}` / `${target}`. |
+| `pr_title` | No | PR title template. Supports `${source}` / `${target}`. |
+| `pr_labels` | No | Comma-separated labels overriding workflow-level `pr_labels`. |
+
+## Required secrets
+
+Pass via `secrets: inherit` from the caller workflow. Same set used by `release.yml`:
+
+| Secret | Purpose |
+|--------|---------|
+| `LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID` | GitHub App credentials for an authenticated token (push + PR). |
+| `LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY` | |
+| `LERIAN_CI_CD_USER_GPG_KEY` | GPG signing for the merge commit. |
+| `LERIAN_CI_CD_USER_GPG_KEY_PASSWORD` | |
+| `LERIAN_CI_CD_USER_NAME` | Git committer identity (must match GPG key for signature to be valid). |
+| `LERIAN_CI_CD_USER_EMAIL` | |
+
+## Required permissions in the caller job
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+## Usage
+
+### Fan-out `develop` into every `develop-*` on push
+
+```yaml
+name: Backmerge
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  backmerge:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    with:
+      rules: |
+        [
+          { "from": "develop", "to": "develop-*", "mode": "direct-with-pr-fallback" }
+        ]
+    secrets: inherit
+```
+
+### Multi-rule: `main → develop` and `develop → develop-*`
+
+```yaml
+name: Backmerge
+on:
+  push:
+    branches: [main, develop]
+
+jobs:
+  backmerge:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    with:
+      rules: |
+        [
+          { "from": "main",    "to": "develop",   "mode": "direct-with-pr-fallback" },
+          { "from": "develop", "to": "develop-*", "mode": "direct" }
+        ]
+      pr_labels: "backmerge,automation"
+    secrets: inherit
+```
+
+The workflow filters rules by whether the **caller's** pushed branch is the rule's `from`: on push to `main`, only the first rule runs; on push to `develop`, only the second. Filtering happens implicitly via the source-branch matching — rules whose `from` is not the current ref still execute and emit `skipped` when the target is already up to date, so this is cheap rather than incorrect. For tight filtering, gate the job with `if:` in the caller.
+
+### Manual trigger from a `self-*` workflow in the caller
+
+```yaml
+name: Self — Backmerge
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+
+jobs:
+  run:
+    uses: ./.github/workflows/backmerge-impl.yml
+    with:
+      rules: |
+        [{ "from": "develop", "to": "develop-*" }]
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+```
+
+## Behavior
+
+1. **Expand** — validates `rules` JSON, expands globs via `git ls-remote --heads`, builds a list of `(from, to, mode, …)` pairs. Pairs where `from == to` are dropped. Empty result short-circuits the workflow.
+2. **Sync** — matrix job (`fail-fast: false`) running `backmerge-sync` per pair. Each pair is independent; one failure does not stop the others.
+3. **Report** — every pair appends its outcome (`skipped`, `pushed`, `pr-opened`, `pr-existing`, `failed`, plus optional PR URL) to the workflow's job summary.
+
+## Notes
+
+- The workflow uses `secrets: inherit` style — secrets are referenced directly without being declared in `workflow_call.secrets:` (same pattern as `release.yml`).
+- The GPG identity (`git_committer_name` / `git_committer_email`) and the composite's `git-user-name` / `git-user-email` are both bound to `LERIAN_CI_CD_USER_NAME` / `_EMAIL` so the merge-commit signature is valid.
+- Glob expansion uses HTTPS `git ls-remote` against `${{ github.repository }}` — no checkout required in the `expand` job.
+- The `[skip ci]` token is included in the default commit message to avoid retriggering CI on each target branch.

--- a/docs/backmerge.md
+++ b/docs/backmerge.md
@@ -17,6 +17,31 @@ Decouples backmerge from semantic-release events. Suited for fan-out scenarios l
 | `pr_labels` | Default comma-separated labels for fallback PRs. Overridden per rule when `rules[].pr_labels` is set. | No | `""` |
 | `dry_run` | Preview merges and PRs without applying changes. | No | `false` |
 
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has_pairs` | `"true"` when rule expansion resolved at least one source→target pair, `"false"` otherwise. Use to gate downstream jobs. |
+| `matrix` | JSON object `{ "include": [...] }` listing every resolved pair. Always valid JSON — `{"include":[]}` when `has_pairs` is `"false"`. |
+
+### Downstream gating example
+
+```yaml
+jobs:
+  backmerge:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    with:
+      rules: '[{ "from": "develop", "to": "develop-*" }]'
+    secrets: inherit
+
+  notify:
+    needs: backmerge
+    if: needs.backmerge.outputs.has_pairs == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - run: echo "${{ needs.backmerge.outputs.matrix }}"
+```
+
 ### Rules schema
 
 Each entry in `rules` is an object:

--- a/docs/backmerge.md
+++ b/docs/backmerge.md
@@ -93,7 +93,19 @@ jobs:
     secrets: inherit
 ```
 
-The workflow filters rules by whether the **caller's** pushed branch is the rule's `from`: on push to `main`, only the first rule runs; on push to `develop`, only the second. Filtering happens implicitly via the source-branch matching — rules whose `from` is not the current ref still execute and emit `skipped` when the target is already up to date, so this is cheap rather than incorrect. For tight filtering, gate the job with `if:` in the caller.
+> **Heads up:** the workflow does **not** filter rules by `github.ref` — every rule in `rules` runs on every invocation. The `merge-base --is-ancestor` short-circuit inside the composite makes irrelevant rules cheap (they exit as `skipped`), but if you want to scope which rules execute by trigger branch, gate the job in the caller:
+>
+> ```yaml
+> jobs:
+>   backmerge:
+>     if: github.ref_name == 'main' || github.ref_name == 'develop'
+>     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+>     with:
+>       rules: ${{ github.ref_name == 'main'
+>         && '[{ "from": "main", "to": "develop" }]'
+>         || '[{ "from": "develop", "to": "develop-*" }]' }}
+>     secrets: inherit
+> ```
 
 ### Manual trigger from a `self-*` workflow in the caller
 

--- a/docs/backmerge.md
+++ b/docs/backmerge.md
@@ -107,7 +107,7 @@ jobs:
 >     secrets: inherit
 > ```
 
-### Manual trigger from a `self-*` workflow in the caller
+### Manual trigger with `workflow_dispatch`
 
 ```yaml
 name: Self — Backmerge
@@ -120,7 +120,7 @@ on:
 
 jobs:
   run:
-    uses: ./.github/workflows/backmerge-impl.yml
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
     with:
       rules: |
         [{ "from": "develop", "to": "develop-*" }]

--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -19,7 +19,7 @@ Single source → single target. For fan-out across multiple targets (e.g., `dev
 | `mode` | `direct`, `pr`, or `direct-with-pr-fallback` | No | `direct-with-pr-fallback` |
 | `commit-message` | Direct-merge commit message. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} into ${target} [skip ci]` |
 | `pr-title` | Fallback PR title. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} → ${target}` |
-| `pr-labels` | Comma-separated labels for the fallback PR. Empty by default — only opt in to labels that exist in the caller repo. | No | `""` |
+| `pr-labels` | Comma-separated labels applied to the PR opened in `pr` or fallback mode. Empty by default — only opt in to labels that exist in the caller repo. | No | `""` |
 | `git-user-name` | Git `user.name` for the merge commit | No | `github-actions[bot]` |
 | `git-user-email` | Git `user.email` for the merge commit | No | `41898282+github-actions[bot]@users.noreply.github.com` |
 | `dry-run` | Preview actions without pushing or opening PRs | No | `false` |
@@ -29,8 +29,8 @@ Single source → single target. For fan-out across multiple targets (e.g., `dev
 | Output | Description |
 |--------|-------------|
 | `action` | One of `skipped`, `pushed`, `pr-opened`, `pr-existing`, `failed` |
-| `pr-url` | URL of the fallback PR (empty when no PR was created) |
-| `pr-number` | Number of the fallback PR (empty when no PR was created) |
+| `pr-url` | URL of the PR opened or reused in `pr` or fallback mode (empty when no PR was created) |
+| `pr-number` | Number of the PR opened or reused in `pr` or fallback mode (empty when no PR was created) |
 
 ## Modes
 

--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -1,0 +1,101 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>backmerge-sync</h1></td>
+  </tr>
+</table>
+
+Syncs a source branch into a target branch via direct push, pull request, or direct-with-PR-fallback. Designed for keeping long-lived integration branches (e.g., `develop-*`) in sync with their parent (`develop`).
+
+Single source → single target. For fan-out across multiple targets (e.g., `develop` → every `develop-*`), call this composite from a matrix in the consuming workflow.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github-token` | GitHub token with `contents:write` and `pull-requests:write` | Yes | |
+| `source-branch` | Branch to merge from | Yes | |
+| `target-branch` | Branch to merge into | Yes | |
+| `mode` | `direct`, `pr`, or `direct-with-pr-fallback` | No | `direct-with-pr-fallback` |
+| `commit-message` | Direct-merge commit message. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} into ${target} [skip ci]` |
+| `pr-title` | Fallback PR title. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} → ${target}` |
+| `pr-labels` | Comma-separated labels for the fallback PR | No | `backmerge,automation` |
+| `git-user-name` | Git `user.name` for the merge commit | No | `github-actions[bot]` |
+| `git-user-email` | Git `user.email` for the merge commit | No | `41898282+github-actions[bot]@users.noreply.github.com` |
+| `dry-run` | Preview actions without pushing or opening PRs | No | `false` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `action` | One of `skipped`, `pushed`, `pr-opened`, `pr-existing`, `failed` |
+| `pr-url` | URL of the fallback PR (empty when no PR was created) |
+| `pr-number` | Number of the fallback PR (empty when no PR was created) |
+
+## Modes
+
+| Mode | Behavior |
+|------|----------|
+| `direct` | Merge and push. Fails the step on conflict or rejected push. No PR is opened. |
+| `pr` | Always open (or reuse) a PR from `source-branch` into `target-branch`. Never pushes directly. |
+| `direct-with-pr-fallback` | Try direct merge & push first. On conflict or rejection, fall back to opening a PR. |
+
+If the target branch already contains the source (`merge-base --is-ancestor`), the step is a no-op and outputs `action=skipped`.
+
+## Usage as composite step
+
+```yaml
+- name: Checkout
+  uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+    persist-credentials: true   # required for direct push
+
+- name: Sync develop into develop-fetcher
+  uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1.x.x
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    source-branch: develop
+    target-branch: develop-fetcher
+    mode: direct-with-pr-fallback
+```
+
+## Usage with matrix fan-out
+
+```yaml
+jobs:
+  fanout:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [develop-fetcher, develop-matcher, develop-product]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1.x.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          source-branch: develop
+          target-branch: ${{ matrix.target }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+The caller must run `actions/checkout` with `fetch-depth: 0` and `persist-credentials: true` before invoking this composite — direct pushes rely on credentials configured by the checkout step.
+
+## Notes
+
+- Idempotent: re-running with an already-merged target outputs `skipped`; re-running after a fallback PR was opened outputs `pr-existing`.
+- `dry-run: true` logs every intended action via `::notice::` annotations without pushing or calling `gh pr create`.
+- `[skip ci]` is included in the default commit message to avoid re-triggering CI on the target branch. Override `commit-message` to change this.

--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -19,7 +19,7 @@ Single source → single target. For fan-out across multiple targets (e.g., `dev
 | `mode` | `direct`, `pr`, or `direct-with-pr-fallback` | No | `direct-with-pr-fallback` |
 | `commit-message` | Direct-merge commit message. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} into ${target} [skip ci]` |
 | `pr-title` | Fallback PR title. Supports `${source}` / `${target}` | No | `chore(backmerge): sync ${source} → ${target}` |
-| `pr-labels` | Comma-separated labels for the fallback PR | No | `backmerge,automation` |
+| `pr-labels` | Comma-separated labels for the fallback PR. Empty by default — only opt in to labels that exist in the caller repo. | No | `""` |
 | `git-user-name` | Git `user.name` for the merge commit | No | `github-actions[bot]` |
 | `git-user-email` | Git `user.email` for the merge commit | No | `41898282+github-actions[bot]@users.noreply.github.com` |
 | `dry-run` | Preview actions without pushing or opening PRs | No | `false` |

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -24,9 +24,9 @@ inputs:
     required: false
     default: "chore(backmerge): sync ${source} → ${target}"
   pr-labels:
-    description: Comma-separated labels applied to the fallback PR
+    description: Comma-separated labels applied to the fallback PR. Default empty so the composite works in any repo; opt in by passing labels that exist in the caller repo.
     required: false
-    default: "backmerge,automation"
+    default: ""
   git-user-name:
     description: Git user.name for the merge commit
     required: false
@@ -54,6 +54,7 @@ outputs:
 runs:
   using: composite
   steps:
+    # ----------------- Validate Inputs -----------------
     - name: Validate inputs
       shell: bash
       env:
@@ -72,7 +73,16 @@ runs:
           echo "::error::source-branch and target-branch must differ (got '$SOURCE_BRANCH')"
           exit 1
         fi
+        if ! git check-ref-format --branch "$SOURCE_BRANCH" >/dev/null 2>&1; then
+          echo "::error::Invalid source-branch ref: '$SOURCE_BRANCH'"
+          exit 1
+        fi
+        if ! git check-ref-format --branch "$TARGET_BRANCH" >/dev/null 2>&1; then
+          echo "::error::Invalid target-branch ref: '$TARGET_BRANCH'"
+          exit 1
+        fi
 
+    # ----------------- Fetch Branches -----------------
     - name: Fetch branches
       shell: bash
       env:
@@ -83,6 +93,7 @@ runs:
           "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" \
           "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
 
+    # ----------------- Sync Branches -----------------
     - name: Sync branches
       id: sync
       shell: bash
@@ -101,7 +112,10 @@ runs:
         set -euo pipefail
 
         render() {
-          printf '%s' "$1" | sed -e "s|\${source}|${SOURCE_BRANCH}|g" -e "s|\${target}|${TARGET_BRANCH}|g"
+          local rendered="$1"
+          rendered=${rendered//'${source}'/$SOURCE_BRANCH}
+          rendered=${rendered//'${target}'/$TARGET_BRANCH}
+          printf '%s' "$rendered"
         }
 
         emit() {
@@ -195,6 +209,14 @@ runs:
         fi
 
         if ! git push origin "$TARGET_BRANCH"; then
+          # A rejected push can mean another worker advanced target — refetch and re-check ancestry.
+          git fetch --no-tags origin \
+            "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+          if git merge-base --is-ancestor "$SOURCE_SHA" "origin/${TARGET_BRANCH}"; then
+            echo "::notice::${TARGET_BRANCH} already contains ${SOURCE_BRANCH} after push rejection — skipping"
+            emit "skipped"
+            exit 0
+          fi
           if [ "$MODE" = "direct" ]; then
             echo "::error::Push to ${TARGET_BRANCH} rejected (mode=direct)"
             emit "failed"

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -1,0 +1,209 @@
+name: Backmerge Sync
+description: "Syncs a source branch into a target branch via direct push, PR, or direct-with-PR-fallback."
+
+inputs:
+  github-token:
+    description: GitHub token with contents:write and pull-requests:write permissions
+    required: true
+  source-branch:
+    description: Source branch to merge from (e.g., develop)
+    required: true
+  target-branch:
+    description: Target branch to merge into (e.g., develop-fetcher)
+    required: true
+  mode:
+    description: 'Sync strategy: "direct" (push merge commit, fail on conflict), "pr" (always open a PR), or "direct-with-pr-fallback" (try direct push, open PR on conflict).'
+    required: false
+    default: direct-with-pr-fallback
+  commit-message:
+    description: Commit message for direct merge. Supports ${source} and ${target} placeholders.
+    required: false
+    default: "chore(backmerge): sync ${source} into ${target} [skip ci]"
+  pr-title:
+    description: PR title template. Supports ${source} and ${target} placeholders.
+    required: false
+    default: "chore(backmerge): sync ${source} → ${target}"
+  pr-labels:
+    description: Comma-separated labels applied to the fallback PR
+    required: false
+    default: "backmerge,automation"
+  git-user-name:
+    description: Git user.name for the merge commit
+    required: false
+    default: "github-actions[bot]"
+  git-user-email:
+    description: Git user.email for the merge commit
+    required: false
+    default: "41898282+github-actions[bot]@users.noreply.github.com"
+  dry-run:
+    description: Preview actions without pushing or opening PRs
+    required: false
+    default: "false"
+
+outputs:
+  action:
+    description: "Action taken: skipped | pushed | pr-opened | pr-existing | failed"
+    value: ${{ steps.sync.outputs.action }}
+  pr-url:
+    description: URL of the fallback PR (empty when no PR was created)
+    value: ${{ steps.sync.outputs.pr_url }}
+  pr-number:
+    description: Number of the fallback PR (empty when no PR was created)
+    value: ${{ steps.sync.outputs.pr_number }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+      run: |
+        case "$MODE" in
+          direct|pr|direct-with-pr-fallback) ;;
+          *)
+            echo "::error::Invalid mode '$MODE'. Must be one of: direct, pr, direct-with-pr-fallback"
+            exit 1
+            ;;
+        esac
+        if [ "$SOURCE_BRANCH" = "$TARGET_BRANCH" ]; then
+          echo "::error::source-branch and target-branch must differ (got '$SOURCE_BRANCH')"
+          exit 1
+        fi
+
+    - name: Fetch branches
+      shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+      run: |
+        git fetch --no-tags --prune origin \
+          "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" \
+          "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+
+    - name: Sync branches
+      id: sync
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        MODE: ${{ inputs.mode }}
+        COMMIT_MESSAGE_TEMPLATE: ${{ inputs.commit-message }}
+        PR_TITLE_TEMPLATE: ${{ inputs.pr-title }}
+        PR_LABELS: ${{ inputs.pr-labels }}
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+
+        render() {
+          printf '%s' "$1" | sed -e "s|\${source}|${SOURCE_BRANCH}|g" -e "s|\${target}|${TARGET_BRANCH}|g"
+        }
+
+        emit() {
+          echo "action=$1" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${2:-}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${3:-}" >> "$GITHUB_OUTPUT"
+        }
+
+        SOURCE_SHA=$(git rev-parse "origin/${SOURCE_BRANCH}")
+        TARGET_SHA=$(git rev-parse "origin/${TARGET_BRANCH}")
+
+        if git merge-base --is-ancestor "$SOURCE_SHA" "$TARGET_SHA"; then
+          echo "::notice::${TARGET_BRANCH} already contains ${SOURCE_BRANCH} — skipping"
+          emit "skipped"
+          exit 0
+        fi
+
+        COMMIT_MESSAGE=$(render "$COMMIT_MESSAGE_TEMPLATE")
+        PR_TITLE=$(render "$PR_TITLE_TEMPLATE")
+
+        open_pr() {
+          EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$SOURCE_BRANCH" --state open --json number,url --jq '.[0]' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUM=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            echo "::notice::Backmerge PR #${PR_NUM} already exists: ${PR_URL}"
+            emit "pr-existing" "$PR_URL" "$PR_NUM"
+            return 0
+          fi
+
+          PR_BODY="## Description
+
+        Automated backmerge from \`${SOURCE_BRANCH}\` into \`${TARGET_BRANCH}\`.
+
+        ${1:-A direct push could not be performed.} This PR needs review and merge to keep \`${TARGET_BRANCH}\` in sync.
+
+        > Created automatically by the \`backmerge-sync\` composite action."
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::[dry-run] would open PR: ${PR_TITLE} (${SOURCE_BRANCH} → ${TARGET_BRANCH})"
+            emit "pr-opened" "" ""
+            return 0
+          fi
+
+          LABEL_ARGS=()
+          IFS=',' read -ra LABELS <<< "$PR_LABELS"
+          for L in "${LABELS[@]}"; do
+            L_TRIMMED=$(echo "$L" | xargs)
+            [ -n "$L_TRIMMED" ] && LABEL_ARGS+=(--label "$L_TRIMMED")
+          done
+
+          PR_URL=$(gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$SOURCE_BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            "${LABEL_ARGS[@]}")
+
+          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "::notice::Opened backmerge PR #${PR_NUM}: ${PR_URL}"
+          emit "pr-opened" "$PR_URL" "$PR_NUM"
+        }
+
+        if [ "$MODE" = "pr" ]; then
+          open_pr "PR-only mode."
+          exit 0
+        fi
+
+        # direct or direct-with-pr-fallback: try direct merge
+        git config user.name "$GIT_USER_NAME"
+        git config user.email "$GIT_USER_EMAIL"
+
+        git checkout -B "$TARGET_BRANCH" "origin/${TARGET_BRANCH}"
+
+        if ! git merge --no-ff "origin/${SOURCE_BRANCH}" -m "$COMMIT_MESSAGE"; then
+          git merge --abort || true
+          if [ "$MODE" = "direct" ]; then
+            echo "::error::Merge conflict between ${SOURCE_BRANCH} and ${TARGET_BRANCH} (mode=direct)"
+            emit "failed"
+            exit 1
+          fi
+          echo "::warning::Merge conflict — falling back to PR"
+          open_pr "A direct merge conflicts with \`${TARGET_BRANCH}\`."
+          exit 0
+        fi
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "::notice::[dry-run] would push ${TARGET_BRANCH} (${SOURCE_BRANCH} merged cleanly)"
+          emit "pushed"
+          exit 0
+        fi
+
+        if ! git push origin "$TARGET_BRANCH"; then
+          if [ "$MODE" = "direct" ]; then
+            echo "::error::Push to ${TARGET_BRANCH} rejected (mode=direct)"
+            emit "failed"
+            exit 1
+          fi
+          echo "::warning::Push rejected — falling back to PR"
+          open_pr "A direct push to \`${TARGET_BRANCH}\` was rejected."
+          exit 0
+        fi
+
+        echo "::notice::Pushed merge of ${SOURCE_BRANCH} into ${TARGET_BRANCH}"
+        emit "pushed"

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: "chore(backmerge): sync ${source} → ${target}"
   pr-labels:
-    description: Comma-separated labels applied to the fallback PR. Default empty so the composite works in any repo; opt in by passing labels that exist in the caller repo.
+    description: Comma-separated labels applied to the PR opened in `pr` or fallback mode. Default empty so the composite works in any repo; opt in by passing labels that exist in the caller repo.
     required: false
     default: ""
   git-user-name:
@@ -45,10 +45,10 @@ outputs:
     description: "Action taken: skipped | pushed | pr-opened | pr-existing | failed"
     value: ${{ steps.sync.outputs.action }}
   pr-url:
-    description: URL of the fallback PR (empty when no PR was created)
+    description: URL of the PR opened or reused in `pr` or fallback mode (empty when no PR was created)
     value: ${{ steps.sync.outputs.pr-url }}
   pr-number:
-    description: Number of the fallback PR (empty when no PR was created)
+    description: Number of the PR opened or reused in `pr` or fallback mode (empty when no PR was created)
     value: ${{ steps.sync.outputs.pr-number }}
 
 runs:
@@ -61,11 +61,19 @@ runs:
         MODE: ${{ inputs.mode }}
         SOURCE_BRANCH: ${{ inputs.source-branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
+        DRY_RUN: ${{ inputs.dry-run }}
       run: |
         case "$MODE" in
           direct|pr|direct-with-pr-fallback) ;;
           *)
             echo "::error::Invalid mode '$MODE'. Must be one of: direct, pr, direct-with-pr-fallback"
+            exit 1
+            ;;
+        esac
+        case "$DRY_RUN" in
+          true|false) ;;
+          *)
+            echo "::error::Invalid dry-run '$DRY_RUN'. Must be 'true' or 'false'"
             exit 1
             ;;
         esac

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -46,10 +46,10 @@ outputs:
     value: ${{ steps.sync.outputs.action }}
   pr-url:
     description: URL of the fallback PR (empty when no PR was created)
-    value: ${{ steps.sync.outputs.pr_url }}
+    value: ${{ steps.sync.outputs.pr-url }}
   pr-number:
     description: Number of the fallback PR (empty when no PR was created)
-    value: ${{ steps.sync.outputs.pr_number }}
+    value: ${{ steps.sync.outputs.pr-number }}
 
 runs:
   using: composite
@@ -106,8 +106,8 @@ runs:
 
         emit() {
           echo "action=$1" >> "$GITHUB_OUTPUT"
-          echo "pr_url=${2:-}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${3:-}" >> "$GITHUB_OUTPUT"
+          echo "pr-url=${2:-}" >> "$GITHUB_OUTPUT"
+          echo "pr-number=${3:-}" >> "$GITHUB_OUTPUT"
         }
 
         SOURCE_SHA=$(git rev-parse "origin/${SOURCE_BRANCH}")


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds a new composite action `src/config/backmerge-sync` that syncs one branch into another via direct push, pull request, or direct-with-PR-fallback.

Motivated by repositories that operate long-lived integration branches (e.g. `develop-fetcher`, `develop-matcher`, `develop-product` in `product-console`) which drift from `develop` and require manual `git merge` rituals. The existing `src/config/backmerge-pr` composite is tied to the release flow (fixed `version`-based PR title, only opens a PR — never attempts a direct push) and does not generalize to a recurring `develop → develop-*` sync.

This composite is single source → single target by design. Fan-out across multiple targets is the responsibility of the consuming workflow (matrix), keeping the composite focused on one capability.

Highlights:

- `mode: direct` — push merge commit; fail on conflict or rejected push.
- `mode: pr` — always open (or reuse) a PR; never push directly.
- `mode: direct-with-pr-fallback` (default) — try direct, fall back to PR on conflict/rejection.
- Idempotent: `merge-base --is-ancestor` short-circuit; existing open PRs are reused.
- `dry-run` support via `::notice::` annotations.
- Configurable commit-message and PR-title templates with `${source}` / `${target}` placeholders.

Does **not** modify `src/config/backmerge-pr` or `release.yml` — out of scope for this PR.

The companion workflow described in #323 (multi-rule, glob fan-out) will be introduced in a follow-up that consumes this composite.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. New composite, opt-in; no existing workflow or composite is modified.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** to be exercised against `product-console` once merged to `develop` (beta tag) — the `develop → develop-*` fan-out described in #323 is the first real consumer.

## Related Issues

Refs #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backmerge sync action: sync branches with modes (direct, PR, direct→PR fallback), dry-run, PR reuse, and explicit outcome outputs (skipped/pushed/pr-opened/pr-existing/failed).
  * Orchestrator workflow: accept JSON rules, expand globs to resolved from→to pairs, run per-pair syncs via a matrix, emit matrix/has_pairs outputs, and report per-pair results (supports GPG-signed commits).

* **Documentation**
  * Comprehensive user guide covering inputs/outputs, rule schema, examples, permissions, idempotency, and usage notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/333)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->