### PR TITLE
fix(propagation): pass workflow_files as bash array to apply-bump

### DIFF
--- a/src/config/version-propagation/action.yml
+++ b/src/config/version-propagation/action.yml
@@ -126,6 +126,15 @@ runs:
           # apply-bump.sh, which then matches nothing and reports a false
           # "already on $NEW_TAG".
           mapfile -t globs < <(jq -r '.workflow_files[]' <<<"$target")
+          if [[ ${#globs[@]} -eq 0 ]]; then
+            # Would silently report "already on $NEW_TAG" downstream (same
+            # failure shape as the bug this composite was built to avoid).
+            echo "::warning::workflow_files is empty for $repo@$branch — check config defaults"
+            printf '| %s | %s | skip | invalid-config |\n' "$repo" "$branch" >> "$summary_file"
+            had_failure=1
+            echo "::endgroup::"
+            continue
+          fi
           auto_merge=$(jq -r ".auto_merge.${BUMP_LEVEL}" <<<"$target")
 
           echo "::group::$repo ($branch)"

--- a/src/config/version-propagation/action.yml
+++ b/src/config/version-propagation/action.yml
@@ -129,10 +129,11 @@ runs:
           if [[ ${#globs[@]} -eq 0 ]]; then
             # Would silently report "already on $NEW_TAG" downstream (same
             # failure shape as the bug this composite was built to avoid).
+            # No `::endgroup::` here — the per-target `::group::` is opened
+            # only after this guard passes.
             echo "::warning::workflow_files is empty for $repo@$branch — check config defaults"
             printf '| %s | %s | skip | invalid-config |\n' "$repo" "$branch" >> "$summary_file"
             had_failure=1
-            echo "::endgroup::"
             continue
           fi
           auto_merge=$(jq -r ".auto_merge.${BUMP_LEVEL}" <<<"$target")

--- a/src/config/version-propagation/action.yml
+++ b/src/config/version-propagation/action.yml
@@ -119,7 +119,13 @@ runs:
         while IFS= read -r target; do
           repo=$(jq -r '.repo' <<<"$target")
           branch=$(jq -r '.target_branch' <<<"$target")
-          globs=$(jq -r '.workflow_files | join(" ")' <<<"$target")
+          # Read globs into an array so we never expose the patterns to
+          # word-splitting + pathname expansion in the parent shell. Otherwise a
+          # `*.yml` literal at the target repo root (e.g. docker-compose.yml)
+          # would silently rewrite the glob to that filename before reaching
+          # apply-bump.sh, which then matches nothing and reports a false
+          # "already on $NEW_TAG".
+          mapfile -t globs < <(jq -r '.workflow_files[]' <<<"$target")
           auto_merge=$(jq -r ".auto_merge.${BUMP_LEVEL}" <<<"$target")
 
           echo "::group::$repo ($branch)"
@@ -135,7 +141,7 @@ runs:
 
           pushd "$workdir" >/dev/null
           rc=0
-          "$ACTION_PATH/scripts/apply-bump.sh" "$NEW_TAG" $globs || rc=$?
+          "$ACTION_PATH/scripts/apply-bump.sh" "$NEW_TAG" "${globs[@]}" || rc=$?
           if [[ "$rc" -eq 10 ]]; then
             echo "no version changes for $repo (already on $NEW_TAG)"
             printf '| %s | %s | skip | up-to-date |\n' "$repo" "$branch" >> "$summary_file"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Real-world bug observed in [run 25758785218](https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/25758785218/job/75655301604): the `v1.28.10` propagation reported `LerianStudio/go-boilerplate-ddd` as `already on v1.28.10` while the repo was actually still pinned to `v1.28.5`.

Root cause: in `src/config/version-propagation/action.yml`, the workflow_files globs were assembled with `globs=$(jq -r '.workflow_files | join(" ")' <<<"$target")` and then passed unquoted to `apply-bump.sh`:

```bash
"$ACTION_PATH/scripts/apply-bump.sh" "$NEW_TAG" $globs   # unquoted — bug
```

Because the per-target loop runs **after** `pushd "$workdir"` (the cloned target repo), the parent shell performed both word-splitting and **pathname expansion** of `*.yml` against the target's root. `go-boilerplate-ddd` has `docker-compose.yml` at the repo root, so `*.yml` expanded to `docker-compose.yml` before `apply-bump.sh` was even invoked. The script then looked for `.github/workflows/docker-compose.yml` (which never exists), `nullglob` zeroed the inner loop, the script returned exit 10, and the composite incorrectly reported the target as up-to-date.

Fix: read `workflow_files` into a bash array and pass it quoted, so the patterns reach `apply-bump.sh` as literals. The intentional `nullglob`-scoped expansion inside `.github/workflows/` still happens inside the script.

```bash
mapfile -t globs < <(jq -r '.workflow_files[]' <<<"$target")
"$ACTION_PATH/scripts/apply-bump.sh" "$NEW_TAG" "${globs[@]}"
```

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Behavior change is strictly corrective: previously-skipped targets with root-level `*.yml` files will now be processed as designed. Targets that were already being rewritten correctly remain unaffected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (no input or default change)
- [x] Confirmed no secrets or tokens are printed in logs (no logging change)
- [x] Checked that unrelated workflows are not affected (single-line change inside an internal composite action)

**Caller repo / workflow run:** Will validate after merge on the next stable release — expect `go-boilerplate-ddd/main` to be rewritten from `v1.28.5` to the new tag in the same propagation job.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version propagation to correctly handle multiple workflow file patterns by treating each pattern separately, validating empty pattern lists (emits a warning and skips invalid targets), and passing patterns intact to downstream steps to prevent unintended splitting or pathname expansion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/347)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->