### PR TITLE
fix(gptchangelog): always wrap version references in backticks

### DIFF
--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -308,7 +308,7 @@ runs:
           rm -f "$USERNAMES_FILE"
           echo "👥 Contributors: $CONTRIBUTORS"
 
-          PROMPT="Generate a changelog for ${APP_NAME} ONLY. Commits: ${COMMITS_TEXT} --- STRICT RULES: 1) NEVER mention other components - only ${APP_NAME}. 2) Use bullet points. 3) Group by Features, Fixes, Improvements (skip empty sections). 4) No markdown headers. 5) Max 5 bullet points. 6) End with Contributors: ${CONTRIBUTORS}"
+          PROMPT="Generate a changelog for ${APP_NAME} ONLY. Commits: ${COMMITS_TEXT} --- STRICT RULES: 1) NEVER mention other components - only ${APP_NAME}. 2) Use bullet points. 3) Group by Features, Fixes, Improvements (skip empty sections). 4) No markdown headers. 5) Max 5 bullet points. 6) End with Contributors: ${CONTRIBUTORS}. 7) ALWAYS wrap version references in backticks - this includes tag names (\`v1\`, \`v1.28.8\`, \`v2.0.0-beta.1\`), action refs (\`@v1\`, \`@v1.28.8\`), and any semver-like token. Never emit a bare version."
 
           REQUEST_BODY=$(jq -n \
             --arg model "$OPENAI_MODEL" \


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds an explicit rule to the `gptchangelog` LLM prompt requiring that every version reference be wrapped in backticks. Without this constraint the model occasionally emitted bare versions like `Bumped to v1.28.8` or `Pin to @v1`, which then:

- Get rendered without monospace styling in the GitHub release notes.
- Make `@`-prefixed action refs (`@v1`) look like user mentions.
- Break copy-paste into a tag or action `uses:` line.

The new rule covers all three forms explicitly so the model can't ambiguously interpret it:

> 7) ALWAYS wrap version references in backticks — this includes tag names (`v1`, `v1.28.8`, `v2.0.0-beta.1`), action refs (`@v1`, `@v1.28.8`), and any semver-like token. Never emit a bare version.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Prompt-only change.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

The next changelog generation run will exercise the new prompt rule.

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved AI-generated changelog formatting by enforcing consistent backtick wrapping for all version references and tags, ensuring better readability and consistency in auto-generated release notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->