### PR TITLE
fix(backmerge-sync): skip non-existent labels instead of failing PR creation

### DIFF
--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -99,3 +99,4 @@ The caller must run `actions/checkout` with `fetch-depth: 0` and `persist-creden
 - Idempotent: re-running with an already-merged target outputs `skipped`; re-running after a fallback PR was opened outputs `pr-existing`.
 - `dry-run: true` logs every intended action via `::notice::` annotations without pushing or calling `gh pr create`.
 - `[skip ci]` is included in the default commit message to avoid re-triggering CI on the target branch. Override `commit-message` to change this.
+- Labels passed via `pr-labels` are filtered against the caller repo's existing labels — entries that do not exist are skipped with a `::warning::` rather than failing the PR creation.

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -169,11 +169,19 @@ runs:
           fi
 
           LABEL_ARGS=()
-          IFS=',' read -ra LABELS <<< "$PR_LABELS"
-          for L in "${LABELS[@]}"; do
-            L_TRIMMED=$(echo "$L" | xargs)
-            [ -n "$L_TRIMMED" ] && LABEL_ARGS+=(--label "$L_TRIMMED")
-          done
+          if [ -n "$PR_LABELS" ]; then
+            EXISTING_LABELS=$(gh label list --limit 200 --json name --jq '.[].name' 2>/dev/null || echo "")
+            IFS=',' read -ra LABELS <<< "$PR_LABELS"
+            for L in "${LABELS[@]}"; do
+              L_TRIMMED=$(echo "$L" | xargs)
+              [ -z "$L_TRIMMED" ] && continue
+              if echo "$EXISTING_LABELS" | grep -qFx "$L_TRIMMED"; then
+                LABEL_ARGS+=(--label "$L_TRIMMED")
+              else
+                echo "::warning::Label '$L_TRIMMED' does not exist in this repository — skipping"
+              fi
+            done
+          fi
 
           PR_URL=$(gh pr create \
             --base "$TARGET_BRANCH" \

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -170,10 +170,11 @@ runs:
 
           LABEL_ARGS=()
           if [ -n "$PR_LABELS" ]; then
-            EXISTING_LABELS=$(gh label list --limit 200 --json name --jq '.[].name' 2>/dev/null || echo "")
+            EXISTING_LABELS=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/labels?per_page=100" --jq '.[].name' 2>/dev/null || echo "")
             IFS=',' read -ra LABELS <<< "$PR_LABELS"
             for L in "${LABELS[@]}"; do
-              L_TRIMMED=$(echo "$L" | xargs)
+              L_TRIMMED="${L#"${L%%[![:space:]]*}"}"
+              L_TRIMMED="${L_TRIMMED%"${L_TRIMMED##*[![:space:]]}"}"
               [ -z "$L_TRIMMED" ] && continue
               if echo "$EXISTING_LABELS" | grep -qFx "$L_TRIMMED"; then
                 LABEL_ARGS+=(--label "$L_TRIMMED")


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When the caller repository does not have one of the labels listed in `pr-labels`, `gh pr create --label <name>` returns a non-zero exit and `set -e` aborts the fallback PR step entirely, leaving the merge conflict unhandled.

The composite now pre-fetches the caller's existing labels via `gh label list` and forwards only those that exist. Missing labels are emitted as `::warning::` annotations instead of failing the step. The PR is created either with the valid subset of labels or with none at all.

Observed in `product-console` run [25690230845](https://github.com/LerianStudio/product-console/actions/runs/25690230845/job/75424452444): direct merge of `develop` into `develop-matcher` hit a conflict, fallback kicked in correctly, but `gh pr create --label backmerge` failed because `backmerge` is not a label in `product-console`.

Cherry-picked from PR #333 (the original feature PR for the `backmerge-sync` composite) so it can ship independently and unblock active backmerge runs in caller repos.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Failure mode changes from hard error to warning + partial labels; the success path is unchanged when all labels exist.

## Testing

- [x] YAML syntax validated locally
- [x] Reproduced the failure mode in `product-console` run 25690230845
- [x] Verified all existing inputs still work with default values (default `pr-labels` is empty, so the new branch is a no-op when callers do not set labels)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** https://github.com/LerianStudio/product-console/actions/runs/25690230845/job/75424452444 (failure that motivated this fix)

## Related Issues

Refs #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PR creation no longer fails when requested labels don't exist; missing labels are skipped and emit a warning.
  * Empty or whitespace-only labels are ignored.

* **Documentation**
  * Clarified that comma-separated labels are trimmed and validated against the repository’s existing labels before being applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/337)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->