### PR TITLE
chore: promote develop to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,18 +252,18 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to DockerHub
         if: inputs.enable_dockerhub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_IMAGE_PUSH_TOKEN }}
 
       - name: Log in to GHCR
         if: inputs.enable_ghcr
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -313,7 +313,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ steps.image-names.outputs.images }}
           tags: |
@@ -321,7 +321,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.build_context_from_working_dir == true && matrix.app.working_dir || inputs.build_context }}
           file: ${{ matrix.app.working_dir }}/${{ inputs.dockerfile_name }}

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -116,7 +116,7 @@ jobs:
     steps:
       - name: Log in to Docker Hub
         if: ${{ inputs.enable_docker_login }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_IMAGE_PULL_TOKEN }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -155,10 +155,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to Docker Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ inputs.docker_registry }}
           username: ${{ secrets.DOCKER_USERNAME || github.actor }}
@@ -166,14 +166,14 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ inputs.docker_registry }}/${{ github.repository }}
           tags: ${{ inputs.docker_tags }}
 
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: ${{ inputs.docker_platforms }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -101,7 +101,7 @@ jobs:
         run: ${{ inputs.test_cmd }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           distribution: ${{ inputs.goreleaser_distribution }}
           version: ${{ inputs.goreleaser_version }}

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -80,7 +80,7 @@ jobs:
             git fetch --tags
 
             # Get tags created in the last hour (recent release)
-            LATEST_TAGS=$(git tag --sort=-creatordate | head -20)
+            LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
             echo "📌 Recent tags: $LATEST_TAGS"
 
             # Find first stable tag (no beta/rc/alpha)
@@ -193,7 +193,7 @@ jobs:
                 # Escape regex metacharacters in app name for grep
                 # shellcheck disable=SC2001,SC2016
                 APP_NAME_ESCAPED=$(echo "$APP_NAME" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')
-                LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+                LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
                 if [ -n "$LATEST_TAG" ]; then
                   echo "📦 Found stable tag for $APP_NAME: $LATEST_TAG"
@@ -329,7 +329,7 @@ jobs:
             echo "🔍 Looking for tags matching: $TAG_PATTERN"
 
             # Find the latest STABLE tag for this app (exclude beta/rc/alpha)
-            LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+            LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
             if [ -z "$LAST_TAG" ]; then
               echo "⚠️ No stable tag found for $APP_NAME - skipping"

--- a/.github/workflows/helm-release-notification.yml
+++ b/.github/workflows/helm-release-notification.yml
@@ -101,7 +101,7 @@ jobs:
           CHART_NAME=$(echo "${CHART_NAME_STRIPPED//-/ }" | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
 
           # Get latest release tag for this chart
-          LATEST_TAG=$(git tag -l "${CHART_NAME_RAW}-v*" --sort=-v:refname | head -1)
+          LATEST_TAG=$(git tag -l "${CHART_NAME_RAW}-v*" --sort=-v:refname | head -1 || true)
           if [ -z "$LATEST_TAG" ]; then
             echo "::error::No release tag found matching pattern '${CHART_NAME_RAW}-v*'"
             exit 1

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -512,7 +512,7 @@ jobs:
               *) continue ;;
             esac
             if [ -n "${NEW_MAJOR}" ]; then
-              OLD_MAJOR=$(echo "${OLD_HEAD#update/${CHART}/}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+              OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
               if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
                 continue
               fi

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -501,28 +501,39 @@ jobs:
 
           # Supersede older open update PRs for the same chart and major version line.
           # Cross-major PRs are kept: 1.x and 2.x release lines can be open simultaneously.
+          # Fail closed: if a major cannot be derived on either side, nothing is closed.
           NEW_MAJOR=$(echo "${SOURCE_REF}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+          if [ -z "${NEW_MAJOR}" ]; then
+            echo "::warning::Skipping superseded PR cleanup: could not derive major from SOURCE_REF='${SOURCE_REF}'"
+            exit 0
+          fi
 
-          gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
-            --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' |
+          # Best-effort: a transient listing failure must not fail the job after the PR exists.
+          if ! OPEN_UPDATE_PRS=$(
+            gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
+              --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"'
+          ); then
+            echo "::warning::Failed to list open PRs for supersession cleanup"
+            exit 0
+          fi
+
           while read -r OLD_NUM OLD_HEAD; do
+            [ -z "${OLD_NUM}" ] && continue
             [ "${OLD_HEAD}" = "${BRANCH_NAME}" ] && continue
             case "${OLD_HEAD}" in
               "update/${CHART}/"*) ;;
               *) continue ;;
             esac
-            if [ -n "${NEW_MAJOR}" ]; then
-              OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
-              if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
-                continue
-              fi
+            OLD_MAJOR=$(echo "${OLD_HEAD#"update/${CHART}/"}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+            if [ -z "${OLD_MAJOR}" ] || [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
+              continue
             fi
             echo "Closing superseded PR #${OLD_NUM} (${OLD_HEAD})"
             gh pr close "${OLD_NUM}" \
               --comment "Superseded by ${PR_URL}." \
               --delete-branch \
               || echo "::warning::Failed to close superseded PR #${OLD_NUM}"
-          done
+          done <<< "${OPEN_UPDATE_PRS}"
 
       - name: Summary
         env:

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -446,6 +446,7 @@ jobs:
           BASE_BRANCH: ${{ inputs.base_branch }}
           HAS_NEW_ENV_VARS: ${{ steps.payload.outputs.has_new_env_vars }}
           UPDATED_COMPONENTS: ${{ steps.process.outputs.updated_components }}
+          SOURCE_REF: ${{ steps.payload.outputs.source_ref }}
         run: |
 
           # Push the branch
@@ -497,6 +498,31 @@ jobs:
 
           echo "PR created: ${PR_URL}"
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+          # Supersede older open update PRs for the same chart and major version line.
+          # Cross-major PRs are kept: 1.x and 2.x release lines can be open simultaneously.
+          NEW_MAJOR=$(echo "${SOURCE_REF}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+
+          gh pr list --base "${BASE_BRANCH}" --state open --limit 100 \
+            --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' |
+          while read -r OLD_NUM OLD_HEAD; do
+            [ "${OLD_HEAD}" = "${BRANCH_NAME}" ] && continue
+            case "${OLD_HEAD}" in
+              "update/${CHART}/"*) ;;
+              *) continue ;;
+            esac
+            if [ -n "${NEW_MAJOR}" ]; then
+              OLD_MAJOR=$(echo "${OLD_HEAD#update/${CHART}/}" | sed -nE 's/^v?([0-9]+)\..*/\1/p')
+              if [ -n "${OLD_MAJOR}" ] && [ "${OLD_MAJOR}" != "${NEW_MAJOR}" ]; then
+                continue
+              fi
+            fi
+            echo "Closing superseded PR #${OLD_NUM} (${OLD_HEAD})"
+            gh pr close "${OLD_NUM}" \
+              --comment "Superseded by ${PR_URL}." \
+              --delete-branch \
+              || echo "::warning::Failed to close superseded PR #${OLD_NUM}"
+          done
 
       - name: Summary
         env:

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -124,7 +124,7 @@ jobs:
     steps:
       # ----------------- Setup -----------------
       - name: Login to Docker Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ inputs.docker_registry }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -166,7 +166,7 @@ jobs:
     steps:
       # ----------------- Setup -----------------
       - name: Login to Docker Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ inputs.docker_registry }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: inputs.enable_docker_scan
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       # ----------------- Filesystem Scanning (Secrets + Vulnerabilities) -----------------
       - name: Trivy Filesystem Scan
@@ -192,7 +192,7 @@ jobs:
       # ----------------- Docker Build -----------------
       - name: Build Docker Image for Scanning
         if: always() && inputs.enable_docker_scan
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           # yamllint disable-line rule:line-length
           context: ${{ inputs.build_context_from_working_dir == true && matrix.working_dir || (inputs.monorepo_type == 'type2' && matrix.working_dir == inputs.frontend_folder && inputs.frontend_folder || '.') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,10 +350,32 @@ jobs:
       - name: Update floating major version tag
         uses: LerianStudio/github-actions-shared-workflows/src/config/update-major-tag@v1
 
+  # ----------------- Enforce GitHub Latest -----------------
+  enforce_latest:
+    name: Enforce Latest Release
+    needs: [publish_release, publish_release_status]
+    if: always() && needs.publish_release_status.outputs.release_published == 'true'
+    runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: write
+    steps:
+      - name: Re-assert highest stable semver as Latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          highest=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-pre-releases --exclude-drafts \
+            --json tagName --jq '.[].tagName' | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [ -n "$highest" ]; then
+            echo "::notice::Re-asserting GitHub Latest to highest stable semver: $highest"
+            gh release edit "$highest" --repo "$GITHUB_REPOSITORY" --latest
+          else
+            echo "ℹ️ No stable vX.Y.Z release found — leaving Latest untouched"
+          fi
+
   # Slack notification
   notify:
     name: Notify
-    needs: [prepare, publish_release, publish_release_status, generate_changelog, update_major_tag]
+    needs: [prepare, publish_release, publish_release_status, generate_changelog, update_major_tag, enforce_latest]
     if: always() && needs.prepare.outputs.has_changes == 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
@@ -362,10 +384,11 @@ jobs:
             && 'failure' || 'success' }}
       workflow_name: "Release"
       failed_jobs: >-
-        ${{ format('{0}{1}{2}',
+        ${{ format('{0}{1}{2}{3}',
           (needs.publish_release.result == 'failure' && 'Publish Release' || ''),
           (needs.generate_changelog.result == 'failure' && ' / Generate Changelog' || ''),
-          (needs.update_major_tag.result == 'failure' && ' / Update Major Tag' || '')
+          (needs.update_major_tag.result == 'failure' && ' / Update Major Tag' || ''),
+          (needs.enforce_latest.result == 'failure' && ' / Enforce Latest' || '')
         ) }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -140,6 +140,7 @@ clusters:
     # only after aligning their ArgoCD app naming with the standard convention.
     app_helmfile_env:
       rosiehr: cross
+      forge: cross
     apps:
       - midaz
       - fetcher

--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -79,7 +79,7 @@ runs:
           echo "📌 Triggered by branch/workflow_run, finding latest stable tags..."
           git fetch --tags
 
-          LATEST_TAGS=$(git tag --sort=-creatordate | head -20)
+          LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
           echo "📌 Recent tags: $LATEST_TAGS"
 
           TAG_NAME=""
@@ -164,7 +164,7 @@ runs:
             APP_NAME=$(basename "$path")
             # shellcheck disable=SC2001,SC2016
             APP_NAME_ESCAPED=$(echo "$APP_NAME" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')
-            LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+            LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
             if [ -n "$LATEST_TAG" ]; then
               echo "📦 Found stable tag for $APP_NAME: $LATEST_TAG"
@@ -234,7 +234,7 @@ runs:
             TAG_GREP_PATTERN="^v"
           fi
 
-          LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1)
+          LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
           if [ -z "$LAST_TAG" ]; then
             echo "⚠️ No stable tag found for $APP_NAME - skipping"

--- a/src/config/release-tag-check/action.yml
+++ b/src/config/release-tag-check/action.yml
@@ -24,7 +24,7 @@ runs:
         PREVIOUS_TAG: ${{ inputs.previous-tag }}
       run: |
         git fetch --tags origin
-        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1 || true)
         if [ "$NEW_TAG" != "$PREVIOUS_TAG" ] && [ -n "$NEW_TAG" ]; then
           echo "release_published=true" >> "$GITHUB_OUTPUT"
           VERSION="${NEW_TAG#v}"


### PR DESCRIPTION
## Summary

Promotes `develop` to `main`, releasing the helm-update-chart supersede fix (#400) to all consumers (workflows are referenced via `@main`).

## Included
- #400 — `helm-update-chart.yml`: close superseded update PRs for the same chart and major version line. Fail-closed on unparsable majors, non-fatal PR listing.

Plus whatever else was already sitting on `develop` ahead of `main` (see commit list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD action pins for Docker and GoReleaser; improved robustness when tag lookups are empty.
  * Updated deployment matrix to use a per-app helmfile values override for one cluster.

* **New Features**
  * Added an "enforce latest" release job to mark the highest stable release as Latest.
  * Added automatic cleanup of superseded Helm chart update PRs with a superseded notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->