### PR TITLE
fix(self-pr-validation): re-run on PR edited + ready_for_review

### DIFF
--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -7,8 +7,10 @@ on:
       - main
     types:
       - opened
+      - edited
       - synchronize
       - reopened
+      - ready_for_review
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The self pr-validation suite only listened to `opened / synchronize / reopened`. Editing the PR title or body from the GitHub UI did **not** retrigger the check, so a fix applied through the UI would leave the validation pinned to its previous (possibly failed) state until someone pushed a new commit.

The reusable `pr-validation.yml` consumed by downstream repos already listens to `edited`. The self workflow should match that contract.

## Changes

`.github/workflows/self-pr-validation.yml`:

```diff
 on:
   pull_request:
     branches:
       - develop
       - main
     types:
       - opened
+      - edited
       - synchronize
       - reopened
+      - ready_for_review
   workflow_dispatch:
```

- `edited` covers title / body / base-ref changes from the UI — the exact case where a maintainer fixes the PR title to satisfy the title-scope rule and expects the check to re-run.
- `ready_for_review` covers draft → ready transitions, which is when reviewers need a current validation result.

## Type of Change

- [x] `fix`: Self-CI trigger did not cover PR edits
- [ ] `feat`
- [ ] `docs`
- [ ] `BREAKING CHANGE`: None.

## Breaking Changes

None. The validation logic is untouched; only the trigger surface widens.

## Testing

GitHub will trigger a fresh run of self-pr-validation against this PR on every `edited` event after merge. Until then, the change is no-op for in-flight PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation to respond to additional pull request state changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/372)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->