### PR TITLE
fix(backmerge): correct empty-PR detection and broaden glob matching

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -86,7 +86,7 @@ jobs:
               echo "::error::Invalid 'from' branch ref: '$FROM'"
               exit 1
             fi
-            if [[ "$TO" != *"*"* ]] && ! git check-ref-format --branch "$TO" >/dev/null 2>&1; then
+            if [[ "$TO" != *[\*\?\[]* ]] && ! git check-ref-format --branch "$TO" >/dev/null 2>&1; then
               echo "::error::Invalid 'to' branch ref: '$TO'"
               exit 1
             fi
@@ -99,7 +99,7 @@ jobs:
                 ;;
             esac
 
-            if [[ "$TO" == *"*"* ]]; then
+            if [[ "$TO" == *[\*\?\[]* ]]; then
               TARGETS=$(git ls-remote --heads "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$TO" | awk '{print $2}' | sed 's|refs/heads/||')
               if [ -z "$TARGETS" ]; then
                 echo "::warning::No remote branches match pattern '$TO' — rule skipped"

--- a/src/config/backmerge-sync/README.md
+++ b/src/config/backmerge-sync/README.md
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: true
       - uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1.x.x
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -145,7 +145,7 @@ runs:
         PR_TITLE=$(render "$PR_TITLE_TEMPLATE")
 
         open_pr() {
-          EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$SOURCE_BRANCH" --state open --json number,url --jq '.[0]' 2>/dev/null || echo "")
+          EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$SOURCE_BRANCH" --state open --json number,url --jq 'if length>0 then .[0] else empty end' 2>/dev/null || echo "")
           if [ -n "$EXISTING_PR" ]; then
             PR_NUM=$(echo "$EXISTING_PR" | jq -r '.number')
             PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')


### PR DESCRIPTION
<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\">
  <tr>
    <td><img src=\"https://github.com/LerianStudio.png\" width=\"72\" alt=\"Lerian\" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Two issues surfaced by CodeRabbit on PR #338:

1. **`backmerge-sync` — bug in existing-PR detection.** `gh pr list ... --jq '.[0]'` on an empty array outputs the literal string `null` (4 chars), and `[ -n \"$EXISTING_PR\" ]` evaluates true. The composite then emits `pr-existing` and skips PR creation whenever no PR actually existed — i.e. the very first conflict for any (source, target) pair would never open a fallback PR. Replace with `jq 'if length>0 then .[0] else empty end'` so the variable is genuinely empty when there is no match.

2. **`backmerge` workflow — glob detection too narrow.** `[[ \"$TO\" == *\"*\"* ]]` only matches patterns containing `*`. Valid fnmatch patterns like `release-?` or `v[0-9]` are misclassified as literal branch refs and fail `git check-ref-format`. Widen the predicate to `*[\*\?\[]*` so `?` and bracket classes also trigger glob expansion via `git ls-remote`.

Both are minimal, targeted fixes — no behavior change for the happy paths exercised by existing callers.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Failure-mode fix and broader glob acceptance only.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected
- [x] Manual reproduction of the `jq '.[0]'` -> `null` behavior on an empty result set

## Related Issues

Addresses CodeRabbit review on #338. Refs #323.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved branch pattern matching to treat additional glob characters (e.g., ? and character classes).
  * Enhanced pull request detection to avoid false positives when no matching PR exists.

* **Documentation**
  * Updated usage example to add persist-credentials and relax the composite-action reference to v1.x.x.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/340)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/340)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->