### PR TITLE
fix(ci): add shared_paths input to go-pr-analysis workflow

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -16,6 +16,11 @@ on:
         type: string
         required: false
         default: ''
+      shared_paths:
+        description: 'Newline-separated (or JSON array) path patterns that, when changed, trigger analysis for ALL components in filter_paths.'
+        type: string
+        required: false
+        default: ''
       path_level:
         description: 'Directory depth level to extract app name'
         type: number
@@ -111,6 +116,7 @@ jobs:
         uses: LerianStudio/github-actions-shared-workflows/src/config/changed-paths@v1
         with:
           filter-paths: ${{ inputs.filter_paths }}
+          shared-paths: ${{ inputs.shared_paths }}
           path-level: ${{ inputs.path_level }}
           get-app-name: 'true'
           app-name-prefix: ${{ inputs.app_name_prefix }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`go-pr-analysis.yml` was missing the `shared_paths` `workflow_call` input, even though its sibling `pr-security-scan.yml` already exposes it and the underlying `src/config/changed-paths` action already supports `shared-paths`. This caused `startup_failure` for any caller that passed `shared_paths`, and silent vacuous passes for PRs that only touched shared files (e.g. `go.mod`, `pkg/`, `Makefile`).

This PR mirrors the input from `pr-security-scan.yml` — adds `shared_paths` to the inputs block and wires it through to the `changed-paths` step. Default is `''`, so existing callers are unaffected.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Not yet validated against a live caller — the change is additive and the default `''` preserves current behavior.

## Related Issues

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Go PR Analysis workflow with configurable shared path support, enabling more flexible path-based triggering for analysis workflows across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->