### PR TITLE
chore: promote develop to main (severino-bot + lerian-hq matrix entries)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -63,6 +63,9 @@ apps:
     # Anacleto-exclusive
     - ungoliant-controller
 
+    # Benedita-exclusive
+    - severino-bot                # internal Slack bot (benedita only)
+
 clusters:
   firmino:
     apps:
@@ -138,3 +141,4 @@ clusters:
       - forge
       - lerian-map
       - tenant-manager
+      - severino-bot

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -53,10 +53,11 @@ apps:
     - plugin-br-bank-transfer-jd  # JD-specific build (anacleto only)
     - plugin-bc-correios
 
-    # Clotilde-exclusive Lerian platform suite
+    # Lerian internal platform suite (Clotilde + Benedita)
     - backoffice-console
     - cs-platform
     - forge
+    - lerian-hq
     - lerian-map
     - tenant-manager
 
@@ -136,5 +137,6 @@ clusters:
       - backoffice-console
       - cs-platform
       - forge
+      - lerian-hq
       - lerian-map
       - tenant-manager


### PR DESCRIPTION
## What

Promotes `develop` → `main`. Batches 2 feature PRs already merged into develop:

| PR | Change |
|---|---|
| #368 | Register **lerian-hq** in deployment matrix (benedita) |
| #374 | Register **severino-bot** in deployment matrix (benedita) |

## Diff

Single file: `config/deployment-matrix.yml` (+7 / -1):
- `apps.registry`: adds `lerian-hq` and `severino-bot`
- `clusters.benedita.apps`: adds both apps to benedita's resolved cluster list

## Why now

Callers of `gitops-update.yml` resolve the deployment matrix from **`main`** at runtime (the workflow's default `deployment_matrix_ref`). Both apps need their matrix entries on `main` before their respective build pipelines can run `update_gitops` end-to-end.

## Risk

**Zero runtime risk.** `config/deployment-matrix.yml` is in `self-release.yml`'s `paths-ignore` — matrix-only promotions don't cut a new shared-workflows tag. The change takes effect immediately on merge for all callers on the current shared-workflows version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to enable new applications `lerian-hq` and `severino-bot` for deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/375)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->