### PR TITLE
feat(matrix): register rosiehr + app_helmfile_env override for cross/ apps

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -421,6 +421,7 @@ jobs:
           KUSTOMIZE_BASE_PATH: ${{ inputs.kustomize_base_path }}
           KUSTOMIZE_IMAGE_NAME: ${{ inputs.kustomize_image_name }}
           KUSTOMIZE_ENVIRONMENTS: ${{ inputs.kustomize_environments }}
+          MANIFEST_FILE: shared-workflows/${{ inputs.deployment_matrix_file }}
         run: |
           set -euo pipefail
 
@@ -572,10 +573,27 @@ jobs:
                 continue
               fi
 
-              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${ENV}/${APP_NAME}/values.yaml"
+              # Check for a per-app helmfile_env override in the deployment matrix.
+              # Some apps (e.g. rosiehr, cs-platform, forge, lerian-map on Benedita) have
+              # their values.yaml under cross/ instead of the tag-derived env (dev/stg/prd).
+              # The override is declared as clusters.<server>.app_helmfile_env.<app>: <env>.
+              HELMFILE_ENV="$ENV"
+              if [[ -f "$MANIFEST_FILE" ]]; then
+                HELMFILE_ENV_OVERRIDE=$(yq -o=json '.' "$MANIFEST_FILE" \
+                  | jq -r --arg server "$SERVER" --arg app "$APP_NAME" \
+                    '.clusters[$server].app_helmfile_env[$app] // empty' 2>/dev/null || echo "")
+                if [[ -n "$HELMFILE_ENV_OVERRIDE" ]]; then
+                  HELMFILE_ENV="$HELMFILE_ENV_OVERRIDE"
+                fi
+              fi
+
+              VALUES_FILE="gitops/environments/${SERVER}/helmfile/applications/${HELMFILE_ENV}/${APP_NAME}/values.yaml"
 
               echo ""
               echo "Processing: $SERVER/$ENV"
+              if [[ "$HELMFILE_ENV" != "$ENV" ]]; then
+                echo "  helmfile_env override: $HELMFILE_ENV (tag-derived: $ENV)"
+              fi
               echo "  Path: $VALUES_FILE"
 
               # Check if file exists

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -132,10 +132,13 @@ clusters:
     # where {env} = dev | stg | prd | sandbox (derived from the git tag type).
     # Apps whose values.yaml lives under cross/ instead of dev/ must be listed here;
     # otherwise the gitops-update workflow warns "values file not found" and skips them.
+    #
+    # IMPORTANT: only list apps whose ArgoCD app name follows the standard
+    # {server}-{app}-{env} pattern (e.g. benedita-rosiehr-dev). Apps like
+    # cs-platform, forge, lerian-map use non-standard ArgoCD names (no -dev suffix)
+    # so their gitops-update sync target would resolve incorrectly. Add them here
+    # only after aligning their ArgoCD app naming with the standard convention.
     app_helmfile_env:
-      cs-platform: cross
-      forge: cross
-      lerian-map: cross
       rosiehr: cross
     apps:
       - midaz

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -66,6 +66,7 @@ apps:
 
     # Benedita-exclusive
     - severino-bot                # internal Slack bot (benedita only)
+    - rosiehr                     # internal HR app (benedita only); values at cross/ — see app_helmfile_env below
 
 clusters:
   firmino:
@@ -126,6 +127,16 @@ clusters:
       - lerian-notification
 
   benedita:
+    # app_helmfile_env: per-app override for the helmfile applications sub-directory.
+    # Default path: environments/benedita/helmfile/applications/{env}/{app}/values.yaml
+    # where {env} = dev | stg | prd | sandbox (derived from the git tag type).
+    # Apps whose values.yaml lives under cross/ instead of dev/ must be listed here;
+    # otherwise the gitops-update workflow warns "values file not found" and skips them.
+    app_helmfile_env:
+      cs-platform: cross
+      forge: cross
+      lerian-map: cross
+      rosiehr: cross
     apps:
       - midaz
       - fetcher
@@ -147,3 +158,4 @@ clusters:
       - tenant-manager
       - severino-bot
       - lerian-notification
+      - rosiehr


### PR DESCRIPTION
Promote develop → main.

## Changes

- Registers `rosiehr` in the deployment matrix (Benedita cluster, `cross/` path)
- Adds `app_helmfile_env` schema to `deployment-matrix.yml` — fixes silent skip for apps whose `values.yaml` lives under `cross/` instead of `dev/` (cs-platform, forge, lerian-map, rosiehr)
- Adds override lookup in `gitops-update.yml` so those apps get the correct `HELMFILE_ENV` at runtime

## Why

Without this, a new tag on rosiehr (or any `cross/` app) would run the gitops-update workflow, fail to find the values file at the expected `dev/` path, log a warning, and skip the PR — silently.

## Test plan

- [ ] Merge → triggers new shared-workflows release
- [ ] Update rosiehr `build.yml` to new release tag
- [ ] Push a test tag on rosiehr → gitops PR opens automatically against `cross/rosiehr/values.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now respects per-application environment overrides from the deployment manifest when applying tags.
  * Deployment process logs and uses overridden environments when constructing per-app deployment configurations.
  * Rosiehr is now registered for deployment and configured with a custom environment mapping for the benedita cluster.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->