### PR TITLE
fix(gitops): match single-app artifact in default download pattern

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -36,7 +36,7 @@ on:
         type: string
         default: 'main'
       artifact_pattern:
-        description: 'Pattern to download artifacts (defaults to "gitops-tags-<repo-name>-*" if not provided)'
+        description: 'Pattern to download artifacts (defaults to "gitops-tags-<repo-name>*" if not provided, matching both single-app and monorepo artifact names)'
         type: string
         required: false
       yaml_key_mappings:
@@ -167,7 +167,7 @@ jobs:
 
           # Generate artifact pattern if not provided
           if [[ -z "${{ inputs.artifact_pattern }}" ]]; then
-            ARTIFACT_PATTERN="gitops-tags-${APP_NAME}-*"
+            ARTIFACT_PATTERN="gitops-tags-${APP_NAME}*"
           else
             ARTIFACT_PATTERN="${{ inputs.artifact_pattern }}"
           fi


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fixes a naming mismatch between `build.yml` and `gitops-update.yml` that broke GitOps updates for all single-app (non-monorepo) repositories.

`build.yml` uploads its GitOps artifact as `gitops-tags-${{ matrix.app.name }}`, which for single-app repos resolves to `gitops-tags-<repo-name>` (e.g., `gitops-tags-plugin-fees`).

`gitops-update.yml` built its default download pattern as `gitops-tags-${APP_NAME}-*`. The trailing `-*` glob requires at least one character after the hyphen, so it never matched the single-app artifact name. The fallback legacy name `gitops-tags` also did not match, so the `Validate artifacts exist` step failed with `No artifacts directory found`, blocking GitOps updates and ArgoCD syncs for every single-app caller at `v1.13.1`.

**Fix:** drop the hyphen from the default pattern → `gitops-tags-${APP_NAME}*`. This matches both:
- `gitops-tags-plugin-fees` (single-app)
- `gitops-tags-plugin-fees-api` (monorepo)

Monorepo callers that already pass `artifact_pattern` explicitly are unaffected. The `artifact_pattern` input description is updated to reflect the new default.

**Affected workflow:** `.github/workflows/gitops-update.yml`

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The change only widens the default glob; previously-matching artifact names continue to match, and callers passing an explicit `artifact_pattern` are not affected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** to be validated on `plugin-fees` (the affected repo in #106) once a beta tag is cut.

## Related Issues

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitOps workflow artifact pattern matching behavior. The default pattern now matches `gitops-tags-<repo-name>*` instead of `gitops-tags-<repo-name>-*`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->