### PR TITLE
chore(backmerge): pin composite to @v1 and examples to @v1.28.8

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Backmerge ${{ matrix.from }} → ${{ matrix.to }}
         id: sync
-        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@develop
+        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           source-branch: ${{ matrix.from }}

--- a/docs/backmerge.md
+++ b/docs/backmerge.md
@@ -29,7 +29,7 @@ Decouples backmerge from semantic-release events. Suited for fan-out scenarios l
 ```yaml
 jobs:
   backmerge:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.28.8
     with:
       rules: '[{ "from": "develop", "to": "develop-*" }]'
     secrets: inherit
@@ -88,7 +88,7 @@ on:
 
 jobs:
   backmerge:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.28.8
     with:
       rules: |
         [
@@ -107,7 +107,7 @@ on:
 
 jobs:
   backmerge:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.28.8
     with:
       rules: |
         [
@@ -124,7 +124,7 @@ jobs:
 > jobs:
 >   backmerge:
 >     if: github.ref_name == 'main' || github.ref_name == 'develop'
->     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+>     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.28.8
 >     with:
 >       rules: ${{ github.ref_name == 'main'
 >         && '[{ "from": "main", "to": "develop" }]'
@@ -145,7 +145,7 @@ on:
 
 jobs:
   run:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/backmerge.yml@v1.28.8
     with:
       rules: |
         [{ "from": "develop", "to": "develop-*" }]

--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -52,7 +52,7 @@ If the target branch already contains the source (`merge-base --is-ancestor`), t
     persist-credentials: true   # required for direct push
 
 - name: Sync develop into develop-fetcher
-  uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1.x.x
+  uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     source-branch: develop
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1.x.x
+      - uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           source-branch: develop


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Pins `@develop` references in the freshly-merged backmerge code to the upcoming release version, so the merge from develop → main in #338 ships with stable refs:

- `.github/workflows/backmerge.yml` — composite ref `LerianStudio/.../src/config/backmerge-sync@develop` → `@v1` (floating major, per repo convention for composites).
- `docs/backmerge.md` — five caller-invocation examples updated from `@develop` → `@v1.28.8` (the version generated by the upcoming release merge).
- `src/config/backmerge-sync/README.md` — two example invocations updated from `@v1.x.x` placeholder → `@v1`.

Targets `develop` so the change is included in the merge PR #338 (develop → main) and lands in `main` alongside the v1.28.8 release.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Internal reference bump and documentation examples only — no behavior change.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

## Related Issues

Refs #323, prepares #338.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples to reference stable version tags for backmerge workflows, ensuring consistent behavior.

* **Chores**
  * Updated GitHub Actions workflow configuration to use versioned references instead of development branch references, improving stability and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->