### PR TITLE
fix: guard git tag pipelines against SIGPIPE in gptchangelog (closes #388)

### DIFF
--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -80,7 +80,7 @@ jobs:
             git fetch --tags
 
             # Get tags created in the last hour (recent release)
-            LATEST_TAGS=$(git tag --sort=-creatordate | head -20)
+            LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
             echo "📌 Recent tags: $LATEST_TAGS"
 
             # Find first stable tag (no beta/rc/alpha)
@@ -193,7 +193,7 @@ jobs:
                 # Escape regex metacharacters in app name for grep
                 # shellcheck disable=SC2001,SC2016
                 APP_NAME_ESCAPED=$(echo "$APP_NAME" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')
-                LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+                LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
                 if [ -n "$LATEST_TAG" ]; then
                   echo "📦 Found stable tag for $APP_NAME: $LATEST_TAG"
@@ -329,7 +329,7 @@ jobs:
             echo "🔍 Looking for tags matching: $TAG_PATTERN"
 
             # Find the latest STABLE tag for this app (exclude beta/rc/alpha)
-            LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+            LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
             if [ -z "$LAST_TAG" ]; then
               echo "⚠️ No stable tag found for $APP_NAME - skipping"

--- a/.github/workflows/helm-release-notification.yml
+++ b/.github/workflows/helm-release-notification.yml
@@ -101,7 +101,7 @@ jobs:
           CHART_NAME=$(echo "${CHART_NAME_STRIPPED//-/ }" | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
 
           # Get latest release tag for this chart
-          LATEST_TAG=$(git tag -l "${CHART_NAME_RAW}-v*" --sort=-v:refname | head -1)
+          LATEST_TAG=$(git tag -l "${CHART_NAME_RAW}-v*" --sort=-v:refname | head -1 || true)
           if [ -z "$LATEST_TAG" ]; then
             echo "::error::No release tag found matching pattern '${CHART_NAME_RAW}-v*'"
             exit 1

--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -79,7 +79,7 @@ runs:
           echo "📌 Triggered by branch/workflow_run, finding latest stable tags..."
           git fetch --tags
 
-          LATEST_TAGS=$(git tag --sort=-creatordate | head -20)
+          LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
           echo "📌 Recent tags: $LATEST_TAGS"
 
           TAG_NAME=""
@@ -164,7 +164,7 @@ runs:
             APP_NAME=$(basename "$path")
             # shellcheck disable=SC2001,SC2016
             APP_NAME_ESCAPED=$(echo "$APP_NAME" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')
-            LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+            LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
             if [ -n "$LATEST_TAG" ]; then
               echo "📦 Found stable tag for $APP_NAME: $LATEST_TAG"
@@ -234,7 +234,7 @@ runs:
             TAG_GREP_PATTERN="^v"
           fi
 
-          LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+          LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
           if [ -z "$LAST_TAG" ]; then
             echo "⚠️ No stable tag found for $APP_NAME - skipping"

--- a/src/config/release-tag-check/action.yml
+++ b/src/config/release-tag-check/action.yml
@@ -24,7 +24,7 @@ runs:
         PREVIOUS_TAG: ${{ inputs.previous-tag }}
       run: |
         git fetch --tags origin
-        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1 || true)
         if [ "$NEW_TAG" != "$PREVIOUS_TAG" ] && [ -n "$NEW_TAG" ]; then
           echo "release_published=true" >> "$GITHUB_OUTPUT"
           VERSION="${NEW_TAG#v}"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Under the GitHub Actions default shell (`bash --noprofile --norc -eo pipefail`), a pipeline like `git tag --sort=... | head -N` fails with **exit 141 (SIGPIPE)** on repos with many tags: `head` closes the pipe after N lines, `git tag` receives `SIGPIPE`, and `pipefail` propagates `141`, which `set -e` turns into a step failure. This broke the `Generate Changelog` job on every stable release in tag-heavy repos (observed on `plugin-br-pix-indirect-btg`, run linked below).

This PR appends `|| true` to every unguarded `git tag … | head …` pipeline — the same pattern already used in `src/config/release-tag-snapshot/action.yml:17` and `src/config/changed-paths/action.yml:94,96`. As a bonus it also fixes a latent `set -e` abort on the grep-filtered pipelines (`grep` returns `1` when no tag matches); downstream code already handles an empty result via `[ -z "$TAG" ]` guards, so behavior is preserved.

Affected workflow(s)/actions:
- `src/changelog/gptchangelog/action.yml` (lines 82, 167, 237) — the action consumed by `release.yml` via `@v1`
- `.github/workflows/gptchangelog.yml` (lines 83, 196, 332)
- `src/config/release-tag-check/action.yml` (line 27) — used by `release.yml`'s release-detection path
- `.github/workflows/helm-release-notification.yml` (line 104)

Repo-wide sweep result: `.github/workflows/dispatch-helm.yml:122` uses `… | tail -1`. `tail` reads the entire stream and never closes the pipe early, so it is **not** SIGPIPE-vulnerable and was intentionally left unchanged. No other unguarded `git tag … | head/tail` pipelines remain.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally (`yaml.safe_load` on all 4 files)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (no input/output/signature change — only `|| true` appended)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** failing run that motivated the fix — https://github.com/LerianStudio/plugin-br-pix-indirect-btg/actions/runs/26657889439/job/78572886408

## Consumers that benefit

Any repo consuming `release.yml` with `enable_changelog: true` (and the `gptchangelog` / `helm-release-notification` workflows) on a repository with a large tag history — in particular every repo running a maintenance/patch line, which accumulates tags fastest. The `gptchangelog` action is pinned by consumers as `@v1`; on merge to `main` the `update_major_tag` job (enabled by `self-release.yml`) moves the floating `v1` tag, so consumers pick up the fix automatically.

## Related Issues

Closes #388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of GitHub Actions workflows to handle edge cases with missing tags, preventing premature failures during release and changelog automation processes. These updates enhance workflow stability across repository build and release pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->