### PR TITLE
feat(build): add app_name input for single-app image name override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,14 +181,19 @@ jobs:
 
       - name: Set matrix
         id: set-matrix
+        env:
+          APP_NAME_INPUT: ${{ inputs.app_name }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          FILTER_PATHS: ${{ inputs.filter_paths }}
+          CHANGED_MATRIX: ${{ steps.changed-paths.outputs.matrix }}
         run: |
-          if [ -z "${{ inputs.filter_paths }}" ]; then
+          if [ -z "$FILTER_PATHS" ]; then
             # Single app mode - build from root
-            APP_NAME="${{ inputs.app_name != '' && inputs.app_name || github.event.repository.name }}"
+            APP_NAME="${APP_NAME_INPUT:-$REPO_NAME}"
             echo "matrix=[{\"name\": \"${APP_NAME}\", \"working_dir\": \".\"}]" >> "$GITHUB_OUTPUT"
             echo "has_builds=true" >> "$GITHUB_OUTPUT"
           else
-            MATRIX='${{ steps.changed-paths.outputs.matrix }}'
+            MATRIX="$CHANGED_MATRIX"
             if [ "$MATRIX" == "[]" ] || [ -z "$MATRIX" ]; then
               echo "matrix=[]" >> "$GITHUB_OUTPUT"
               echo "has_builds=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,11 @@ on:
         description: 'Name of the Dockerfile'
         type: string
         default: 'Dockerfile'
+      app_name:
+        description: 'Override app/image name (single-app mode only, i.e. when filter_paths is empty). Defaults to repository name.'
+        type: string
+        required: false
+        default: ''
       app_name_prefix:
         description: 'Prefix for app names in monorepo (e.g., "midaz" results in "midaz-agent")'
         type: string
@@ -179,7 +184,7 @@ jobs:
         run: |
           if [ -z "${{ inputs.filter_paths }}" ]; then
             # Single app mode - build from root
-            APP_NAME="${{ github.event.repository.name }}"
+            APP_NAME="${{ inputs.app_name != '' && inputs.app_name || github.event.repository.name }}"
             echo "matrix=[{\"name\": \"${APP_NAME}\", \"working_dir\": \".\"}]" >> "$GITHUB_OUTPUT"
             echo "has_builds=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,10 @@ jobs:
           if [ -z "$FILTER_PATHS" ]; then
             # Single app mode - build from root
             APP_NAME="${APP_NAME_INPUT:-$REPO_NAME}"
+            if [[ ! "$APP_NAME" =~ ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$ ]]; then
+              echo "::error::Invalid app_name '${APP_NAME}'. Must match Docker image name rules: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$"
+              exit 1
+            fi
             echo "matrix=[{\"name\": \"${APP_NAME}\", \"working_dir\": \".\"}]" >> "$GITHUB_OUTPUT"
             echo "has_builds=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds an optional `app_name` input to the `build.yml` reusable workflow so callers can override the Docker image name in single-app mode (when `filter_paths` is empty). When omitted, the workflow keeps using `github.event.repository.name`, preserving existing behavior for all current callers.

This unblocks repositories that need to build multiple Docker images from different Dockerfiles (e.g. `plugin-br-pix-direct-jd` with both `docker-app.Dockerfile` and `docker-job.Dockerfile`) by allowing the shared workflow to be called multiple times with distinct image names.

**Affected workflow:** `.github/workflows/build.yml`
- New input: `app_name` (string, optional, default `''`)
- `set-matrix` step now resolves `APP_NAME` as `inputs.app_name` when provided, falling back to `github.event.repository.name`

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The new input is optional with an empty default, and the fallback expression preserves the previous behavior (`github.event.repository.name`) for every existing caller.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** to be validated on `plugin-br-pix-direct-jd` after merge of a beta tag.

## Related Issues

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional input to override the app/image name in single-app mode (when no path filters are set).
  * If not provided, the app/image name falls back to the repository name.
  * Single-app builds continue to run from the repository root and mark builds as present for that mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/351)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->