### PR TITLE
fix(gitops-update): allowlist gitops_repository for privileged checkout

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -124,8 +124,22 @@ jobs:
       # Trust model: this is a `workflow_call` reusable workflow, NOT triggered by
       # untrusted PRs. `inputs.gitops_repository` is supplied by trusted caller
       # workflows (default: LerianStudio/midaz-firmino-gitops) and the MANAGE_TOKEN
-      # is required for the subsequent commit/push step. CodeQL flags this as
-      # `actions/untrusted-checkout` defensively but the call surface is internal-only.
+      # is required for the subsequent commit/push step. The allowlist step below
+      # enforces that the repository is a LerianStudio-owned `*-gitops` repo so a
+      # compromised caller cannot redirect the privileged checkout to an arbitrary
+      # target (CodeQL: `actions/untrusted-checkout`).
+      - name: Validate gitops_repository against allowlist
+        shell: bash
+        env:
+          GITOPS_REPOSITORY: ${{ inputs.gitops_repository }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITOPS_REPOSITORY" =~ ^LerianStudio/[A-Za-z0-9._-]+-gitops$ ]]; then
+            echo "::error::gitops_repository '$GITOPS_REPOSITORY' is not allowed. Must match ^LerianStudio/<name>-gitops$ (e.g. LerianStudio/midaz-firmino-gitops)."
+            exit 1
+          fi
+          echo "gitops_repository validated: $GITOPS_REPOSITORY"
+
       - name: Checkout GitOps Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Hardens the `update_gitops` job against the `actions/untrusted-checkout/medium` CodeQL finding on `.github/workflows/gitops-update.yml`.

Adds a new step (`Validate gitops_repository against allowlist`) that runs **before** the privileged `Checkout GitOps Repository` step and fails fast unless `inputs.gitops_repository` matches the regex `^LerianStudio/[A-Za-z0-9._-]+-gitops$`. The subsequent checkout binds `MANAGE_TOKEN` to the working tree, so restricting the repository to LerianStudio-owned `*-gitops` repos defends against a compromised caller redirecting the privileged checkout to an attacker-controlled target.

The "Trust model" comment block is updated to document the new defense-in-depth posture.

The companion mitigation (`persist-credentials: false` on the matrix manifest checkout — line 137 in the issue) is already applied in `main` and not part of this PR.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Existing callers (`LerianStudio/midaz-firmino-gitops`, `LerianStudio/midaz-clotilde-gitops`, `LerianStudio/midaz-anacleto-gitops`) all satisfy the regex. Any caller passing a non-LerianStudio repo or one that does not end in `-gitops` will now fail fast with a clear error message — which is the intended security posture.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _to be validated on a caller after merge to `develop` via beta tag_

## Related Issues

Refs #357 (item 2 of 3 — item 1 already in `main`; item 3 is a manual CodeQL dismissal in the Security tab if the heuristic still flags the line after this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation to the workflow that enforces gitops repository naming requirements. The workflow will now fail with an error if the provided repository name does not match the expected format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/361)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->