### PR TITLE
feat(matrix): register rosiehr + add app_helmfile_env override for cross/ apps

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -421,6 +421,7 @@ jobs:
           KUSTOMIZE_BASE_PATH: ${{ inputs.kustomize_base_path }}
           KUSTOMIZE_IMAGE_NAME: ${{ inputs.kustomize_image_name }}
           KUSTOMIZE_ENVIRONMENTS: ${{ inputs.kustomize_environments }}
+          MANIFEST_FILE: shared-workflows/${{ inputs.deployment_matrix_file }}
         run: |
           set -euo pipefail
 
@@ -572,10 +573,27 @@ jobs:
                 continue
               fi
 
-              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${APP_NAME}/values.yaml"
+              # Check for a per-app helmfile_env override in the deployment matrix.
+              # Some apps (e.g. rosiehr, cs-platform, forge, lerian-map on Benedita) have
+              # their values.yaml under cross/ instead of the tag-derived env (dev/stg/prd).
+              # The override is declared as clusters.<server>.app_helmfile_env.<app>: <env>.
+              HELMFILE_ENV="$ENV"
+              if [[ -f "$MANIFEST_FILE" ]]; then
+                HELMFILE_ENV_OVERRIDE=$(yq -o=json '.' "$MANIFEST_FILE" \
+                  | jq -r --arg server "$SERVER" --arg app "$APP_NAME" \
+                    '.clusters[$server].app_helmfile_env[$app] // empty' 2>/dev/null || echo "")
+                if [[ -n "$HELMFILE_ENV_OVERRIDE" ]]; then
+                  HELMFILE_ENV="$HELMFILE_ENV_OVERRIDE"
+                fi
+              fi
+
+              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${HELMFILE_ENV}/${APP_NAME}/values.yaml"
 
               echo ""
               echo "Processing: $SERVER/$ENV"
+              if [[ "$HELMFILE_ENV" != "$ENV" ]]; then
+                echo "  helmfile_env override: $HELMFILE_ENV (tag-derived: $ENV)"
+              fi
               echo "  Path: $VALUES_FILE"
 
               # Check if file exists

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -66,6 +66,7 @@ apps:
 
     # Benedita-exclusive
     - severino-bot                # internal Slack bot (benedita only)
+    - rosiehr                     # internal HR app (benedita only); values at cross/ — see app_helmfile_env below
 
 clusters:
   firmino:
@@ -126,6 +127,16 @@ clusters:
       - lerian-notification
 
   benedita:
+    # app_helmfile_env: per-app override for the helmfile applications sub-directory.
+    # Default path: environments/benedita/helmfile/applications/{env}/{app}/values.yaml
+    # where {env} = dev | stg | prd | sandbox (derived from the git tag type).
+    # Apps whose values.yaml lives under cross/ instead of dev/ must be listed here;
+    # otherwise the gitops-update workflow warns "values file not found" and skips them.
+    app_helmfile_env:
+      cs-platform: cross
+      forge: cross
+      lerian-map: cross
+      rosiehr: cross
     apps:
       - midaz
       - fetcher
@@ -147,3 +158,4 @@ clusters:
       - tenant-manager
       - severino-bot
       - lerian-notification
+      - rosiehr


### PR DESCRIPTION
## Summary

Two changes in a single PR because they're causally coupled — registering rosiehr alone wouldn't trigger automation without the `app_helmfile_env` fix.

### 1. Register rosiehr in the deployment matrix

- `apps.registry`: add `rosiehr` (Benedita-exclusive internal HR app)
- `clusters.benedita.apps`: add `rosiehr`
- `rosiehr/build.yml` already has the `update_gitops` job wired up — this PR unblocks it

### 2. Add `app_helmfile_env` override for `cross/` apps (root-cause fix)

**Background:** PR #760 in midaz-firmino-gitops moved `cs-platform`, `forge`, and `lerian-map` from `environments/benedita/helmfile/applications/dev/` to `cross/`. The `gitops-update` workflow builds the values file path as:
```
environments/{server}/helmfile/applications/{env}/{app}/values.yaml
```
where `{env}` = `dev | stg | prd | sandbox` (derived from git tag type). After the move, the workflow silently skipped updates ("values file not found") and bumps were done manually.

**Fix:** New optional field `app_helmfile_env` per cluster in the deployment matrix:
```yaml
clusters:
  benedita:
    app_helmfile_env:
      cs-platform: cross
      forge: cross
      lerian-map: cross
      rosiehr: cross
```

The `gitops-update` workflow reads this override when building `VALUES_FILE`, substituting `cross` for the tag-derived env. The `sync_matrix` still uses the tag-derived env (`dev`) so ArgoCD app name resolution (`benedita-rosiehr-dev`) works correctly.

## How the flow will work after merge

1. Push tag `v0.1.3` on LerianStudio/rosiehr
2. `build.yml` runs → `update_gitops` job triggers
3. Workflow resolves cluster: `benedita` (from matrix)
4. For `ENV=dev` (production tag): looks up `app_helmfile_env` → `HELMFILE_ENV=cross`
5. Updates `environments/benedita/helmfile/applications/cross/rosiehr/values.yaml` → `.rosiehr.image.tag: "0.1.3"`
6. Commits to midaz-firmino-gitops as `ci(rosiehr): update image tags (production)`
7. ArgoCD syncs `benedita-rosiehr-dev`

## Files changed

| File | Change |
|------|--------|
| `config/deployment-matrix.yml` | Add `rosiehr` to registry + benedita apps; add `app_helmfile_env` block |
| `.github/workflows/gitops-update.yml` | Read `app_helmfile_env` override when constructing `VALUES_FILE` path |

## Pre-requisite / note

The `deployment_matrix_ref` used by callers defaults to `main`. This PR must merge **before** the next rosiehr release tag is pushed for the automation to take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rosiehr application is now available for deployment across supported clusters
  * Deployment configuration system now supports per-application environment overrides for enhanced flexibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->