### PR TITLE
feat(benedita): register forge under app_helmfile_env (cross)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -140,6 +140,7 @@ clusters:
     # only after aligning their ArgoCD app naming with the standard convention.
     app_helmfile_env:
       rosiehr: cross
+      forge: cross
     apps:
       - midaz
       - fetcher


### PR DESCRIPTION
> Re-opened against **develop** (the previous PR #397 mistakenly targeted `main`).

## What
Add `forge: cross` under `clusters.benedita.app_helmfile_env` so gitops-update resolves forge's values at `environments/benedita/helmfile/applications/cross/forge/values.yaml` (forge's values live under `cross/`, like rosiehr).

```diff
     app_helmfile_env:
       rosiehr: cross
+      forge: cross
```

## Why
`LerianStudio/forge` does not auto-deploy to benedita: its gitops-update run logs `No files were updated` because the workflow searches `applications/{dev,stg,prd,sandbox}/forge/` while forge's values are under `cross/forge/`. The `app_helmfile_env` override fixes the path. (v1.12.0 was deployed manually via midaz-firmino-gitops PR #826.)

## Non-standard ArgoCD name caveat — addressed
The comment here warns to register apps "after aligning their ArgoCD app naming with the standard convention" (forge's app is `benedita-forge`, no `-dev`). The **companion forge PR** passes `argocd_app_name_template: "{server}-{app}"` to gitops-update, so the sync target resolves to the real `benedita-forge` without renaming the app. With that override, registering `forge: cross` here is safe.

## Companion PR (must land together)
**LerianStudio/forge#20** — bumps gitops-update `@v1.29.0`→`@v1.32.0` (the `app_helmfile_env` consumption only exists from v1.32.0), adds the `argocd_app_name_template` override, and drops the dead `deploy_in_clotilde` target. Neither PR regresses anything alone; forge auto-deploy starts once both merge.

> Follow-up: `lerian-map` (@v1.24.2, also non-standard name + under `cross/`, also unregistered here) is silently broken the same way and relies on manual bumps — worth the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the Beneditá cluster to route a specific service through an alternate per-application configuration path, switching its values source to the cross configuration directory to ensure it uses the intended settings during deploys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->