### PR TITLE
chore(github): complete labeler rules and tidy dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,11 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "LerianStudio/devops-team"
+    open-pull-requests-limit: 15
+    # Reviewers are resolved via CODEOWNERS (the `reviewers` field is deprecated).
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     ignore:
       # LerianStudio internal actions follow our own pinning strategy:
       # composites use floating @vN (auto-track minor/patch), reusable workflows

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
-      - "/src/**"
+    # The github-actions ecosystem only honors `directory: "/"` — Dependabot
+    # scans `.github/workflows/` and the root-level action.yml, and ignores any
+    # other path or glob. Composites under `src/**/action.yml` are NOT monitored
+    # by this config; their action versions require a separate drift check.
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/src/**"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -57,6 +59,7 @@ updates:
           - "sonatype-nexus-community/nancy-github-action"
           - "trufflesecurity/trufflehog"
           - "anchore/sbom-action"
+          - "sigstore/cosign-installer"
         update-types:
           - "minor"
           - "patch"
@@ -122,6 +125,8 @@ updates:
           - "actions/labeler"
           - "actions/github-script"
           - "mikefarah/yq"
+          - "crazy-max/ghaction-github-labeler"
+          - "Mattraks/delete-workflow-runs"
         update-types:
           - "major"
           - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,22 @@ updates:
     reviewers:
       - "LerianStudio/devops-team"
     ignore:
-      # LerianStudio internal actions are pinned to @main intentionally
+      # LerianStudio internal actions follow our own pinning strategy:
+      # composites use floating @vN (auto-track minor/patch), reusable workflows
+      # use exact @vN.M.P. Dependabot opt-out — bumps handled via release tooling.
       - dependency-name: "LerianStudio/*"
     groups:
-      # Core GitHub-provided actions (checkout, setup-*, upload/download-artifact, etc.)
+      # Core GitHub-provided actions (checkout, setup-*, upload/download-artifact, etc.).
+      # Specific actions/* entries owned by semantic groups below are excluded so
+      # Dependabot routes them to their intended group instead of this catch-all.
       actions-core:
         patterns:
           - "actions/*"
+        exclude-patterns:
+          - "actions/dependency-review-action"
+          - "actions/create-github-app-token"
+          - "actions/labeler"
+          - "actions/github-script"
         update-types:
           - "major"
           - "minor"
@@ -90,7 +99,6 @@ updates:
       notifications:
         patterns:
           - "rtCamp/action-slack-notify"
-          - "slackapi/slack-github-action"
           - "SethCohen/github-releases-to-discord"
         update-types:
           - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,10 @@ updates:
       include: "scope"
     open-pull-requests-limit: 15
     # Reviewers are resolved via CODEOWNERS (the `reviewers` field is deprecated).
+    # `semver-major-days` is not supported for the github-actions ecosystem;
+    # only `default-days` is honored here.
     cooldown:
       default-days: 3
-      semver-major-days: 7
     ignore:
       # LerianStudio internal actions follow our own pinning strategy:
       # composites use floating @vN (auto-track minor/patch), reusable workflows

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,6 +29,7 @@ security:
     - any-glob-to-any-file:
       - ".github/workflows/go-security.yml"
       - ".github/workflows/pr-security-scan.yml"
+      - "src/security/**"
       - "SECURITY.md"
 
 # ── Change types ───────────────────────────────────────────────────────────────
@@ -40,6 +41,7 @@ documentation:
       - "docs/**"
       - "*.md"
       - ".github/**/*.md"
+      - "src/**/*.md"
 
 # Changes to dependabot.yml (usually opened automatically by Dependabot itself)
 dependencies:
@@ -62,3 +64,61 @@ github-config:
 deployment-matrix:
   - changed-files:
     - any-glob-to-any-file: "config/deployment-matrix.yml"
+
+# ── Capabilities ──────────────────────────────────────────────────────────────
+
+config:
+  - changed-files:
+    - any-glob-to-any-file: "src/config/**"
+
+notify:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/notify/**"
+      - ".github/workflows/slack-notify.yml"
+      - ".github/workflows/release-notification.yml"
+
+lint:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/lint/**"
+      - ".yamllint.yml"
+      - ".golangci.yml"
+
+validate:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/validate/**"
+      - ".github/workflows/pr-validation.yml"
+      - ".github/workflows/self-pr-validation.yml"
+
+changelog:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/changelog/**"
+      - ".github/workflows/gptchangelog.yml"
+
+routine:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/routine.yml"
+      - ".github/workflows/self-routine.yml"
+      - ".github/workflows/stale.yml"
+      - ".github/workflows/stale-issue.yml"
+      - ".github/workflows/stale-pr.yml"
+      - ".github/workflows/branch-cleanup.yml"
+      - ".github/workflows/workflow-runs-cleanup.yml"
+
+# ── File-type generic rules (apply across all src/ composites) ────────────────
+
+composite:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/**/*.yml"
+      - "src/**/*.yaml"
+
+scripts:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/**/*.sh"
+      - "src/**/*.bash"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -112,6 +112,14 @@
   color: "1f6feb"
   description: Changes to periodic maintenance routines (self-routine.yml and related reusables)
 
+- name: composite
+  color: "8b949e"
+  description: Changes to any composite action manifest (src/**/*.yml)
+
+- name: scripts
+  color: "4b5563"
+  description: Changes to shell scripts (src/**/*.sh)
+
 # ── Stale management ──────────────────────────────────────────────────────────
 
 - name: stale


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Aligns repo automation with the composite layout under `src/`:

- **Dependabot** now scans every composite manifest (`src/**`) in addition to root workflows, so action versions used inside composites are kept up to date. Adds three actions to existing groups so their PRs land bundled:
  - `sigstore/cosign-installer` → `security-scanners`
  - `crazy-max/ghaction-github-labeler` → `utilities`
  - `Mattraks/delete-workflow-runs` → `utilities`
- **Labels** gain two generic, file-type-based labels: `composite` (any `.yml` under `src/`) and `scripts` (any `.sh`/`.bash` under `src/`).
- **Labeler** is completed so every label declared in `labels.yml` now has an automatic rule:
  - Extends `security` and `documentation` to also cover `src/security/**` and `src/**/*.md`.
  - Adds capability rules for `config`, `notify`, `lint`, `validate`, `changelog` and `routine` (matched by `src/<cap>/**` and the related workflow files).
  - Adds the new generic `composite` and `scripts` rules.

The capability rules tag PRs by domain; the file-type rules tag them by what kind of file was touched. A PR editing `src/lint/yamllint/action.yml` will be labeled `lint` + `composite`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Existing Dependabot groups keep their semantics; new labels are additive and the new labeler rules only attach extra labels, never remove existing ones.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Will be validated post-merge by the next Dependabot run (Monday 08:00 America/Sao_Paulo) and by running `labels-sync.yml` to register `composite` and `scripts`.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automated dependency scanning: refined update groups with exclusion patterns, increased open-PR limits, added a cooldown policy, adjusted security scanner patterns, and removed one notification target.
  * Improved automated labeling: broader detection for security and documentation changes and added capability-based mappings for many source areas and workflows.
  * Added two labels to distinguish composite action manifests and shell script changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/363)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->