### PR TITLE
fix(matrix): scope app_helmfile_env to rosiehr only

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -132,10 +132,13 @@ clusters:
     # where {env} = dev | stg | prd | sandbox (derived from the git tag type).
     # Apps whose values.yaml lives under cross/ instead of dev/ must be listed here;
     # otherwise the gitops-update workflow warns "values file not found" and skips them.
+    #
+    # IMPORTANT: only list apps whose ArgoCD app name follows the standard
+    # {server}-{app}-{env} pattern (e.g. benedita-rosiehr-dev). Apps like
+    # cs-platform, forge, lerian-map use non-standard ArgoCD names (no -dev suffix)
+    # so their gitops-update sync target would resolve incorrectly. Add them here
+    # only after aligning their ArgoCD app naming with the standard convention.
     app_helmfile_env:
-      cs-platform: cross
-      forge: cross
-      lerian-map: cross
       rosiehr: cross
     apps:
       - midaz


### PR DESCRIPTION
## Problem

As pointed out by Gandalf in #386: `cs-platform`, `forge`, and `lerian-map` were listed in `app_helmfile_env` but their ArgoCD app names don't follow the standard `{server}-{app}-{env}` pattern (they have no `-dev`/`-stg`/`-prd` suffix). The workflow would update the correct `cross/` values file but then attempt to sync a non-existent ArgoCD app (`benedita-cs-platform-dev`), silently skipping the sync.

## Fix

Remove the three apps from `app_helmfile_env`. Only `rosiehr` stays — it follows the standard naming (`benedita-rosiehr-dev`) so path override + ArgoCD sync both work correctly.

Add a comment documenting the constraint so future contributors know why the other apps are excluded and what's needed to add them back.

## Note

This does NOT break the values file path for cs-platform/forge/lerian-map — those apps don't call `gitops-update` via CI today. Their `cross/` paths are managed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment configuration documentation with clarifying comments regarding application naming conventions and override patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->