### PR TITLE
feat(benedita): register forge under app_helmfile_env (cross)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -140,6 +140,7 @@ clusters:
     # only after aligning their ArgoCD app naming with the standard convention.
     app_helmfile_env:
       rosiehr: cross
+      forge: cross
     apps:
       - midaz
       - fetcher


### PR DESCRIPTION
## What
Add `forge: cross` under `clusters.benedita.app_helmfile_env` so the gitops-update workflow resolves forge's values at `environments/benedita/helmfile/applications/cross/forge/values.yaml` (forge's values live under `cross/`, like rosiehr).

```diff
     app_helmfile_env:
       rosiehr: cross
+      forge: cross
```

## Why
`LerianStudio/forge` does not auto-deploy to benedita: its gitops-update run logs `No files were updated` because the workflow searches `applications/{dev,stg,prd,sandbox}/forge/` while forge's values are under `cross/forge/`. The `app_helmfile_env` override fixes the path. (v1.12.0 was deployed manually via midaz-firmino-gitops PR #826.)

## About the non-standard ArgoCD name caveat
The comment here warns to only register apps "after aligning their ArgoCD app naming with the standard convention" (forge's app is `benedita-forge`, no `-dev`). The **companion forge PR** addresses this without renaming the ArgoCD app, by passing `argocd_app_name_template: "{server}-{app}"` to gitops-update — so the sync target resolves to the real `benedita-forge`. With that override in place, registering `forge: cross` here is safe.

## Companion PR (must land together)
**LerianStudio/forge#20** — bumps gitops-update `@v1.29.0`→`@v1.32.0` (this `app_helmfile_env` consumption only exists from v1.32.0), adds the `argocd_app_name_template` override, and drops the dead `deploy_in_clotilde` target. Neither PR regresses anything on its own; forge auto-deploy starts working once both merge.

> Note: `lerian-map` (@v1.24.2, also non-standard name, also under `cross/`, also not registered here) is silently broken the same way and currently relies on manual bumps — worth the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the Benedita cluster to specify the values path for the `forge` service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->