### PR TITLE
feat(gitops-update): resilient argocd sync (prune/async/timeout)

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -56,6 +56,10 @@ on:
         description: 'Enable ArgoCD sync after GitOps update'
         type: boolean
         default: true
+      argocd_prune:
+        description: 'Pass --prune to argocd app sync so orphaned resources are cleaned up automatically. Opt-in; safer left disabled in production.'
+        type: boolean
+        default: false
       use_dynamic_mapping:
         description: 'Use dynamic mapping for multiple components (like midaz)'
         type: boolean
@@ -767,8 +771,14 @@ jobs:
           ARGOCD_URL: ${{ secrets.ARGOCD_URL }}
           ARGOCD_TOKEN: ${{ secrets.ARGOCD_GHUSER_TOKEN }}
           APP_NAME: ${{ steps.resolve_argocd_app.outputs.name }}
+          ARGOCD_PRUNE: ${{ inputs.argocd_prune }}
         run: |
           set -uo pipefail
+
+          PRUNE_FLAG=""
+          if [[ "$ARGOCD_PRUNE" == "true" ]]; then
+            PRUNE_FLAG="--prune"
+          fi
 
           echo "::group::argocd app get $APP_NAME"
           if ! argocd app get "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web; then
@@ -781,7 +791,7 @@ jobs:
 
           echo "::group::argocd app sync $APP_NAME"
           for attempt in 1 2 3 4 5; do
-            if argocd app sync "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web; then
+            if argocd app sync "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --async --timeout 180 $PRUNE_FLAG; then
               break
             fi
             if [[ "$attempt" == "5" ]]; then
@@ -789,13 +799,13 @@ jobs:
               echo "::error::Sync failed for $APP_NAME after 5 attempts"
               exit 1
             fi
-            echo "Sync attempt $attempt failed, retrying in 5s..."
-            sleep 5
+            echo "Sync attempt $attempt failed, retrying in 30s..."
+            sleep 30
           done
           echo "::endgroup::"
 
           echo "::group::argocd app wait $APP_NAME"
-          if ! argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web; then
+          if ! argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --timeout 180; then
             echo "::endgroup::"
             echo "::error::Timeout waiting for sync completion of $APP_NAME"
             exit 1

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -123,6 +123,7 @@ update_gitops:
 | `commit_message_prefix` | string | (repo name) | Prefix for commit message (auto-generated) |
 | `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
 | `enable_argocd_sync` | boolean | `true` | Enable ArgoCD sync |
+| `argocd_prune` | boolean | `false` | Pass `--prune` to `argocd app sync` so orphaned resources are cleaned up automatically. Opt-in; safer left disabled in production |
 | `use_dynamic_mapping` | boolean | `false` | Use dynamic mapping for multiple components |
 | `yq_version` | string | `v4.44.3` | Version of yq to install |
 | `enable_docker_login` | boolean | `true` | Enable Docker Hub login to avoid rate limits |
@@ -301,6 +302,12 @@ The workflow uses a matrix strategy for ArgoCD sync:
 2. A separate `argocd_sync` job runs in parallel for each combination
 3. Each job first checks if the ArgoCD app exists before attempting sync
 4. Each sync has `continue-on-error: true` for graceful failure handling
+
+### Sync Command Behavior
+
+The `argocd app sync` call uses `--async --timeout 180`, dispatching the sync without blocking on completion. A subsequent `argocd app wait --timeout 180` confirms the rollout. On failure, the step retries up to 5 times with a 30s interval between attempts.
+
+When `argocd_prune` is `true`, `--prune` is appended so orphaned resources left behind by previous renames/removals are cleaned up automatically. Keep this disabled by default in production and enable per-caller when you knowingly need cleanup.
 
 ### App Existence Check
 


### PR DESCRIPTION
## Description

Makes the ArgoCD sync job in `gitops-update.yml` resilient to the failure mode reported in #152, where `argocd app sync` exited 1 due to `resources require pruning` even though the sync itself applied successfully. The CLI's synchronous wait also conflated dispatch with completion, so transient slowness produced false failures.

Changes to the `argocd_sync` job:

- New optional input `argocd_prune` (boolean, default `false`). When `true`, appends `--prune` so orphaned resources from previous renames/removals are cleaned up automatically during sync. Opt-in to keep production safe.
- `argocd app sync` now runs with `--async --timeout 180` — dispatches the sync without blocking; completion confirmation is delegated to the existing `argocd app wait` step.
- `argocd app wait` gains an explicit `--timeout 180` for predictable behavior independent of CLI defaults.
- Retry interval increased from `5s` to `30s`, giving a previous attempt time to settle before retrying.

`docs/gitops-update-workflow.md` updated with the new input row and a short "Sync Command Behavior" subsection.

The standalone `LerianStudio/github-actions-argocd-sync` action referenced in the original issue lives in a separate repo and will need a parallel change there.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. New input `argocd_prune` defaults to `false`, preserving current behavior. The `--async`/`--timeout` flags do not change the externally observable outcome — the existing `argocd app wait` step still gates job success on actual sync completion.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be added after triggering a real run against this branch_

## Related Issues

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workflow input to control ArgoCD pruning behavior during synchronization.

* **Updates**
  * ArgoCD synchronization now executes asynchronously with 180-second timeout.
  * Retry logic updated to 30-second wait intervals, maximum 5 attempts.

* **Documentation**
  * Updated workflow documentation with new input details and synchronization command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->