### PR TITLE
fix(release): merge develop into main

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -653,7 +653,7 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         run: |
           if [[ -f coverage.txt ]]; then
-            COVERAGE=$(go tool cover -func=coverage.txt | grep total | awk '{print $3}' | sed 's/%//')
+            COVERAGE=$(go tool cover -func=coverage.txt | grep '^total:' | awk '{print $3}' | sed 's/%//')
             echo "coverage=$COVERAGE" >> "$GITHUB_OUTPUT"
             echo "Total coverage: $COVERAGE%"
 


### PR DESCRIPTION
## Summary

Release-merge to ship the `go-pr-analysis` coverage-grep fix into a tagged version. Unblocks downstream Coverage gates that fail for any consumer repo with a function name containing lowercase `total`.

## What's in this release
- #334 — `fix(go-pr-analysis): anchor coverage grep to summary line only` — changes `grep total` → `grep '^total:'` on the Calculate coverage extraction so per-function lines stop colliding with the summary line. Filed while debugging LerianStudio/underwriter#30 (Coverage check failing with `Invalid format '77.8'`).

## Test plan
- [x] All 16 PR-validation checks green on #334 (Action Lint, CodeQL, YAML Lint, Pinned Actions, README, Shell, Spelling, etc.).
- [x] Manually verified `go tool cover -func=coverage.txt | grep '^total:'` returns exactly one line on underwriter's coverage profile.
- [ ] Post-merge: confirm new tag is cut and underwriter develop's `.github/workflows/go-combined-analysis.yml` can bump from `v1.27.5` to the new version.

🤖 Filed by Galadriel while debugging LerianStudio/underwriter#30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved accuracy of coverage calculation in CI/CD pipeline for more reliable metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->