### PR TITLE
feat(deployment-matrix): register lerian-notification on firmino

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -41,6 +41,7 @@ apps:
     - reporter
     - tracer
     - product-console
+    - lerian-notification         # firmino-dev only today
 
     # Plugins
     - plugin-access-manager       # caller repo may push as plugin-identity / plugin-auth / casdoor
@@ -72,6 +73,7 @@ clusters:
       - reporter
       - tracer
       - product-console
+      - lerian-notification
       - plugin-access-manager
       - plugin-fees
       - plugin-br-pix-direct-jd


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds the new `lerian-notification` service to `config/deployment-matrix.yml`. Without this, the upstream `build.yml` -> `update_gitops` job in [LerianStudio/lerian-notification#42](https://github.com/LerianStudio/lerian-notification/pull/42) resolves to an empty cluster list and skips the gitops bump entirely.

`lerian-notification` is the new Core-platform service onboarded in firmino-dev (see [midaz-firmino-gitops#664](https://github.com/LerianStudio/midaz-firmino-gitops/pull/664)). Only firmino is in scope today.

## Changes

```diff
 apps:
   registry:
     # Core platform
     ...
     - product-console
+    - lerian-notification         # firmino-dev only today
```

```diff
 clusters:
   firmino:
     apps:
       ...
       - product-console
+      - lerian-notification
       - plugin-access-manager
```

Other clusters (`clotilde`, `anacleto`, `benedita`) are left unchanged.

## Type of Change

- [x] `feat`: New entry in the deployment matrix manifest
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only
- [ ] `BREAKING CHANGE`: None

## Breaking Changes

None.

## Testing

Manifest is YAML data only. Schema validation is enforced by the loader in `gitops-update.yml` (the workflow reads this file at runtime and would fail loudly on a syntax/registry mismatch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to enable lerian-notification service on the firmino cluster.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/371)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->