### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -47,6 +47,7 @@ apps:
     - plugin-fees
     - plugin-br-pix-direct-jd
     - plugin-br-pix-indirect-btg
+    - plugin-br-pix-switch        # multi-component PIX hub (firmino-only today)
     - plugin-br-bank-transfer     # generic build (firmino + clotilde)
     - plugin-br-bank-transfer-jd  # JD-specific build (anacleto only)
     - plugin-bc-correios
@@ -75,6 +76,7 @@ clusters:
       - plugin-fees
       - plugin-br-pix-direct-jd
       - plugin-br-pix-indirect-btg
+      - plugin-br-pix-switch
       - plugin-br-bank-transfer
       - plugin-bc-correios
 


### PR DESCRIPTION
## Summary

Promote `develop` to `main` so the latest changes are available to consumer repos via a stable tag.

## Commits being promoted

- **#369** — `feat(deployment-matrix): register plugin-br-pix-switch for firmino`
- `chore(changelog): backmerge main into develop` (auto-generated bookkeeping)

## Followup

Once this merges, semantic-release will cut a new tag (e.g. `v1.29.1`) carrying the `plugin-br-pix-switch` matrix entry. `LerianStudio/plugin-br-pix-switch`'s `build.yml` follow-up will pin to that tag to enable the `update_gitops` auto-flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support additional applications on internal infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/370)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->