### PR TITLE
fix(security-reporter): validate github-script output before parsing

### DIFF
--- a/src/security/codeql-reporter/action.yml
+++ b/src/security/codeql-reporter/action.yml
@@ -319,8 +319,14 @@ runs:
           exit 1
         fi
 
-        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings')
-        FINDINGS_COUNT=$(echo "$RESULT" | jq -r '.findings_count')
+        HAS_FINDINGS=$(echo "$RESULT" | jq -er '.has_findings | if type=="boolean" then tostring else error("has_findings must be boolean") end') || {
+          echo "::error::codeql-reporter: github-script output missing or invalid \`has_findings\` (expected boolean). Raw output: $RESULT"
+          exit 1
+        }
+        FINDINGS_COUNT=$(echo "$RESULT" | jq -er '.findings_count | if (type=="number" and . >= 0 and floor == .) then tostring else error("findings_count must be a non-negative integer") end') || {
+          echo "::error::codeql-reporter: github-script output missing or invalid \`findings_count\` (expected non-negative integer). Raw output: $RESULT"
+          exit 1
+        }
         echo "has_findings=$HAS_FINDINGS" >> "$GITHUB_OUTPUT"
         echo "findings_count=$FINDINGS_COUNT" >> "$GITHUB_OUTPUT"
         echo "Parsed outputs: has_findings=$HAS_FINDINGS, findings_count=$FINDINGS_COUNT"

--- a/src/security/codeql-reporter/action.yml
+++ b/src/security/codeql-reporter/action.yml
@@ -306,8 +306,21 @@ runs:
       env:
         RESULT: ${{ steps.report.outputs.result }}
       run: |
-        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings // false')
-        FINDINGS_COUNT=$(echo "$RESULT" | jq -r '.findings_count // 0')
+        set -euo pipefail
+
+        if [ -z "$RESULT" ]; then
+          echo "::error::codeql-reporter: github-script produced no output. The script step likely failed (API error, rate limit, or runtime exception). Check the previous step's logs."
+          exit 1
+        fi
+
+        if ! echo "$RESULT" | jq empty >/dev/null 2>&1; then
+          echo "::error::codeql-reporter: github-script output is not valid JSON. Raw output:"
+          echo "$RESULT"
+          exit 1
+        fi
+
+        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings')
+        FINDINGS_COUNT=$(echo "$RESULT" | jq -r '.findings_count')
         echo "has_findings=$HAS_FINDINGS" >> "$GITHUB_OUTPUT"
         echo "findings_count=$FINDINGS_COUNT" >> "$GITHUB_OUTPUT"
         echo "Parsed outputs: has_findings=$HAS_FINDINGS, findings_count=$FINDINGS_COUNT"

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -461,8 +461,14 @@ runs:
           exit 1
         fi
 
-        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings')
-        HAS_ERRORS=$(echo "$RESULT" | jq -r '.has_errors')
+        HAS_FINDINGS=$(echo "$RESULT" | jq -er '.has_findings | if type=="boolean" then tostring else error("has_findings must be boolean") end') || {
+          echo "::error::pr-security-reporter: github-script output missing or invalid \`has_findings\` (expected boolean). Raw output: $RESULT"
+          exit 1
+        }
+        HAS_ERRORS=$(echo "$RESULT" | jq -er '.has_errors | if type=="boolean" then tostring else error("has_errors must be boolean") end') || {
+          echo "::error::pr-security-reporter: github-script output missing or invalid \`has_errors\` (expected boolean). Raw output: $RESULT"
+          exit 1
+        }
         echo "has_findings=$HAS_FINDINGS" >> "$GITHUB_OUTPUT"
         echo "has_errors=$HAS_ERRORS" >> "$GITHUB_OUTPUT"
         echo "Parsed outputs: has_findings=$HAS_FINDINGS, has_errors=$HAS_ERRORS"

--- a/src/security/pr-security-reporter/action.yml
+++ b/src/security/pr-security-reporter/action.yml
@@ -445,10 +445,24 @@ runs:
     - name: Parse outputs
       id: parse-outputs
       shell: bash
+      env:
+        RESULT: ${{ steps.report.outputs.result }}
       run: |
-        RESULT='${{ steps.report.outputs.result }}'
-        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings // false')
-        HAS_ERRORS=$(echo "$RESULT" | jq -r '.has_errors // false')
+        set -euo pipefail
+
+        if [ -z "$RESULT" ]; then
+          echo "::error::pr-security-reporter: github-script produced no output. The script step likely failed (API error, rate limit, or runtime exception). Check the previous step's logs."
+          exit 1
+        fi
+
+        if ! echo "$RESULT" | jq empty >/dev/null 2>&1; then
+          echo "::error::pr-security-reporter: github-script output is not valid JSON. Raw output:"
+          echo "$RESULT"
+          exit 1
+        fi
+
+        HAS_FINDINGS=$(echo "$RESULT" | jq -r '.has_findings')
+        HAS_ERRORS=$(echo "$RESULT" | jq -r '.has_errors')
         echo "has_findings=$HAS_FINDINGS" >> "$GITHUB_OUTPUT"
         echo "has_errors=$HAS_ERRORS" >> "$GITHUB_OUTPUT"
         echo "Parsed outputs: has_findings=$HAS_FINDINGS, has_errors=$HAS_ERRORS"


### PR DESCRIPTION
## Description

The `Parse outputs` step in `pr-security-reporter` and `codeql-reporter` piped the `github-script` step output (`$RESULT`) directly to `jq` with `// false` defaults. If the script step failed silently or returned empty/malformed JSON (API error, rate limit, runtime exception), `jq` defaulted to `false` and downstream gates reported "no findings" — masking real failures.

This PR adds explicit validation in both composites:

- `set -euo pipefail` in the bash step
- Fail fast with `::error::` if `$RESULT` is empty (github-script produced no output)
- Fail fast with `::error::` if `$RESULT` is not valid JSON (`jq empty` check), printing the raw payload to aid debugging
- Drop the `// default` fallbacks from the extraction `jq` calls — the JSON contract is now enforced upstream
- `pr-security-reporter` also moves `result` from inline interpolation to a step-level `env` var for parity with `codeql-reporter` and safer quoting

Affected composites:
- `src/security/pr-security-reporter/action.yml`
- `src/security/codeql-reporter/action.yml`

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. Outputs (`has_findings`, `has_errors`, `findings_count`) keep the same names and semantics on the success path. The only behavior change is that previously-silent failures now surface as a failed step with a clear error annotation.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — will validate via a caller PR after merge to develop_

## Related Issues

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Security reporting actions now perform stricter validation of their outputs: empty or non-JSON results fail immediately, required boolean fields are enforced, and invalid or missing values trigger clear error messages (including raw output) and stop the workflow. This improves detection of malformed reports and increases CI reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/355)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->