### PR TITLE
feat: register lerian-hq in deployment matrix (benedita)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -57,6 +57,7 @@ apps:
     - backoffice-console
     - cs-platform
     - forge
+    - lerian-hq
     - lerian-map
     - tenant-manager
 
@@ -136,5 +137,6 @@ clusters:
       - backoffice-console
       - cs-platform
       - forge
+      - lerian-hq
       - lerian-map
       - tenant-manager

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -53,7 +53,7 @@ apps:
     - plugin-br-bank-transfer-jd  # JD-specific build (anacleto only)
     - plugin-bc-correios
 
-    # Clotilde-exclusive Lerian platform suite
+    # Lerian internal platform suite (Clotilde + Benedita)
     - backoffice-console
     - cs-platform
     - forge


### PR DESCRIPTION
## What

Registers `lerian-hq` (Lerian internal hub, https://github.com/LerianStudio/lerian-hq) as a deployable app for the `benedita` cluster.

```diff
 apps:
   registry:
     ...
     # Clotilde-exclusive Lerian platform suite
     - backoffice-console
     - cs-platform
     - forge
+    - lerian-hq
     - lerian-map
     - tenant-manager

 clusters:
   benedita:
     apps:
       ...
       - forge
+      - lerian-hq
       - lerian-map
       - tenant-manager
```

## Why

Without this, the `gitops-update.yml` reusable workflow has no way to resolve which cluster(s) `lerian-hq` deploys to, so tag-bump pushes from the app repo's `build.yml` would silently no-op against the gitops repo. After this PR merges, the app repo's `update_gitops` job (separate PR on LerianStudio/lerian-hq) will be able to bump `.lerian-hq.image.tag` in `environments/benedita/helmfile/applications/dev/lerian-hq/values.yaml` on every image release.

## Scope

- Added to **benedita** cluster only. Not deployed to clotilde / anacleto / firmino.
- The 'Clotilde-exclusive' comment in `apps.registry` is technically outdated already (lerian-map and friends also run on benedita) — left as-is to avoid bundling a comment-cleanup with this functional change.

## Verification

- YAML parses
- Alphabetical position consistent with surrounding entries
- No unintended deltas (diff is purely +2 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled lerian-hq in the global apps registry allow-list.
  * Registered lerian-hq for deployment to the benedita cluster.
  * This registration makes the automated deployment workflow eligible to resolve and target lerian-hq for benedita.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/368)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->