### PR TITLE
fix(gitops-update): refuse semver downgrade unless explicitly allowed

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -100,6 +100,10 @@ on:
         description: 'Template for the ArgoCD application name. Supports placeholders {server}, {app}, {env}. Default {server}-{app}-{env} preserves current behavior. For kustomize layouts without env split, use e.g. {server}-{app}.'
         type: string
         default: '{server}-{app}-{env}'
+      allow_downgrade:
+        description: 'Allow writing a tag that is semver-lower than the value already in values.yaml. Default false guards against the failure mode where a production release (e.g. 1.1.1) overwrites a dev environment already on a higher pre-release (e.g. 1.2.0-beta.12). Set true for intentional rollbacks.'
+        type: boolean
+        default: false
 
 jobs:
   update_gitops:
@@ -422,8 +426,77 @@ jobs:
           KUSTOMIZE_IMAGE_NAME: ${{ inputs.kustomize_image_name }}
           KUSTOMIZE_ENVIRONMENTS: ${{ inputs.kustomize_environments }}
           MANIFEST_FILE: shared-workflows/${{ inputs.deployment_matrix_file }}
+          ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
         run: |
           set -euo pipefail
+
+          # Semver precedence comparison (pure bash, no external deps).
+          # Returns 0 when $1 > $2 strictly per https://semver.org/#spec-item-11.
+          # `sort -V` was rejected: GNU coreutils does not implement spec-correct
+          # prerelease precedence (it sorts "1.2.0" < "1.2.0-beta.12" instead of >).
+          semver_gt() {
+            local a="${1#v}" b="${2#v}"
+            [[ "$a" == "$b" ]] && return 1
+            local a_core="${a%%-*}" a_pre=""
+            [[ "$a" == *-* ]] && a_pre="${a#*-}"
+            local b_core="${b%%-*}" b_pre=""
+            [[ "$b" == *-* ]] && b_pre="${b#*-}"
+            local a_maj a_min a_pat b_maj b_min b_pat
+            IFS=. read -r a_maj a_min a_pat <<< "$a_core"
+            IFS=. read -r b_maj b_min b_pat <<< "$b_core"
+            local pair x y
+            for pair in "$a_maj:$b_maj" "$a_min:$b_min" "$a_pat:$b_pat"; do
+              x=${pair%:*} y=${pair#*:}
+              (( x > y )) && return 0
+              (( x < y )) && return 1
+            done
+            # major.minor.patch equal — apply prerelease rule:
+            # release version > prerelease version (1.2.0 > 1.2.0-beta.X)
+            [[ -z "$a_pre" && -n "$b_pre" ]] && return 0
+            [[ -n "$a_pre" && -z "$b_pre" ]] && return 1
+            [[ -z "$a_pre" && -z "$b_pre" ]] && return 1
+            local -a a_ids b_ids
+            IFS=. read -ra a_ids <<< "$a_pre"
+            IFS=. read -ra b_ids <<< "$b_pre"
+            local i max=${#a_ids[@]}
+            (( ${#b_ids[@]} > max )) && max=${#b_ids[@]}
+            for ((i=0; i<max; i++)); do
+              local ai="${a_ids[i]:-}" bi="${b_ids[i]:-}"
+              [[ -z "$ai" && -n "$bi" ]] && return 1
+              [[ -n "$ai" && -z "$bi" ]] && return 0
+              if [[ "$ai" =~ ^[0-9]+$ && "$bi" =~ ^[0-9]+$ ]]; then
+                (( ai > bi )) && return 0
+                (( ai < bi )) && return 1
+              elif [[ "$ai" =~ ^[0-9]+$ ]]; then
+                return 1   # numeric identifiers have lower precedence than alphanumeric
+              elif [[ "$bi" =~ ^[0-9]+$ ]]; then
+                return 0
+              else
+                [[ "$ai" > "$bi" ]] && return 0
+                [[ "$ai" < "$bi" ]] && return 1
+              fi
+            done
+            return 1
+          }
+
+          # is_upgrade NEW CURRENT -> 0 iff NEW should be written over CURRENT.
+          # Empty CURRENT is treated as a fresh write (always allowed).
+          # Non-semver values (e.g. "latest", branch SHAs) bypass the guard
+          # with a warning, since there is no precedence to compare against.
+          is_upgrade() {
+            local new="$1" current="$2"
+            [[ -z "$current" ]] && return 0
+            local re='^v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'
+            if [[ ! "$current" =~ $re ]]; then
+              echo "::warning::current value '$current' is not semver-shaped; skipping precedence check"
+              return 0
+            fi
+            if [[ ! "$new" =~ $re ]]; then
+              echo "::warning::new value '$new' is not semver-shaped; skipping precedence check"
+              return 0
+            fi
+            semver_gt "$new" "$current"
+          }
 
           # Determine environments to update based on tag type (IS_* from job env)
           if [[ "$IS_BETA" == "true" ]]; then
@@ -552,6 +625,12 @@ jobs:
                   [[ -f "$artifact_file" ]] || continue
                   TAG="$(cut -d= -f2 < "$artifact_file" | tr -d '[:space:]')"
                   [[ -n "$TAG" ]] || continue
+                  CURRENT_TAG=$(yq e ".images[] | select(.name == \"$KUSTOMIZE_IMAGE_NAME\") | .newTag" "$KUSTOMIZATION_FILE" 2>/dev/null || echo "")
+                  if [[ "$CURRENT_TAG" == "null" ]]; then CURRENT_TAG=""; fi
+                  if [[ "$ALLOW_DOWNGRADE" != "true" ]] && ! is_upgrade "$TAG" "$CURRENT_TAG"; then
+                    echo "::warning::Refusing to downgrade ${KUSTOMIZE_IMAGE_NAME} in $KUSTOMIZATION_FILE: $CURRENT_TAG -> $TAG. Pass allow_downgrade=true to override."
+                    continue
+                  fi
                   echo "    kustomize edit set image ${KUSTOMIZE_IMAGE_NAME}=${KUSTOMIZE_IMAGE_NAME}:${TAG}"
                   ( cd "gitops/${TARGET_DIR}" && kustomize edit set image "${KUSTOMIZE_IMAGE_NAME}=${KUSTOMIZE_IMAGE_NAME}:${TAG}" )
                 done
@@ -615,7 +694,12 @@ jobs:
                   if [[ -n "$TAG" ]]; then
                     # Get current value to check if update is needed
                     CURRENT_TAG=$(yq e "$yaml_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                    if [[ "$CURRENT_TAG" == "null" ]]; then CURRENT_TAG=""; fi
                     if [[ "$CURRENT_TAG" != "$TAG" ]]; then
+                      if [[ "$ALLOW_DOWNGRADE" != "true" ]] && ! is_upgrade "$TAG" "$CURRENT_TAG"; then
+                        echo "::warning::Refusing to downgrade $yaml_key in $VALUES_FILE: $CURRENT_TAG -> $TAG. Pass allow_downgrade=true to override."
+                        continue
+                      fi
                       # Use yq with explicit output to preserve formatting
                       TAG="$TAG" yq e "$yaml_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
                       mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
@@ -637,7 +721,12 @@ jobs:
                     TAG="$(cut -d= -f2 < "$ARTIFACT_FILE" | tr -d '[:space:]')"
                     if [[ -n "$TAG" ]]; then
                       CURRENT_TAG=$(yq e "$configmap_key" "$VALUES_FILE" 2>/dev/null || echo "")
+                      if [[ "$CURRENT_TAG" == "null" ]]; then CURRENT_TAG=""; fi
                       if [[ "$CURRENT_TAG" != "$TAG" ]]; then
+                        if [[ "$ALLOW_DOWNGRADE" != "true" ]] && ! is_upgrade "$TAG" "$CURRENT_TAG"; then
+                          echo "::warning::Refusing to downgrade $configmap_key in $VALUES_FILE: $CURRENT_TAG -> $TAG. Pass allow_downgrade=true to override."
+                          continue
+                        fi
                         TAG="$TAG" yq e "$configmap_key = strenv(TAG)" "$VALUES_FILE" > "${VALUES_FILE}.tmp"
                         mv "${VALUES_FILE}.tmp" "$VALUES_FILE"
                         echo "    Updated $configmap_key: $CURRENT_TAG -> $TAG"


### PR DESCRIPTION
> ⚠️ Opened as **draft** — DevOps team review required. Behavior change affects every release pipeline that uses this reusable workflow.

## Summary

`gitops-update.yml` currently writes image tags into `values.yaml` whenever `CURRENT_TAG != TAG`, regardless of semver precedence. When a **production** tag fires, the env loop is `dev stg prd sandbox` — production releases overwrite **dev paths** indiscriminately. This caused a multi-day incident (details below).

This PR adds a semver-correct precedence guard with an explicit override.

| Before | After |
|---|---|
| `1.1.1` overwrites `1.2.0-beta.12` silently | `1.1.1` → `1.2.0-beta.12` is refused with `::warning::`; commit is skipped |
| No way to express "downgrade allowed" intent | New input `allow_downgrade: bool` (default `false`); set `true` for intentional rollbacks |

## Root incident (the bug this prevents)

On **2026-05-31 00:49 UTC**, the auto-bump commit [`LerianStudio/midaz-firmino-gitops@2e46be40`](https://github.com/LerianStudio/midaz-firmino-gitops/commit/2e46be40) (`ci(flowker): update image tags (production)`) downgraded **4 dev paths** (firmino, anacleto, benedita, clotilde) from `1.2.0-beta.12` to `1.1.1`. The audit_db schema in dev had been migrated to v2 by the beta deploys; image `:1.1.1` only ships migration 001. Result: 3 of 4 dev pods stuck in CrashLoopBackOff for 2+ days (`firmino-flowker-dev` reached 270 restarts before the manual fix). Out-of-band fix: [`LerianStudio/midaz-firmino-gitops#814`](https://github.com/LerianStudio/midaz-firmino-gitops/pull/814).

## Changes

- New input **`allow_downgrade`** (boolean, default `false`).
- Pure-bash **`semver_gt`** function — no install step, no external dependency.
  - `sort -V` was tried first and rejected: GNU coreutils does **not** implement [semver §11](https://semver.org/#spec-item-11) precedence for prereleases (it sorts `1.2.0 < 1.2.0-beta.12`, which is backwards).
- Guard applied at **3 update sites**:
  - helmfile `values.yaml` — image tag mappings
  - helmfile `values.yaml` — configmap key mappings
  - kustomization.yaml — `kustomize edit set image`
- Empty/non-semver current value → bypass guard with a `::warning::` (first installs and exotic schemes are not blocked).

## Local test matrix (12 cases, all passing)

```
PASS  1.2.0              vs 1.2.0-beta.12       -> GT   (release > prerelease)
PASS  1.2.0-beta.12      vs 1.2.0               -> LT
PASS  1.2.0              vs 1.1.99              -> GT
PASS  1.1.1              vs 1.2.0-beta.12       -> LT   ← THE INCIDENT
PASS  1.2.0-beta.13      vs 1.2.0-beta.12       -> GT
PASS  1.2.0-rc.1         vs 1.2.0-beta.99       -> GT   (rc > beta)
PASS  1.2.0-alpha        vs 1.2.0-alpha.1       -> LT   (shorter prerelease < longer)
PASS  1.1.1              vs 1.1.1               -> EQ
PASS  2.0.0              vs 1.99.99             -> GT
PASS  v1.2.3             vs 1.2.3               -> EQ   (v-prefix tolerated)
PASS  1.2.0-beta.10      vs 1.2.0-beta.9        -> GT   (numeric ordering)
PASS  1.2.0-beta.12      vs 1.2.0-beta.13       -> LT
```

## Risk / backward compatibility

- **Default behavior changes** for callers: a release that previously silently downgraded will now refuse with a warning. This is the intended behavior; it surfaces a class of bug that was previously invisible.
- Callers that genuinely need rollback set `allow_downgrade: true` at the call site.
- No new dependencies, no new install steps, runs in the same bash shell.
- No changes to the `argocd_sync`, `commit`, or `slack-notify` jobs.

## Test plan

- [ ] Local unit tests pass (12/12 — see matrix above).
- [ ] Trigger a synthetic release in a sandbox caller (`self-pr-validation.yml`?) with `1.1.1` over a dev path on `1.2.0-beta.X` — confirm the workflow log shows the refusal warning and the commit step is a no-op.
- [ ] Same scenario with `allow_downgrade: true` — confirm the downgrade is applied (backward-compatible escape hatch).
- [ ] Upgrade scenario (`1.2.0-beta.13` over `1.2.0-beta.12`) — confirm it still works (no regression).
- [ ] Equal scenario — confirm it still no-ops as before.

## Follow-up not in this PR

The `IS_PRODUCTION` env loop is `dev stg prd sandbox`. Even with the semver guard, this still writes to `dev` (it just no-ops on downgrades). A stricter policy might be: **production releases never touch dev**. That is a behavioral change that deserves its own discussion with the DevOps team and is out of scope here.

cc @LerianStudio/g_github_devops