### PR TITLE
fix(pr-validation): dedupe source-branch feedback and add summary comment

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -215,7 +215,7 @@ jobs:
     name: Notify
     needs: [blocking-checks, advisory-checks, pr-checks-summary]
     if: always() && github.event.pull_request.draft != true && !inputs.dry_run
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/slack-notify.yml@v1.20.1
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/slack-notify.yml@v1.28.12
     with:
       status: ${{ (needs.blocking-checks.outputs.source-branch-result == 'failure' || needs.blocking-checks.outputs.title-result == 'failure' || needs.blocking-checks.outputs.description-result == 'failure') && 'failure' || 'success' }}
       workflow_name: "PR Validation"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -199,6 +199,7 @@ jobs:
 
     steps:
       - name: Post PR validation summary comment
+        continue-on-error: true
         uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -199,7 +199,7 @@ jobs:
 
     steps:
       - name: Post PR validation summary comment
-        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@develop
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@fix/pr-validation-dedupe-and-summary
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -190,6 +190,26 @@ jobs:
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
           dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
 
+  # ----------------- PR Validation Summary Comment -----------------
+  pr-validation-report:
+    name: PR Validation Report
+    runs-on: ${{ inputs.runner_type }}
+    needs: [blocking-checks, advisory-checks]
+    if: always() && github.event.pull_request.draft != true
+
+    steps:
+      - name: Post PR validation summary comment
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@develop
+        with:
+          github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
+          source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}
+          title-result: ${{ needs.blocking-checks.outputs.title-result || 'skipped' }}
+          description-result: ${{ needs.blocking-checks.outputs.description-result || 'skipped' }}
+          size-result: ${{ needs.advisory-checks.outputs.size-result || 'skipped' }}
+          label-result: ${{ needs.advisory-checks.outputs.label-result || 'skipped' }}
+          metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
+          dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
+
   # ----------------- Slack Notification -----------------
   notify:
     name: Notify

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -199,7 +199,7 @@ jobs:
 
     steps:
       - name: Post PR validation summary comment
-        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@fix/pr-validation-dedupe-and-summary
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -89,7 +89,7 @@ jobs:
         id: source-branch
         if: inputs.enforce_source_branches
         continue-on-error: true
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-source-branch@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-source-branch@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           allowed-branches: ${{ inputs.allowed_source_branches }}
@@ -99,7 +99,7 @@ jobs:
       - name: Validate PR title
         id: title
         continue-on-error: true
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-title@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-title@v1
         with:
           github-token: ${{ github.token }}
           types: ${{ inputs.pr_title_types }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Collect results and enforce blocking
         id: collect
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-blocking-collect@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-blocking-collect@v1
         with:
           source-branch-outcome: ${{ steps.source-branch.outcome || 'skipped' }}
           title-outcome: ${{ steps.title.outcome }}
@@ -139,7 +139,7 @@ jobs:
       - name: Check PR metadata
         id: metadata
         continue-on-error: true
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-metadata@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-metadata@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
@@ -147,7 +147,7 @@ jobs:
       - name: Check PR size
         id: size
         continue-on-error: true
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-size@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-size@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           base-ref: ${{ github.base_ref }}
@@ -157,7 +157,7 @@ jobs:
         id: labels
         if: inputs.enable_auto_labeler && !inputs.dry_run
         continue-on-error: true
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-labels@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-labels@v1
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           config-path: ${{ inputs.labeler_config_path }}
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: PR Checks Summary
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-checks-summary@v1.20.1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-checks-summary@v1
         with:
           source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}
           title-result: ${{ needs.blocking-checks.outputs.title-result || 'skipped' }}

--- a/.github/workflows/routine.yml
+++ b/.github/workflows/routine.yml
@@ -81,7 +81,7 @@ jobs:
   branch_cleanup_merged:
     name: Delete merged branch
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && inputs.merged_branch != ''
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.12
     with:
       merged_branch: ${{ inputs.merged_branch }}
       protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
@@ -93,7 +93,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'branch-cleanup-stale'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/branch-cleanup.yml@v1.28.12
     with:
       stale_days: ${{ inputs.branch_stale_days }}
       protected_branches: ${{ inputs.extra_protected_branches != '' && format('{0},{1}', inputs.protected_branches, inputs.extra_protected_branches) || inputs.protected_branches }}
@@ -107,7 +107,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-pr'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1.28.12
     with:
       days_before_stale: ${{ inputs.pr_days_before_stale }}
       days_before_close: ${{ inputs.pr_days_before_close }}
@@ -122,7 +122,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'stale-issue'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1.28.12
     with:
       days_before_stale: ${{ inputs.issue_days_before_stale }}
       days_before_close: ${{ inputs.issue_days_before_close }}
@@ -137,7 +137,7 @@ jobs:
       github.event_name == 'push'
       || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'labels-sync'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/labels-sync.yml@v1.28.12
     with:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
@@ -149,7 +149,7 @@ jobs:
     if: |
       github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && (inputs.routine == 'all' || inputs.routine == 'workflow-runs-cleanup'))
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@v1.28.4
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/workflow-runs-cleanup.yml@v1.28.12
     with:
       retention_days: ${{ inputs.workflow_runs_retention_days }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   stale-pr:
     name: Stale PRs
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-pr.yml@v1.28.12
     with:
       days_before_stale: ${{ inputs.days_before_pr_stale }}
       days_before_close: ${{ inputs.days_before_pr_close }}
@@ -62,7 +62,7 @@ jobs:
 
   stale-issue:
     name: Stale issues
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@develop
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/stale-issue.yml@v1.28.12
     with:
       days_before_stale: ${{ inputs.days_before_issue_stale }}
       days_before_close: ${{ inputs.days_before_issue_close }}

--- a/docs/pr-validation.md
+++ b/docs/pr-validation.md
@@ -17,7 +17,8 @@ Comprehensive pull request validation workflow that enforces best practices, cod
 - **Draft PR support** — Skips validations for draft PRs
 - **Source branch validation** — Enforce PRs to protected branches come from specific source branches
 - **Dry run mode** — Preview validations without posting comments or labels
-- **Summary report** — Aggregated validation status
+- **Summary report** — Aggregated validation status (step summary + idempotent PR comment)
+- **Idempotent feedback** — Source branch failures and the mergeability summary are upserted via stable markers (no stacked duplicates across commits)
 
 ## Architecture
 
@@ -36,7 +37,9 @@ pr-validation.yml (reusable workflow)
     ├── src/validate/pr-size            (size calculation + labeling)
     └── src/validate/pr-labels          (auto-label by files)
               ↓
-  Summary — pr-checks-summary (always runs)
+  Summary — pr-checks-summary (always runs, step summary)
+              ↓
+  Report  — pr-validation-reporter (always runs, PR comment)
               ↓
   Notify  — slack-notify.yml (optional)
 ```
@@ -145,7 +148,8 @@ feat fix docs style refactor perf test chore ci build revert
 |-----|------|------------|-----------|
 | `blocking-checks` | 1 (fail-fast) | `pr-source-branch`, `pr-title`, `pr-description` | non-draft |
 | `advisory-checks` | 2 (informational) | `pr-metadata`, `pr-size`, `pr-labels` | non-draft, blocking-checks passed |
-| `pr-checks-summary` | — | `pr-checks-summary` | always |
+| `pr-checks-summary` | — | `pr-checks-summary` | always (writes to step summary) |
+| `pr-validation-report` | — | `pr-validation-reporter` | non-draft (upserts single PR comment) |
 | `notify` | — | `slack-notify.yml` | non-draft, `!dry_run` |
 
 ### Blocking checks (Tier 1)
@@ -163,7 +167,7 @@ feat fix docs style refactor perf test chore ci build revert
 When `dry_run: true`:
 - Title, description, and metadata validations still run (read-only checks)
 - Size is calculated and logged but **labels are not applied**
-- Source branch is validated but **REQUEST_CHANGES review is not posted**
+- Source branch is validated but **the failure comment is not posted/updated**
 - Auto-labeling is **skipped entirely**
 - Slack notification is **skipped**
 - Summary report includes a DRY RUN banner

--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -1,0 +1,58 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>pr-validation-reporter</h1></td>
+  </tr>
+</table>
+
+Posts a single mergeability summary comment aggregating all PR validation check results (blocking + advisory). Updates the same comment on subsequent runs via a stable HTML marker instead of stacking new ones.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github-token` | GitHub token with `pull-requests:write` and `issues:write` permissions | Yes | — |
+| `source-branch-result` | Result of source branch validation | No | `skipped` |
+| `title-result` | Result of PR title validation | No | `skipped` |
+| `description-result` | Result of PR description validation | No | `skipped` |
+| `size-result` | Result of PR size check | No | `skipped` |
+| `label-result` | Result of auto-label step | No | `skipped` |
+| `metadata-result` | Result of PR metadata check | No | `skipped` |
+| `dry-run` | When `true`, skip posting the summary comment | No | `false` |
+
+## Usage as composite step
+
+```yaml
+jobs:
+  pr-validation-report:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [blocking-checks, advisory-checks]
+    if: always() && github.event.pull_request.draft != true
+    steps:
+      - name: Post PR Validation Summary
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/pr-validation-reporter@v1.x.x
+        with:
+          github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
+          source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result }}
+          title-result: ${{ needs.blocking-checks.outputs.title-result }}
+          description-result: ${{ needs.blocking-checks.outputs.description-result }}
+          size-result: ${{ needs.advisory-checks.outputs.size-result }}
+          label-result: ${{ needs.advisory-checks.outputs.label-result }}
+          metadata-result: ${{ needs.advisory-checks.outputs.metadata-result }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  pull-requests: write
+  issues: write
+```
+
+## Comment marker
+
+The composite upserts a comment identified by:
+
+```html
+<!-- pr-validation-report -->
+```

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -84,6 +84,10 @@ runs:
           }
           body += `---\n<sub>🔍 [View workflow run](${runUrl})</sub>\n`;
 
+          const viewerLogin = await github.rest.users.getAuthenticated()
+            .then(({ data }) => data.login)
+            .catch(() => null);
+
           const comments = await github.paginate(github.rest.issues.listComments, {
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -91,7 +95,10 @@ runs:
             per_page: 100,
           });
 
-          const existing = comments.find(c => c.body?.includes(marker));
+          const marked = comments.filter(c => c.body?.includes(marker));
+          const existing = viewerLogin
+            ? marked.find(c => c.user?.login === viewerLogin)
+            : marked.find(c => c.user?.type === 'Bot');
           const params = { owner: context.repo.owner, repo: context.repo.repo, body };
 
           if (existing) {

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -1,0 +1,101 @@
+name: PR Validation Reporter
+description: Posts a single mergeability summary comment aggregating all PR validation check results, updating it on subsequent runs.
+
+inputs:
+  github-token:
+    description: GitHub token with pull-requests:write and issues:write permissions
+    required: true
+  source-branch-result:
+    description: Result of source branch validation (success/failure/skipped)
+    required: false
+    default: "skipped"
+  title-result:
+    description: Result of PR title validation (success/failure/skipped)
+    required: false
+    default: "skipped"
+  description-result:
+    description: Result of PR description validation (success/failure/skipped)
+    required: false
+    default: "skipped"
+  size-result:
+    description: Result of PR size check (success/failure/skipped)
+    required: false
+    default: "skipped"
+  label-result:
+    description: Result of auto-label step (success/failure/skipped)
+    required: false
+    default: "skipped"
+  metadata-result:
+    description: Result of PR metadata check (success/failure/skipped)
+    required: false
+    default: "skipped"
+  dry-run:
+    description: When true, skip posting the summary comment
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Post PR validation summary
+      if: inputs.dry-run != 'true'
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        SOURCE_BRANCH_RESULT: ${{ inputs.source-branch-result }}
+        TITLE_RESULT: ${{ inputs.title-result }}
+        DESCRIPTION_RESULT: ${{ inputs.description-result }}
+        SIZE_RESULT: ${{ inputs.size-result }}
+        LABEL_RESULT: ${{ inputs.label-result }}
+        METADATA_RESULT: ${{ inputs.metadata-result }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const checks = [
+            { label: 'Source Branch',  result: process.env.SOURCE_BRANCH_RESULT, blocking: true  },
+            { label: 'PR Title',       result: process.env.TITLE_RESULT,         blocking: true  },
+            { label: 'PR Description', result: process.env.DESCRIPTION_RESULT,   blocking: true  },
+            { label: 'PR Size',        result: process.env.SIZE_RESULT,          blocking: false },
+            { label: 'Auto Labels',    result: process.env.LABEL_RESULT,         blocking: false },
+            { label: 'PR Metadata',    result: process.env.METADATA_RESULT,      blocking: false },
+          ];
+
+          const icon = (r) => ({ success: '✅', failure: '❌', skipped: '⏭️' }[r] ?? '⚠️');
+
+          const blockingFailures = checks.filter(c => c.blocking && c.result === 'failure');
+          const verdictHeader = blockingFailures.length > 0
+            ? `## 🚫 PR Blocked — ${blockingFailures.length} blocking failure${blockingFailures.length === 1 ? '' : 's'}\n\n`
+            : `## ✅ PR Mergeable — no blocking failures\n\n`;
+
+          let table = '| Check | Status | Blocking |\n|-------|--------|----------|\n';
+          for (const c of checks) {
+            table += `| ${c.label} | ${icon(c.result)} ${c.result} | ${c.blocking ? 'yes' : 'no'} |\n`;
+          }
+          table += '\n';
+
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          const marker = '<!-- pr-validation-report -->';
+          let body = `${marker}\n`;
+          body += `## 🔍 PR Validation Summary\n\n`;
+          body += verdictHeader;
+          body += table;
+          if (blockingFailures.length > 0) {
+            body += `> Fix the blocking checks above before merge.\n\n`;
+          }
+          body += `---\n<sub>🔍 [View workflow run](${runUrl})</sub>\n`;
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            per_page: 100,
+          });
+
+          const existing = comments.find(c => c.body?.includes(marker));
+          const params = { owner: context.repo.owner, repo: context.repo.repo, body };
+
+          if (existing) {
+            await github.rest.issues.updateComment({ ...params, comment_id: existing.id });
+          } else {
+            await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
+          }

--- a/src/validate/pr-source-branch/README.md
+++ b/src/validate/pr-source-branch/README.md
@@ -7,6 +7,8 @@
 
 Validates that PRs to protected branches come from allowed source branches. Supports exact branch names and prefix patterns (e.g., `hotfix/*`).
 
+On failure, upserts a single PR comment (identified by the `<!-- pr-source-branch-validation -->` marker) instead of stacking a new `REQUEST_CHANGES` review on every commit. When the source branch becomes valid in a later run, the same comment is rewritten to a passing message. The job's failure status (and any branch-protection check requirement) still gates merges.
+
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -14,7 +16,7 @@ Validates that PRs to protected branches come from allowed source branches. Supp
 | `github-token` | GitHub token with pull-requests write permission | Yes | |
 | `allowed-branches` | Allowed source branches (pipe-separated, supports `*` wildcard) | No | `develop\|release-candidate\|hotfix/*` |
 | `target-branches` | Target branches that require validation (pipe-separated) | No | `main` |
-| `dry-run` | When true, validate without posting REQUEST_CHANGES review | No | `false` |
+| `dry-run` | When true, validate without upserting the failure comment | No | `false` |
 
 ## Usage as composite step
 
@@ -51,4 +53,5 @@ jobs:
 ```yaml
 permissions:
   pull-requests: write
+  issues: write
 ```

--- a/src/validate/pr-source-branch/action.yml
+++ b/src/validate/pr-source-branch/action.yml
@@ -58,22 +58,46 @@ runs:
             }
           }
 
-          if (!isAllowed) {
-            if (dryRun) {
-              core.notice(`DRY RUN — would post REQUEST_CHANGES review: source '${sourceBranch}' not allowed for target '${targetBranch}'`);
-            } else {
-              const message = `⚠️ **Invalid Source Branch**\n\nPull requests to **${targetBranch}** can only come from:\n${allowedBranches.map(b => `- \`${b}\``).join('\n')}\n\nYour source branch: \`${sourceBranch}\`\n\nPlease **change the base branch** or create a PR from an allowed branch.`;
+          const marker = '<!-- pr-source-branch-validation -->';
 
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                body: message,
-                event: 'REQUEST_CHANGES'
-              });
+          async function findExistingComment() {
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            return comments.find(c => c.body?.includes(marker));
+          }
+
+          async function upsertComment(body) {
+            const fullBody = `${marker}\n${body}`;
+            const existing = await findExistingComment();
+            const params = { owner: context.repo.owner, repo: context.repo.repo, body: fullBody };
+            if (existing) {
+              await github.rest.issues.updateComment({ ...params, comment_id: existing.id });
+            } else {
+              await github.rest.issues.createComment({ ...params, issue_number: context.issue.number });
+            }
+          }
+
+          if (!isAllowed) {
+            const message = `⚠️ **Invalid Source Branch**\n\nPull requests to **${targetBranch}** can only come from:\n${allowedBranches.map(b => `- \`${b}\``).join('\n')}\n\nYour source branch: \`${sourceBranch}\`\n\nPlease **change the base branch** or create a PR from an allowed branch.`;
+
+            if (dryRun) {
+              core.notice(`DRY RUN — would upsert source-branch validation comment for '${sourceBranch}' → '${targetBranch}'`);
+            } else {
+              await upsertComment(message);
             }
 
             core.setFailed(`Source branch '${sourceBranch}' is not allowed for PRs to '${targetBranch}'`);
           } else {
             console.log(`✅ Source branch '${sourceBranch}' is allowed`);
+            if (!dryRun) {
+              const existing = await findExistingComment();
+              if (existing) {
+                const message = `✅ **Source Branch — now valid**\n\nSource branch \`${sourceBranch}\` is allowed for target \`${targetBranch}\`.`;
+                await upsertComment(message);
+              }
+            }
           }

--- a/src/validate/pr-source-branch/action.yml
+++ b/src/validate/pr-source-branch/action.yml
@@ -60,6 +60,10 @@ runs:
 
           const marker = '<!-- pr-source-branch-validation -->';
 
+          const viewerLogin = await github.rest.users.getAuthenticated()
+            .then(({ data }) => data.login)
+            .catch(() => null);
+
           async function findExistingComment() {
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -67,7 +71,11 @@ runs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            return comments.find(c => c.body?.includes(marker));
+            const marked = comments.filter(c => c.body?.includes(marker));
+            if (viewerLogin) {
+              return marked.find(c => c.user?.login === viewerLogin);
+            }
+            return marked.find(c => c.user?.type === 'Bot');
           }
 
           async function upsertComment(body) {


### PR DESCRIPTION
## Description

Resolves the two UX issues reported in #317 affecting `pr-validation.yml`:

1. **Stacked source-branch reviews.** `src/validate/pr-source-branch` used to call `github.rest.pulls.createReview` with `REQUEST_CHANGES` on every commit, producing a stack of identical "Invalid Source Branch" reviews. It now upserts a single PR comment identified by the `<!-- pr-source-branch-validation -->` marker (same pattern used by `pr-security-reporter` and `pr-lint-reporter`). When the source branch later becomes valid, the existing comment is rewritten to a passing message instead of being left as stale `CHANGES_REQUESTED`. Merge blocking is unchanged — it continues to be gated by the job's failure exit status via `pr-blocking-collect`.
2. **No consolidated mergeability comment.** Added `src/notify/pr-validation-reporter`, a new composite that upserts one PR comment aggregating the blocking (source branch, title, description) and advisory (size, label, metadata) checks plus a verdict header (`Mergeable` vs `Blocked — N blocking failures`). The composite is wired into `pr-validation.yml` as a new `pr-validation-report` job; `pr-checks-summary` is kept as-is for the step summary.

Docs (`docs/pr-validation.md`, `src/validate/pr-source-branch/README.md`) updated to reflect the new behavior.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. No reusable-workflow inputs changed and no input defaults shifted. The user-facing change is that source-branch failures now appear as an updated PR comment instead of a stacked `CHANGES_REQUESTED` review; merge blocking via job status is preserved.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be validated post-merge against a caller pinned at `@develop`._

## Related Issues

Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consolidated PR validation summary reporter that upserts a single summary comment for non-draft PRs and aggregates blocking/advisory results.
  * Source-branch validation now upserts a stable marker comment (replaces per-commit review noise) and rewrites to passing when fixed.

* **Chores**
  * Updated reusable workflow references to newer v1/v1.28.x channels across CI workflows.

* **Documentation**
  * Clarified idempotent reporting, upsert behavior, workflow steps, and dry-run semantics for comment posting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/358)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->