### PR TITLE
feat(frontend-pr-analysis): add optional i18n key validation job

### DIFF
--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -83,6 +83,22 @@ on:
         description: 'Enable build verification'
         type: boolean
         default: true
+      enable_i18n_check:
+        description: 'Enable i18n key validation (runs i18n_check_script and i18n_keys_check_script)'
+        type: boolean
+        default: false
+      i18n_check_script:
+        description: 'npm script name for extraction-parity check (verifies no new keys leaked unextracted)'
+        type: string
+        default: 'check:i18n'
+      i18n_keys_check_script:
+        description: 'npm script name for locale-parity check (verifies key parity across locale files)'
+        type: string
+        default: 'check:i18n:keys'
+      i18n_check_fail_on_violation:
+        description: 'Fail the workflow if any i18n check reports violations. Set false to surface as warning only during rollout.'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -568,6 +584,62 @@ jobs:
           esac
 
   # ============================================
+  # I18N KEY CHECKS
+  # ============================================
+  i18n-check:
+    name: i18n Check (${{ matrix.app.name }})
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_i18n_check
+    runs-on: ${{ inputs.runner_type }}
+    strategy:
+      fail-fast: false
+      matrix:
+        app: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: ${{ inputs.package_manager }}
+          cache-dependency-path: ${{ matrix.app.working_dir }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.app.working_dir }}
+        run: |
+          case "${{ inputs.package_manager }}" in
+            yarn) yarn install --frozen-lockfile ;;
+            pnpm) pnpm install --frozen-lockfile ;;
+            *) npm ci ;;
+          esac
+
+      - name: Check i18n keys (extraction parity)
+        working-directory: ${{ matrix.app.working_dir }}
+        continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
+        env:
+          I18N_SCRIPT: ${{ inputs.i18n_check_script }}
+        run: |
+          case "${{ inputs.package_manager }}" in
+            yarn) yarn run "$I18N_SCRIPT" ;;
+            pnpm) pnpm run "$I18N_SCRIPT" ;;
+            *) npm run "$I18N_SCRIPT" ;;
+          esac
+
+      - name: Check i18n keys (locale parity)
+        working-directory: ${{ matrix.app.working_dir }}
+        continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
+        env:
+          I18N_KEYS_SCRIPT: ${{ inputs.i18n_keys_check_script }}
+        run: |
+          case "${{ inputs.package_manager }}" in
+            yarn) yarn run "$I18N_KEYS_SCRIPT" ;;
+            pnpm) pnpm run "$I18N_KEYS_SCRIPT" ;;
+            *) npm run "$I18N_KEYS_SCRIPT" ;;
+          esac
+
+  # ============================================
   # NO CHANGES DETECTED
   # ============================================
   no-changes:
@@ -586,12 +658,12 @@ jobs:
   # ============================================
   notify:
     name: Notify
-    needs: [detect-changes, lint, typecheck, security, tests, build]
+    needs: [detect-changes, lint, typecheck, security, tests, build, i18n-check]
     if: always() && needs.detect-changes.outputs.has_changes == 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
-      status: ${{ (needs.lint.result == 'failure' || needs.typecheck.result == 'failure' || needs.security.result == 'failure' || needs.tests.result == 'failure' || needs.build.result == 'failure') && 'failure' || 'success' }}
+      status: ${{ (needs.lint.result == 'failure' || needs.typecheck.result == 'failure' || needs.security.result == 'failure' || needs.tests.result == 'failure' || needs.build.result == 'failure' || needs.i18n-check.result == 'failure') && 'failure' || 'success' }}
       workflow_name: "Frontend PR Analysis"
-      failed_jobs: ${{ needs.lint.result == 'failure' && 'Lint, ' || '' }}${{ needs.typecheck.result == 'failure' && 'TypeCheck, ' || '' }}${{ needs.security.result == 'failure' && 'Security, ' || '' }}${{ needs.tests.result == 'failure' && 'Tests, ' || '' }}${{ needs.build.result == 'failure' && 'Build' || '' }}
+      failed_jobs: ${{ needs.lint.result == 'failure' && 'Lint, ' || '' }}${{ needs.typecheck.result == 'failure' && 'TypeCheck, ' || '' }}${{ needs.security.result == 'failure' && 'Security, ' || '' }}${{ needs.tests.result == 'failure' && 'Tests, ' || '' }}${{ needs.build.result == 'failure' && 'Build, ' || '' }}${{ needs.i18n-check.result == 'failure' && 'i18n Check' || '' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -608,8 +608,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.working_dir }}
+        env:
+          PKG_MANAGER: ${{ inputs.package_manager }}
         run: |
-          case "${{ inputs.package_manager }}" in
+          case "$PKG_MANAGER" in
             yarn) yarn install --frozen-lockfile ;;
             pnpm) pnpm install --frozen-lockfile ;;
             *) npm ci ;;
@@ -619,9 +621,10 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
         env:
+          PKG_MANAGER: ${{ inputs.package_manager }}
           I18N_SCRIPT: ${{ inputs.i18n_check_script }}
         run: |
-          case "${{ inputs.package_manager }}" in
+          case "$PKG_MANAGER" in
             yarn) yarn run "$I18N_SCRIPT" ;;
             pnpm) pnpm run "$I18N_SCRIPT" ;;
             *) npm run "$I18N_SCRIPT" ;;
@@ -631,9 +634,10 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
         env:
+          PKG_MANAGER: ${{ inputs.package_manager }}
           I18N_KEYS_SCRIPT: ${{ inputs.i18n_keys_check_script }}
         run: |
-          case "${{ inputs.package_manager }}" in
+          case "$PKG_MANAGER" in
             yarn) yarn run "$I18N_KEYS_SCRIPT" ;;
             pnpm) pnpm run "$I18N_KEYS_SCRIPT" ;;
             *) npm run "$I18N_KEYS_SCRIPT" ;;

--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -618,8 +618,9 @@ jobs:
           esac
 
       - name: Check i18n keys (extraction parity)
+        id: i18n_extraction
         working-directory: ${{ matrix.app.working_dir }}
-        continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
+        continue-on-error: true
         env:
           PKG_MANAGER: ${{ inputs.package_manager }}
           I18N_SCRIPT: ${{ inputs.i18n_check_script }}
@@ -631,8 +632,9 @@ jobs:
           esac
 
       - name: Check i18n keys (locale parity)
+        id: i18n_locale
         working-directory: ${{ matrix.app.working_dir }}
-        continue-on-error: ${{ !inputs.i18n_check_fail_on_violation }}
+        continue-on-error: true
         env:
           PKG_MANAGER: ${{ inputs.package_manager }}
           I18N_KEYS_SCRIPT: ${{ inputs.i18n_keys_check_script }}
@@ -642,6 +644,15 @@ jobs:
             pnpm) pnpm run "$I18N_KEYS_SCRIPT" ;;
             *) npm run "$I18N_KEYS_SCRIPT" ;;
           esac
+
+      - name: Fail on i18n violations
+        if: inputs.i18n_check_fail_on_violation && (steps.i18n_extraction.outcome == 'failure' || steps.i18n_locale.outcome == 'failure')
+        env:
+          EXTRACTION_OUTCOME: ${{ steps.i18n_extraction.outcome }}
+          LOCALE_OUTCOME: ${{ steps.i18n_locale.outcome }}
+        run: |
+          echo "::error::i18n validation failed (extraction=$EXTRACTION_OUTCOME, locale=$LOCALE_OUTCOME)"
+          exit 1
 
   # ============================================
   # NO CHANGES DETECTED

--- a/docs/frontend-pr-analysis-workflow.md
+++ b/docs/frontend-pr-analysis-workflow.md
@@ -12,6 +12,7 @@ Reusable workflow for comprehensive Frontend/Node.js PR analysis in monorepos. H
 - **Unit Tests**: Runs tests with Jest/Vitest and coverage
 - **Coverage Check**: Threshold enforcement with PR comments
 - **Build Verification**: Ensures code compiles successfully
+- **i18n Key Checks**: Optional FormatJS extraction-parity and locale-parity validation
 - **Skip Logic**: Gracefully skips when no frontend changes detected
 - **Package Manager Support**: npm, yarn, and pnpm
 
@@ -104,6 +105,29 @@ jobs:
     secrets: inherit
 ```
 
+### With i18n Key Checks (FormatJS)
+
+```yaml
+jobs:
+  analysis:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/frontend-pr-analysis.yml@v1.0.0
+    with:
+      app_name_prefix: "product-console"
+      enable_i18n_check: true
+      # i18n_check_script and i18n_keys_check_script default to
+      # 'check:i18n' and 'check:i18n:keys' — override if your package.json
+      # uses different script names.
+    secrets: inherit
+```
+
+Warning-only mode during rollout (does not fail the workflow):
+
+```yaml
+with:
+  enable_i18n_check: true
+  i18n_check_fail_on_violation: false
+```
+
 ### With pnpm
 
 ```yaml
@@ -136,6 +160,10 @@ jobs:
 | `enable_tests` | Enable unit tests | No | `true` |
 | `enable_coverage` | Enable coverage check with PR comment | No | `true` |
 | `enable_build` | Enable build verification | No | `true` |
+| `enable_i18n_check` | Enable i18n key validation (runs both i18n scripts) | No | `false` |
+| `i18n_check_script` | npm script for extraction-parity check | No | `check:i18n` |
+| `i18n_keys_check_script` | npm script for locale-parity check | No | `check:i18n:keys` |
+| `i18n_check_fail_on_violation` | Fail the workflow on i18n violations (set `false` for warning-only rollout) | No | `true` |
 
 ## Secrets
 
@@ -178,6 +206,14 @@ Calculates coverage and posts PR comment per changed app:
 
 ### build
 Verifies code compiles/builds successfully per changed app.
+
+### i18n-check
+Optional. Validates internationalization keys per changed app by running two npm scripts:
+
+- `i18n_check_script` (default `check:i18n`) — extraction parity: catches keys used in source that were never extracted to locale files.
+- `i18n_keys_check_script` (default `check:i18n:keys`) — locale parity: catches keys present in some locale files but missing from others.
+
+Gated by `enable_i18n_check` (default `false`). When `i18n_check_fail_on_violation: false`, violations are reported but do not fail the workflow — useful during initial rollout in noisy codebases.
 
 ### no-changes
 Runs when no frontend changes are detected - outputs skip message.

--- a/docs/frontend-pr-analysis-workflow.md
+++ b/docs/frontend-pr-analysis-workflow.md
@@ -208,6 +208,7 @@ Calculates coverage and posts PR comment per changed app:
 Verifies code compiles/builds successfully per changed app.
 
 ### i18n-check
+
 Optional. Validates internationalization keys per changed app by running two npm scripts:
 
 - `i18n_check_script` (default `check:i18n`) — extraction parity: catches keys used in source that were never extracted to locale files.


### PR DESCRIPTION
## Description

Adds an opt-in `i18n-check` job to `frontend-pr-analysis.yml` that runs two npm scripts per changed app — extraction parity and locale parity. Backward-compatible: gated by `enable_i18n_check` (default `false`); existing callers see no behavior change.

Four new inputs: `enable_i18n_check`, `i18n_check_script`, `i18n_keys_check_script`, `i18n_check_fail_on_violation`. The new job is wired into the `notify` aggregation so i18n failures surface in Slack like other jobs. Docs updated with usage example and rollout (warning-only) mode.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** pending — to be validated in `product-console` against `@feat/frontend-i18n-check` before merge.

## Related Issues

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional i18n validation phase to the frontend PR analysis workflow with configurable scripts and toggleable failure behavior; per-app i18n check results are reported and included in notification summaries.
  * Slack notifications now incorporate i18n-check outcomes into overall status and failed-job reporting.

* **Documentation**
  * Workflow docs updated with i18n validation examples, inputs, and rollout/failure configuration guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/343)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->