### PR TITLE
feat: keep highest stable semver as GitHub Latest on release (closes #389)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,10 +350,32 @@ jobs:
       - name: Update floating major version tag
         uses: LerianStudio/github-actions-shared-workflows/src/config/update-major-tag@v1
 
+  # ----------------- Enforce GitHub Latest -----------------
+  enforce_latest:
+    name: Enforce Latest Release
+    needs: [publish_release, publish_release_status]
+    if: always() && needs.publish_release_status.outputs.release_published == 'true'
+    runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: write
+    steps:
+      - name: Re-assert highest stable semver as Latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          highest=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-pre-releases --exclude-drafts \
+            --json tagName --jq '.[].tagName' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [ -n "$highest" ]; then
+            echo "::notice::Re-asserting GitHub Latest to highest stable semver: $highest"
+            gh release edit "$highest" --repo "$GITHUB_REPOSITORY" --latest
+          else
+            echo "ℹ️ No stable vX.Y.Z release found — leaving Latest untouched"
+          fi
+
   # Slack notification
   notify:
     name: Notify
-    needs: [prepare, publish_release, publish_release_status, generate_changelog, update_major_tag]
+    needs: [prepare, publish_release, publish_release_status, generate_changelog, update_major_tag, enforce_latest]
     if: always() && needs.prepare.outputs.has_changes == 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
@@ -362,10 +384,11 @@ jobs:
             && 'failure' || 'success' }}
       workflow_name: "Release"
       failed_jobs: >-
-        ${{ format('{0}{1}{2}',
+        ${{ format('{0}{1}{2}{3}',
           (needs.publish_release.result == 'failure' && 'Publish Release' || ''),
           (needs.generate_changelog.result == 'failure' && ' / Generate Changelog' || ''),
-          (needs.update_major_tag.result == 'failure' && ' / Update Major Tag' || '')
+          (needs.update_major_tag.result == 'failure' && ' / Update Major Tag' || ''),
+          (needs.enforce_latest.result == 'failure' && ' / Enforce Latest' || '')
         ) }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`release.yml`'s `Semantic Release` step uses `@semantic-release/github`, which creates the GitHub release **without** specifying `make_latest`. The REST API defaults `make_latest` to `true`, so every freshly created release becomes **"Latest"** regardless of semver ordering. A maintenance-line patch (e.g. `v1.6.1` from `maintenance/1.6.x`) published after a higher main-line release (`v1.7.0`) therefore steals the "Latest" badge and has to be reverted by hand.

This PR adds a post-release job, **`enforce_latest`**, that re-asserts "Latest" to the highest **stable** semver release in the repo. It is the option-(a) approach from #389: idempotent, correct for any single-app repo, and requires **no new input and no change in any consumer**.

- Runs only when a release was actually published, gated on the existing aggregated output `needs.publish_release_status.outputs.release_published == 'true'` — so it never runs (and never fails the workflow) when no release was cut.
- Safe under the matrix (monorepo) flow: the job runs once, after the matrix completes, not per-leg.
- `|| true` guards the pipeline so an empty match (no stable `vX.Y.Z` release — e.g. a monorepo using app-prefixed tags, or a pre-1.0 repo) is a clean no-op instead of a `pipefail`/`set -e` abort.
- Main-line behavior is preserved: when the highest stable semver **is** the version just released, `gh release edit --latest` is a no-op.
- Added to the `notify` job's `needs` and `failed_jobs` so a failure surfaces in the Slack summary.

Permissions: the job declares `contents: write` (top-level workflow stays `contents: read`) and uses `github.token`.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None. No inputs/outputs/secrets added or changed; existing callers are unaffected.

## Testing

- [x] YAML syntax validated locally (`yaml.safe_load`)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (no signature change)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated jobs are not affected — `enforce_latest` only edits the "Latest" flag and is gated on `release_published`

Reference logic validated by the caller workaround documented in #389:
```bash
highest=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-pre-releases --exclude-drafts \
  --json tagName --jq '.[].tagName' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
[ -n "$highest" ] && gh release edit "$highest" --repo "$GITHUB_REPOSITORY" --latest
```

**Caller repo / workflow run:** motivating case — https://github.com/LerianStudio/plugin-br-pix-indirect-btg/actions/runs/26657889439/job/78572886408

## Consumers that benefit

Any repo consuming `release.yml` that maintains a maintenance/patch line (semver-minor branch such as `maintenance/1.6.x`): its patch releases will no longer hijack the "Latest" badge from the main line. Repos with a single linear release history are unaffected (no-op). The caller-side `enforce-latest` workaround can be removed once consumers bump to the version carrying this change.

## Related Issues

Closes #389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow automation to improve latest release designation management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LerianStudio/github-actions-shared-workflows/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->