### PR TITLE
fix(helm-update-chart): close superseded update PRs for the same chart and major line

### DIFF
--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -512,7 +512,7 @@ jobs:
               *) continue ;;
             esac
             if [ -n "${NEW_MAJOR}" ]; then
-              OLD_MAJOR=$(echo "${OLD_HEAD#update/${CHART}/}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+              OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
               if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
                 continue
               fi

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -501,28 +501,39 @@ jobs:
 
           # Supersede older open update PRs for the same chart and major version line.
           # Cross-major PRs are kept: 1.x and 2.x release lines can be open simultaneously.
+          # Fail closed: if a major cannot be derived on either side, nothing is closed.
           NEW_MAJOR=$(echo "${SOURCE_REF}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+          if [ -z "${NEW_MAJOR}" ]; then
+            echo "::warning::Skipping superseded PR cleanup: could not derive major from SOURCE_REF='${SOURCE_REF}'"
+            exit 0
+          fi
 
-          gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
-            --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' |
+          # Best-effort: a transient listing failure must not fail the job after the PR exists.
+          if ! OPEN_UPDATE_PRS=$(
+            gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
+              --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"'
+          ); then
+            echo "::warning::Failed to list open PRs for supersession cleanup"
+            exit 0
+          fi
+
           while read -r OLD_NUM OLD_HEAD; do
+            [ -z "${OLD_NUM}" ] && continue
             [ "${OLD_HEAD}" = "${BRANCH_NAME}" ] && continue
             case "${OLD_HEAD}" in
               "update/${CHART}/"*) ;;
               *) continue ;;
             esac
-            if [ -n "${NEW_MAJOR}" ]; then
-              OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
-              if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
-                continue
-              fi
+            OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+            if [ -z "${OLD_MAJOR}" ] || [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
+              continue
             fi
             echo "Closing superseded PR #${OLD_NUM} (${OLD_HEAD})"
             gh pr close "${OLD_NUM}" \
               --comment "Superseded by ${PR_URL}." \
               --delete-branch \
               || echo "::warning::Failed to close superseded PR #${OLD_NUM}"
-          done
+          done <<< "${OPEN_UPDATE_PRS}"
 
       - name: Summary
         env:

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -446,6 +446,7 @@ jobs:
           BASE_BRANCH: ${{ inputs.base_branch }}
           HAS_NEW_ENV_VARS: ${{ steps.payload.outputs.has_new_env_vars }}
           UPDATED_COMPONENTS: ${{ steps.process.outputs.updated_components }}
+          SOURCE_REF: ${{ steps.payload.outputs.source_ref }}
         run: |
 
           # Push the branch
@@ -497,6 +498,31 @@ jobs:
 
           echo "PR created: ${PR_URL}"
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+          # Supersede older open update PRs for the same chart and major version line.
+          # Cross-major PRs are kept: 1.x and 2.x release lines can be open simultaneously.
+          NEW_MAJOR=$(echo "${SOURCE_REF}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+
+          gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
+            --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' |
+          while read -r OLD_NUM OLD_HEAD; do
+            [ "${OLD_HEAD}" = "${BRANCH_NAME}" ] && continue
+            case "${OLD_HEAD}" in
+              "update/${CHART}/"*) ;;
+              *) continue ;;
+            esac
+            if [ -n "${NEW_MAJOR}" ]; then
+              OLD_MAJOR=$(echo "${OLD_HEAD#update/${CHART}/}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+              if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
+                continue
+              fi
+            fi
+            echo "Closing superseded PR #${OLD_NUM} (${OLD_HEAD})"
+            gh pr close "${OLD_NUM}" \
+              --comment "Superseded by ${PR_URL}." \
+              --delete-branch \
+              || echo "::warning::Failed to close superseded PR #${OLD_NUM}"
+          done
 
       - name: Summary
         env:


### PR DESCRIPTION
## Summary

Every dispatch of `helm-update-chart.yml` creates a unique branch (`update/<chart>/<ref>-<timestamp>`) and opens a new PR without touching the previous one. Stale bump PRs accumulate — `helm` had **14 stale open bot PRs** (reporter alone had 5: v1.3.0 → v2.0.0).

## Change

After the new PR is created, list open PRs against the same base whose head matches `update/<chart>/*` and close them with a supersede comment + branch deletion.

**Major-line guard:** only PRs on the same major version line are closed. Observed today: reporter had v1.3.3 and v2.0.0 PRs open simultaneously (1.x maintenance + 2.x) — closing cross-major would have killed a legitimate release channel.

**Failure mode:** non-fatal. If closing fails, the workflow warns and proceeds — worst case is the status quo (a stale PR survives).

## Verification
- YAML parses clean
- Logic mirrors the manual cleanup executed on lerianstudio/helm today (8 superseded PRs closed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now captures release-version context when creating chart update PRs.
  * Automatically detects and marks older chart-update PRs as superseded, posts a notification on them, deletes their branches, and closes them.
  * Preserves existing update PRs that target a different major release series so they remain open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->