### PR TITLE
feat(matrix): register go-boilerplate-ddd for benedita

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -67,6 +67,7 @@ apps:
     # Benedita-exclusive
     - severino-bot                # internal Slack bot (benedita only)
     - rosiehr                     # internal HR app (benedita only); values at cross/ — see app_helmfile_env below
+    - go-boilerplate-ddd          # Go service boilerplate (reference/template); benedita only
 
 clusters:
   firmino:
@@ -162,3 +163,4 @@ clusters:
       - severino-bot
       - lerian-notification
       - rosiehr
+      - go-boilerplate-ddd


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Registers `go-boilerplate-ddd` in `config/deployment-matrix.yml` under the **benedita** cluster (and the `apps.registry` master list).

Without this entry the `gitops-update.yml` reusable resolves `has_sync_targets=false` for the app, so the `ArgoCD Sync` job is skipped on every release (the matrix job renders with unexpanded `${{ matrix.target.server }}` placeholders). After this change, a `go-boilerplate-ddd` release that reaches `update_gitops` will resolve `benedita` as a sync target and trigger the ArgoCD sync.

Registered under benedita only, using the standard ArgoCD app-name pattern (`benedita-go-boilerplate-ddd-{env}`), so no `app_helmfile_env` override is added (values expected at the default `environments/benedita/helmfile/applications/{env}/go-boilerplate-ddd/values.yaml`).

### Prerequisites (outside this repo)

This PR only makes the matrix resolve a target. For the sync to actually succeed, the **gitops repo** must have:
- the app's `values.yaml` under the benedita path above, and
- an ArgoCD application named `benedita-go-boilerplate-ddd-{env}`.

Note that `{env}` is derived from the git tag type (`dev`/`stg`/`prd`/`sandbox`); a stable tag resolves to `prd`.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None. Purely additive — no existing app entry or cluster mapping is modified.

## Testing

- [x] YAML syntax validated locally (`apps.registry` and `clusters.benedita.apps` both contain `go-boilerplate-ddd`)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated end-to-end on the next `go-boilerplate-ddd` release once the gitops-repo prerequisites above are in place.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployed a new application component to production infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->