### PR TITLE
feat(pr-analysis): migrate detect-changes to changed-paths composite

### DIFF
--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -113,123 +113,18 @@ jobs:
     name: Detect Changes
     runs-on: ${{ inputs.runner_type }}
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+      matrix: ${{ steps.changed-paths.outputs.matrix }}
+      has_changes: ${{ steps.changed-paths.outputs.has_changes }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Get changed paths
+        id: changed-paths
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
-          fetch-depth: 0
-
-      - name: Get changed files
-        id: changed
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_REF: ${{ github.base_ref }}
-          EVENT_BEFORE: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git fetch origin "$PR_BASE_SHA" --depth=1 2>/dev/null || true
-            FILES=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" 2>/dev/null || git diff --name-only "origin/${BASE_REF}...HEAD")
-          elif [[ "$EVENT_BEFORE" == "0000000000000000000000000000000000000000" ]] || [[ -z "$EVENT_BEFORE" ]]; then
-            if PREV_COMMIT=$(git rev-parse HEAD^); then
-              FILES=$(git diff --name-only "$PREV_COMMIT" HEAD)
-            else
-              FILES=$(git ls-tree -r --name-only HEAD)
-            fi
-          else
-            FILES=$(git diff --name-only "$EVENT_BEFORE" "$CURRENT_SHA")
-          fi
-          printf "files<<EOF\n%s\nEOF\n" "$FILES" >> "$GITHUB_OUTPUT"
-
-      - name: Build matrix from changed paths
-        id: set-matrix
-        shell: bash
-        run: |
-          FILES="${{ steps.changed.outputs.files }}"
-          FILTER_PATHS='${{ inputs.filter_paths }}'
-          PATH_LEVEL="${{ inputs.path_level }}"
-          APP_NAME_PREFIX="${{ inputs.app_name_prefix }}"
-
-          if [[ -z "$FILES" ]]; then
-            echo "No files changed."
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Single-app mode: if filter_paths is empty, run against root directory
-          if [[ -z "$FILTER_PATHS" ]] || [[ "$FILTER_PATHS" == "[]" ]] || [[ "$FILTER_PATHS" == "" ]]; then
-            echo "Single-app mode: no filter_paths specified, running against root directory"
-            if [[ -n "$APP_NAME_PREFIX" ]]; then
-              APP_NAME="$APP_NAME_PREFIX"
-            else
-              APP_NAME="app"
-            fi
-            MATRIX="[{\"name\":\"$APP_NAME\",\"working_dir\":\".\"}]"
-            echo "Single app matrix: $MATRIX"
-            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Monorepo mode: filter and build matrix from changed paths
-          echo "Monorepo mode: filtering by paths $FILTER_PATHS"
-
-          DIRS=$(echo "$FILES" | xargs -n1 dirname)
-
-          if [[ -n "$PATH_LEVEL" ]] && [[ "$PATH_LEVEL" -gt 0 ]]; then
-            DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
-          fi
-
-          FILTER_LIST=$(echo "$FILTER_PATHS" | jq -r '.[]' 2>/dev/null || echo "")
-          if [[ -n "$FILTER_LIST" ]]; then
-            FILTERED=""
-            while read -r DIR; do
-              while read -r FILTER; do
-                if [[ "$DIR" == "$FILTER"* ]]; then
-                  FILTERED+="$DIR"$'\n'
-                  break
-                fi
-              done <<< "$FILTER_LIST"
-            done <<< "$DIRS"
-            DIRS="$FILTERED"
-          fi
-
-          DIRS=$(echo "$DIRS" | grep -v '^$' | sort -u || true)
-
-          if [[ -z "$DIRS" ]]; then
-            echo "No matching directories found."
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          MATRIX="["
-          FIRST=true
-          while read -r DIR; do
-            if [[ -n "$APP_NAME_PREFIX" ]]; then
-              APP_NAME="${APP_NAME_PREFIX}-$(echo "$DIR" | rev | cut -d'/' -f1 | rev)"
-            else
-              APP_NAME="$(echo "$DIR" | rev | cut -d'/' -f1 | rev)"
-            fi
-            ENTRY="{\"name\":\"$APP_NAME\",\"working_dir\":\"$DIR\"}"
-            if $FIRST; then
-              MATRIX+="$ENTRY"
-              FIRST=false
-            else
-              MATRIX+=",$ENTRY"
-            fi
-          done <<< "$DIRS"
-          MATRIX+="]"
-
-          echo "Changed apps matrix: $MATRIX"
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          filter-paths: ${{ inputs.filter_paths }}
+          path-level: ${{ inputs.path_level }}
+          get-app-name: 'true'
+          app-name-prefix: ${{ inputs.app_name_prefix }}
+          fallback-app-name: ${{ inputs.app_name_prefix != '' && inputs.app_name_prefix || 'app' }}
 
   # ============================================
   # ESLINT

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -103,129 +103,18 @@ jobs:
     name: Detect Changes
     runs-on: ${{ inputs.runner_type }}
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+      matrix: ${{ steps.changed-paths.outputs.matrix }}
+      has_changes: ${{ steps.changed-paths.outputs.has_changes }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Get changed paths
+        id: changed-paths
+        uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
-          fetch-depth: 0
-
-      - name: Get changed files
-        id: changed
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_REF: ${{ github.base_ref }}
-          EVENT_BEFORE: ${{ github.event.before }}
-          GITHUB_SHA_ENV: ${{ github.sha }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            # For PRs, compare base and head
-            git fetch origin "$PR_BASE_SHA" --depth=1 2>/dev/null || true
-            FILES=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" 2>/dev/null || git diff --name-only "origin/${BASE_REF}...HEAD")
-          elif [[ "$EVENT_BEFORE" == "0000000000000000000000000000000000000000" ]] || [[ -z "$EVENT_BEFORE" ]]; then
-            if PREV_COMMIT=$(git rev-parse HEAD^); then
-              FILES=$(git diff --name-only "$PREV_COMMIT" HEAD)
-            else
-              FILES=$(git ls-tree -r --name-only HEAD)
-            fi
-          else
-            FILES=$(git diff --name-only "$EVENT_BEFORE" "$GITHUB_SHA_ENV")
-          fi
-          printf "files<<EOF\n%s\nEOF\n" "$FILES" >> "$GITHUB_OUTPUT"
-
-      - name: Build matrix from changed paths
-        id: set-matrix
-        shell: bash
-        run: |
-          FILES="${{ steps.changed.outputs.files }}"
-          FILTER_PATHS='${{ inputs.filter_paths }}'
-          PATH_LEVEL="${{ inputs.path_level }}"
-          APP_NAME_PREFIX="${{ inputs.app_name_prefix }}"
-
-          if [[ -z "$FILES" ]]; then
-            echo "No files changed."
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Single-app mode: if filter_paths is empty, run against root directory
-          if [[ -z "$FILTER_PATHS" ]] || [[ "$FILTER_PATHS" == "[]" ]] || [[ "$FILTER_PATHS" == "" ]]; then
-            echo "Single-app mode: no filter_paths specified, running against root directory"
-            if [[ -n "$APP_NAME_PREFIX" ]]; then
-              APP_NAME="$APP_NAME_PREFIX"
-            else
-              APP_NAME="app"
-            fi
-            MATRIX="[{\"name\":\"$APP_NAME\",\"working_dir\":\".\"}]"
-            echo "Single app matrix: $MATRIX"
-            echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Monorepo mode: filter and build matrix from changed paths
-          echo "Monorepo mode: filtering by paths $FILTER_PATHS"
-
-          # Get directory for each file
-          DIRS=$(echo "$FILES" | xargs -n1 dirname)
-
-          # Trim to first N path segments
-          if [[ -n "$PATH_LEVEL" ]] && [[ "$PATH_LEVEL" -gt 0 ]]; then
-            DIRS=$(echo "$DIRS" | cut -d'/' -f-"$PATH_LEVEL")
-          fi
-
-          # Filter paths
-          FILTER_LIST=$(echo "$FILTER_PATHS" | jq -r '.[]' 2>/dev/null || echo "")
-          if [[ -n "$FILTER_LIST" ]]; then
-            FILTERED=""
-            while read -r DIR; do
-              while read -r FILTER; do
-                if [[ "$DIR" == "$FILTER"* ]]; then
-                  FILTERED+="$DIR"$'\n'
-                  break
-                fi
-              done <<< "$FILTER_LIST"
-            done <<< "$DIRS"
-            DIRS="$FILTERED"
-          fi
-
-          # Deduplicate and remove empty lines
-          DIRS=$(echo "$DIRS" | grep -v '^$' | sort -u || true)
-
-          if [[ -z "$DIRS" ]]; then
-            echo "No matching directories found."
-            echo "matrix=[]" >> "$GITHUB_OUTPUT"
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Build matrix with app names
-          MATRIX="["
-          FIRST=true
-          while read -r DIR; do
-            if [[ -n "$APP_NAME_PREFIX" ]]; then
-              APP_NAME="${APP_NAME_PREFIX}-$(echo "$DIR" | rev | cut -d'/' -f1 | rev)"
-            else
-              APP_NAME="$(echo "$DIR" | rev | cut -d'/' -f1 | rev)"
-            fi
-            ENTRY="{\"name\":\"$APP_NAME\",\"working_dir\":\"$DIR\"}"
-            if $FIRST; then
-              MATRIX+="$ENTRY"
-              FIRST=false
-            else
-              MATRIX+=",$ENTRY"
-            fi
-          done <<< "$DIRS"
-          MATRIX+="]"
-
-          echo "Changed apps matrix: $MATRIX"
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          filter-paths: ${{ inputs.filter_paths }}
+          path-level: ${{ inputs.path_level }}
+          get-app-name: 'true'
+          app-name-prefix: ${{ inputs.app_name_prefix }}
+          fallback-app-name: ${{ inputs.app_name_prefix != '' && inputs.app_name_prefix || 'app' }}
 
   # ============================================
   # GOLANGCI-LINT

--- a/docs/frontend-pr-analysis-workflow.md
+++ b/docs/frontend-pr-analysis-workflow.md
@@ -177,7 +177,7 @@ Uses `secrets: inherit` pattern. Required secrets:
 ## Jobs
 
 ### detect-changes
-Detects which apps have changes based on `filter_paths`. Outputs a matrix of changed apps for subsequent jobs.
+Detects which apps have changes based on `filter_paths`, delegating to the [`changed-paths`](../src/config/changed-paths/README.md) composite action. Outputs a matrix of changed apps for subsequent jobs.
 
 ### lint
 Runs ESLint per changed app. Configurable arguments via `eslint_args`.

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -139,7 +139,7 @@ Uses `secrets: inherit` pattern. Required secrets:
 ## Jobs
 
 ### detect-changes
-Detects which apps have changes based on `filter_paths`. Outputs a matrix of changed apps for subsequent jobs.
+Detects which apps have changes based on `filter_paths`, delegating to the [`changed-paths`](../src/config/changed-paths/README.md) composite action. Outputs a matrix of changed apps for subsequent jobs.
 
 ### lint
 Runs GolangCI-Lint per changed app. Configurable version and arguments.


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Migrates the `detect-changes` job in the `go-pr-analysis.yml` and `frontend-pr-analysis.yml` reusable workflows from inline bash to a call to the shared `changed-paths` composite action, referenced as `LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1`.

This removes ~216 lines of duplicated change-detection logic and centralizes future improvements (tag-channel diffing, `app_name_overrides`, `shared_paths`, `consolidate_to_root`, etc.) in a single place. Other workflows in this repo (`build.yml`, `pr-security-scan.yml`) already consume the same composite.

**Behavior preserved:**
- Job outputs `matrix` and `has_changes` keep the same shape (`[{name, working_dir}]`, boolean).
- Single-app mode (when `filter_paths` is empty) is preserved via `fallback-app-name` derived from `app_name_prefix` (defaults to `"app"`).
- No PR diff fallback was needed in the composite: it already checks out with `fetch-depth: 0`, so `git diff "$PR_BASE_SHA" HEAD` resolves without the shallow-clone workaround the inline logic carried.

**Affected workflows:** `go-pr-analysis`, `frontend-pr-analysis`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [x] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None for typical usage (`filter_paths=["apps/X"]` with `path_level=2`, which is the established pattern across LerianStudio repos).

Note: the composite extracts app names from the **2nd path segment** (`cut -d'/' -f2`), while the previous inline logic used the **last segment** (`rev | cut -d'/' -f1 | rev`). For the common `filter_paths=["apps/foo"]` + `path_level=2` shape both produce the same name (`foo`). Results may diverge only for unusual `path_level` / path-depth combinations that no current caller is known to use.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be validated against a caller repo via the resulting beta tag before promoting to a stable release._

## Related Issues

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored PR analysis workflows for frontend and Go services to consolidate change detection using a shared action.
  * Simplified workflow job output generation for matrix and change status.

* **Documentation**
  * Updated PR analysis workflow documentation to reflect change detection improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/354)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->