### PR TITLE
feat: add Go PR validation and service release umbrella workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,6 +90,7 @@ validate:
     - any-glob-to-any-file:
       - "src/validate/**"
       - ".github/workflows/pr-validation.yml"
+      - ".github/workflows/go-pr-validation.yml"
       - ".github/workflows/self-pr-validation.yml"
 
 changelog:

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -173,7 +173,7 @@ jobs:
     steps:
       - name: Non-doc change gate
         id: gate
-        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@feat/go-validation-release-umbrellas
         with:
           github-token: ${{ github.token }}
           ignore-globs: ${{ inputs.ignore_globs }}
@@ -203,7 +203,7 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Aggregate Go Analysis result
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
         with:
           result: ${{ needs.go-analysis.result }}
           label: Go Analysis
@@ -229,7 +229,7 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Aggregate security result
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
         with:
           result: ${{ needs.security.result }}
           label: Security

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -193,7 +193,7 @@ jobs:
     steps:
       - name: Non-doc change gate
         id: gate
-        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@feat/go-validation-release-umbrellas
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
         with:
           github-token: ${{ github.token }}
           ignore-globs: ${{ inputs.ignore_globs }}
@@ -223,7 +223,7 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Aggregate Go Analysis result
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
           result: ${{ needs.go-analysis.result }}
           label: Go Analysis
@@ -249,7 +249,7 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Aggregate security result
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
           result: ${{ needs.security.result }}
           label: Security
@@ -275,7 +275,7 @@ jobs:
     runs-on: ${{ inputs.runner_type }}
     steps:
       - name: Aggregate Lib Version result
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
           result: ${{ needs.lib-version.result }}
           label: Lib Version

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -1,0 +1,235 @@
+name: "Go PR Validation"
+
+# Umbrella reusable workflow for Go service repositories.
+# Orchestrates PR metadata validation, a non-doc change gate, the Go analysis
+# pipeline and the security scan pipeline behind opt-in flags, so a caller only
+# needs to reference this single workflow.
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'GitHub runner type to use'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      dry_run:
+        description: 'Preview metadata validations without posting comments or labels'
+        required: false
+        type: boolean
+        default: false
+
+      # ----------------- Pipeline toggles -----------------
+      run_go_analysis:
+        description: 'Run the Go analysis pipeline (lint, tests, coverage, build)'
+        type: boolean
+        default: true
+      run_security:
+        description: 'Run the security scan pipeline (Trivy, CodeQL, prerelease checks)'
+        type: boolean
+        default: true
+
+      # ----------------- Change gate -----------------
+      ignore_globs:
+        description: 'Space-separated glob patterns treated as docs/meta; when only these change, the analysis and security pipelines are skipped.'
+        type: string
+        default: '*.md docs/* .github/* LICENSE* .gitignore'
+
+      # ----------------- PR metadata (pr-validation.yml) -----------------
+      pr_title_types:
+        description: 'Allowed commit types (pipe-separated)'
+        type: string
+        default: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          chore
+          ci
+          build
+          revert
+      pr_title_scopes:
+        description: 'Allowed scopes (pipe-separated, empty = any scope allowed)'
+        type: string
+        default: ''
+      require_scope:
+        description: 'Require scope in PR title'
+        type: boolean
+        default: false
+      enable_auto_labeler:
+        description: 'Enable automatic labeling based on changed files'
+        type: boolean
+        default: true
+      labeler_config_path:
+        description: 'Path to labeler configuration file'
+        type: string
+        default: '.github/labeler.yml'
+      enforce_source_branches:
+        description: 'Enforce that PRs to protected branches come from specific source branches.'
+        type: boolean
+        default: true
+      allowed_source_branches:
+        description: 'Allowed source branches (pipe-separated, supports * prefix matching)'
+        type: string
+        default: 'develop|release-candidate|hotfix/*'
+      target_branches_for_source_check:
+        description: 'Target branches that require source branch validation (pipe-separated)'
+        type: string
+        default: 'main'
+
+      # ----------------- Go analysis (go-pr-analysis.yml) -----------------
+      go_version:
+        description: 'Go version to use'
+        type: string
+        default: '1.23'
+      golangci_lint_version:
+        description: 'GolangCI-Lint version'
+        type: string
+        default: 'v1.62.2'
+      coverage_threshold:
+        description: 'Minimum coverage percentage required (0-100)'
+        type: number
+        default: 80
+      fail_on_coverage_threshold:
+        description: 'Fail the workflow if coverage is below threshold'
+        type: boolean
+        default: false
+      go_private_modules:
+        description: 'GOPRIVATE pattern for private Go modules (e.g., github.com/LerianStudio/*)'
+        type: string
+        default: ''
+      enable_integration_tests:
+        description: 'Enable integration tests (requires make test-integration target)'
+        type: boolean
+        default: false
+      system_packages:
+        description: 'Space-separated apt packages to install before Go commands (CGO repos)'
+        type: string
+        default: ''
+
+      # ----------------- Security (pr-security-scan.yml) -----------------
+      ignore_file:
+        description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml)'
+        type: string
+        default: ''
+      enable_codeql:
+        description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
+        type: boolean
+        default: false
+      codeql_languages:
+        description: 'Languages to analyze with CodeQL (comma-separated, e.g., "go")'
+        type: string
+        default: ''
+
+      # ----------------- Shared -----------------
+      shared_paths:
+        description: 'Newline-separated path patterns that trigger analysis/security for all components.'
+        type: string
+        default: ''
+    secrets:
+      MANAGE_TOKEN:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  # ----------------- PR Metadata Validation -----------------
+  metadata:
+    name: PR Metadata
+    uses: ./.github/workflows/pr-validation.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      dry_run: ${{ inputs.dry_run }}
+      pr_title_types: ${{ inputs.pr_title_types }}
+      pr_title_scopes: ${{ inputs.pr_title_scopes }}
+      require_scope: ${{ inputs.require_scope }}
+      enable_auto_labeler: ${{ inputs.enable_auto_labeler }}
+      labeler_config_path: ${{ inputs.labeler_config_path }}
+      enforce_source_branches: ${{ inputs.enforce_source_branches }}
+      allowed_source_branches: ${{ inputs.allowed_source_branches }}
+      target_branches_for_source_check: ${{ inputs.target_branches_for_source_check }}
+    secrets: inherit
+
+  # ----------------- Change Detection (gate) -----------------
+  changes:
+    name: Detect non-doc changes
+    if: contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)
+    runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
+    steps:
+      - name: Non-doc change gate
+        id: gate
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        with:
+          github-token: ${{ github.token }}
+          ignore-globs: ${{ inputs.ignore_globs }}
+
+  # ----------------- Go Analysis -----------------
+  go-analysis:
+    name: Go Analysis (pipeline)
+    needs: changes
+    if: inputs.run_go_analysis && needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/go-pr-analysis.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      go_version: ${{ inputs.go_version }}
+      golangci_lint_version: ${{ inputs.golangci_lint_version }}
+      coverage_threshold: ${{ inputs.coverage_threshold }}
+      fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
+      go_private_modules: ${{ inputs.go_private_modules }}
+      enable_integration_tests: ${{ inputs.enable_integration_tests }}
+      system_packages: ${{ inputs.system_packages }}
+      shared_paths: ${{ inputs.shared_paths }}
+    secrets: inherit
+
+  go-analysis-gate:
+    name: Go Analysis
+    needs: [changes, go-analysis]
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Aggregate Go Analysis result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        with:
+          result: ${{ needs.go-analysis.result }}
+          label: Go Analysis
+
+  # ----------------- Security Scan -----------------
+  security:
+    name: Security (pipeline)
+    needs: changes
+    if: inputs.run_security && needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/pr-security-scan.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      ignore_file: ${{ inputs.ignore_file }}
+      enable_codeql: ${{ inputs.enable_codeql }}
+      codeql_languages: ${{ inputs.codeql_languages }}
+      shared_paths: ${{ inputs.shared_paths }}
+    secrets: inherit
+
+  security-gate:
+    name: Security
+    needs: [changes, security]
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Aggregate security result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        with:
+          result: ${{ needs.security.result }}
+          label: Security

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -27,6 +27,10 @@ on:
         description: 'Run the security scan pipeline (Trivy, CodeQL, prerelease checks)'
         type: boolean
         default: true
+      run_lib_version_check:
+        description: 'Run the Lerian library version check (fails when a direct Lerian lib is behind latest stable)'
+        type: boolean
+        default: true
 
       # ----------------- Change gate -----------------
       ignore_globs:
@@ -123,6 +127,20 @@ on:
         type: string
         default: ''
 
+      # ----------------- Lerian lib version (lerian-lib-version-check.yml) -----------------
+      lib_version_go_mod_path:
+        description: 'Path to go.mod relative to the repo root'
+        type: string
+        default: 'go.mod'
+      lib_version_check_indirect:
+        description: 'Also check transitive (// indirect) Lerian deps'
+        type: boolean
+        default: false
+      lib_version_comment_on_pr:
+        description: 'Post/update a sticky PR comment with the Lerian lib version table'
+        type: boolean
+        default: true
+
       # ----------------- Shared -----------------
       shared_paths:
         description: 'Newline-separated path patterns that trigger analysis/security for all components.'
@@ -132,6 +150,8 @@ on:
       MANAGE_TOKEN:
         required: false
       SLACK_WEBHOOK_URL:
+        required: false
+      LERIAN_LIB_READ_TOKEN:
         required: false
 
 permissions:
@@ -233,3 +253,29 @@ jobs:
         with:
           result: ${{ needs.security.result }}
           label: Security
+
+  # ----------------- Lerian Library Version Check -----------------
+  lib-version:
+    name: Lib Version (check)
+    needs: changes
+    if: inputs.run_lib_version_check && needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/lerian-lib-version-check.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      go_mod_path: ${{ inputs.lib_version_go_mod_path }}
+      check_indirect: ${{ inputs.lib_version_check_indirect }}
+      comment_on_pr: ${{ inputs.lib_version_comment_on_pr }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  lib-version-gate:
+    name: Lib Version
+    needs: [changes, lib-version]
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Aggregate Lib Version result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@feat/go-validation-release-umbrellas
+        with:
+          result: ${{ needs.lib-version.result }}
+          label: Lib Version

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,8 +1,9 @@
 name: "Go Release"
 
-# Reusable workflow for Go release automation using GoReleaser
-# Builds multi-platform binaries, creates GitHub releases, and publishes Docker images
-# Supports Homebrew tap updates and custom release configurations
+# Umbrella reusable workflow for Go service repositories.
+# On branch pushes it runs semantic-release (gated by a non-doc change detector);
+# on tag pushes it builds and pushes the container image and then updates the
+# GitOps repository. A caller only needs to reference this single workflow.
 
 on:
   workflow_call:
@@ -11,205 +12,173 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
-      go_version:
-        description: 'Go version to use for release builds'
-        type: string
-        default: '1.23'
-      goreleaser_distribution:
-        description: 'GoReleaser distribution to use (goreleaser or goreleaser-pro)'
-        type: string
-        default: 'goreleaser'
-      goreleaser_version:
-        description: 'GoReleaser version to use (default: latest)'
-        type: string
-        default: 'latest'
-      goreleaser_args:
-        description: 'Additional arguments for GoReleaser'
-        type: string
-        default: 'release --clean'
-      run_tests_before_release:
-        description: 'Run tests before creating release'
-        type: boolean
-        default: true
-      test_cmd:
-        description: 'Test command to execute before release'
-        type: string
-        default: 'go test -v ./...'
-      enable_homebrew:
-        description: 'Enable Homebrew formula update'
+      dry_run:
+        description: 'Reserved. Downstream release/build/gitops workflows do not yet expose a dry-run mode.'
+        required: false
         type: boolean
         default: false
-      homebrew_tap_repo:
-        description: 'Homebrew tap repository (format: owner/repo)'
+
+      # ----------------- Change gate -----------------
+      ignore_globs:
+        description: 'Space-separated glob patterns treated as docs/meta; when only these change on a branch push, the release is skipped.'
+        type: string
+        default: '*.md docs/* .github/* LICENSE* .gitignore'
+
+      # ----------------- Release (release.yml) -----------------
+      semantic_version:
+        description: 'Semantic release version to use'
+        type: string
+        default: '23.0.8'
+      enable_changelog:
+        description: 'Generate CHANGELOG.md files via GPT after a successful release'
+        type: boolean
+        default: false
+      enable_major_tag:
+        description: 'Force-update the floating major version tag (e.g. v1) after a successful release'
+        type: boolean
+        default: false
+      stable_releases_only:
+        description: 'Only generate changelogs for stable releases (skip beta/rc/alpha tags)'
+        type: boolean
+        default: true
+
+      # ----------------- Build (build.yml) -----------------
+      enable_dockerhub:
+        description: 'Enable pushing to DockerHub'
+        type: boolean
+        default: true
+      enable_ghcr:
+        description: 'Enable pushing to GitHub Container Registry'
+        type: boolean
+        default: false
+      enable_gitops_artifacts:
+        description: 'Enable GitOps artifacts upload for the downstream gitops-update job'
+        type: boolean
+        default: false
+      app_name:
+        description: 'Override app/image name (single-app mode). Defaults to repository name.'
         type: string
         default: ''
-      enable_docker:
-        description: 'Enable Docker image build and push'
-        type: boolean
-        default: false
-      docker_registry:
-        description: 'Docker registry URL'
+      docker_build_args:
+        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi"). Use BuildKit secrets for sensitive values.'
         type: string
-        default: 'ghcr.io'
-      docker_platforms:
-        description: 'Docker platforms to build for (comma-separated)'
-        type: string
-        default: 'linux/amd64,linux/arm64'
-      docker_tags:
-        description: 'Docker image tags configuration'
-        type: string
-        default: |
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-          type=raw,value=latest,enable={{is_default_branch}}
-      enable_notifications:
-        description: 'Enable release notifications'
-        type: boolean
-        default: false
+        default: ''
       enable_cosign_sign:
-        description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
+        description: 'Sign container images with cosign keyless (OIDC) signing after push'
         type: boolean
         default: true
 
+      # ----------------- GitOps Update (gitops-update.yml) -----------------
+      enable_gitops_update:
+        description: 'Run the gitops-update job on tag push'
+        type: boolean
+        default: true
+      gitops_repository:
+        description: 'GitOps repository to update (org/repo format)'
+        type: string
+        default: 'LerianStudio/midaz-firmino-gitops'
+      gitops_artifact_pattern:
+        description: 'Pattern to download GitOps artifacts (defaults to "gitops-tags-<repo-name>*")'
+        type: string
+        default: ''
+      gitops_yaml_key_mappings:
+        description: 'JSON object mapping artifact names to YAML keys (e.g., {"app.tag": ".api.image.tag"})'
+        type: string
+        default: ''
+
+      # ----------------- Shared -----------------
+      shared_paths:
+        description: 'Newline-separated path patterns that trigger a release/build for all components.'
+        type: string
+        default: ''
+      filter_paths:
+        description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
+        type: string
+        default: ''
+    secrets:
+      MANAGE_TOKEN:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
+      HELM_REPO_TOKEN:
+        required: false
+
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
-  release:
-    name: Create Release
-    runs-on: ${{ inputs.runner_type }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Fetch all tags
-        run: git fetch --force --tags
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: ${{ inputs.go_version }}
-          cache: true
-
-      - name: Run tests
-        if: inputs.run_tests_before_release
-        run: ${{ inputs.test_cmd }}
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
-        with:
-          distribution: ${{ inputs.goreleaser_distribution }}
-          version: ${{ inputs.goreleaser_version }}
-          args: ${{ inputs.goreleaser_args }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.MANAGE_TOKEN || secrets.GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-
-  homebrew:
-    name: Update Homebrew Formula
-    runs-on: ${{ inputs.runner_type }}
-    needs: release
-    if: inputs.enable_homebrew && startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - name: Validate Homebrew configuration
-        run: |
-          if [ -z "${{ inputs.homebrew_tap_repo }}" ]; then
-            echo "Error: homebrew_tap_repo is required when enable_homebrew is true"
-            exit 1
-          fi
-
-      - name: Checkout homebrew-tap
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: ${{ inputs.homebrew_tap_repo }}
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
-          path: homebrew-tap
-        continue-on-error: true
-
-      - name: Update formula
-        if: success()
-        run: |
-          cd homebrew-tap || exit 1
-          # Formula will be auto-generated by GoReleaser
-          echo "Homebrew formula updated"
-        continue-on-error: true
-
-  docker:
-    name: Build and Push Docker Image
+  # ----------------- Change Detection (release gate, branch push only) -----------------
+  changes:
+    name: Detect non-doc changes
+    if: github.ref_type == 'branch'
     runs-on: ${{ inputs.runner_type }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-    needs: release
-    if: inputs.enable_docker && startsWith(github.ref, 'refs/tags/v')
-
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
-      - name: Log in to Docker Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - name: Non-doc change gate
+        id: gate
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
         with:
-          registry: ${{ inputs.docker_registry }}
-          username: ${{ secrets.DOCKER_USERNAME || github.actor }}
-          password: ${{ secrets.DOCKERHUB_IMAGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
+          ignore-globs: ${{ inputs.ignore_globs }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
-        with:
-          images: ${{ inputs.docker_registry }}/${{ github.repository }}
-          tags: ${{ inputs.docker_tags }}
-
-      - name: Build and push
-        id: build-push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          platforms: ${{ inputs.docker_platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # ----------------- Cosign Image Signing -----------------
-      - name: Build cosign image references
-        if: inputs.enable_cosign_sign
-        id: cosign-refs
-        env:
-          DIGEST: ${{ steps.build-push.outputs.digest }}
-          DOCKER_REGISTRY: ${{ inputs.docker_registry }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          REPO=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
-          echo "refs=${DOCKER_REGISTRY}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
-
-      - name: Sign container images with cosign
-        if: inputs.enable_cosign_sign
-        uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
-        with:
-          image-refs: ${{ steps.cosign-refs.outputs.refs }}
-
-  # Slack notification
-  notify:
-    name: Notify
-    needs: [release, homebrew, docker]
-    if: always()
-    uses: ./.github/workflows/slack-notify.yml
+  # ----------------- Release (branch push) -----------------
+  release:
+    needs: changes
+    if: github.ref_type == 'branch' && needs.changes.outputs.code == 'true'
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: read
+    uses: ./.github/workflows/release.yml
     with:
-      status: ${{ (needs.release.result == 'failure' || needs.homebrew.result == 'failure' || needs.docker.result == 'failure') && 'failure' || 'success' }}
-      workflow_name: "Go Release"
-      failed_jobs: ${{ needs.release.result == 'failure' && 'Release, ' || '' }}${{ needs.homebrew.result == 'failure' && 'Homebrew, ' || '' }}${{ needs.docker.result == 'failure' && 'Docker' || '' }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      runner_type: ${{ inputs.runner_type }}
+      semantic_version: ${{ inputs.semantic_version }}
+      enable_changelog: ${{ inputs.enable_changelog }}
+      enable_major_tag: ${{ inputs.enable_major_tag }}
+      stable_releases_only: ${{ inputs.stable_releases_only }}
+      shared_paths: ${{ inputs.shared_paths }}
+      filter_paths: ${{ inputs.filter_paths }}
+    secrets: inherit
+
+  # ----------------- Build (tag push) -----------------
+  build:
+    if: github.ref_type == 'tag'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: write
+    uses: ./.github/workflows/build.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      enable_dockerhub: ${{ inputs.enable_dockerhub }}
+      enable_ghcr: ${{ inputs.enable_ghcr }}
+      enable_gitops_artifacts: ${{ inputs.enable_gitops_artifacts }}
+      app_name: ${{ inputs.app_name }}
+      docker_build_args: ${{ inputs.docker_build_args }}
+      enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      shared_paths: ${{ inputs.shared_paths }}
+      filter_paths: ${{ inputs.filter_paths }}
+    secrets: inherit
+
+  # ----------------- GitOps Update (tag push) -----------------
+  update_gitops:
+    needs: [build]
+    if: github.ref_type == 'tag' && inputs.enable_gitops_update && needs.build.result == 'success' && needs.build.outputs.has_builds == 'true'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: write
+    uses: ./.github/workflows/gitops-update.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      gitops_repository: ${{ inputs.gitops_repository }}
+      artifact_pattern: ${{ inputs.gitops_artifact_pattern }}
+      yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
+    secrets: inherit

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: Non-doc change gate
         id: gate
-        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@feat/go-validation-release-umbrellas
         with:
           github-token: ${{ github.token }}
           ignore-globs: ${{ inputs.ignore_globs }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: Non-doc change gate
         id: gate
-        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@feat/go-validation-release-umbrellas
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
         with:
           github-token: ${{ github.token }}
           ignore-globs: ${{ inputs.ignore_globs }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ Use a scope to identify the affected workflow or area:
 | `go-security` | Go Security workflow |
 | `go-release` | Go Release workflow |
 | `go-pr-analysis` | Go PR Analysis workflow |
+| `go-pr-validation` | Go PR Validation umbrella workflow |
 | `gitops` | GitOps Update workflow |
 | `e2e` | API Dog E2E Tests workflow |
 | `pr-validation` | PR Validation workflow |

--- a/docs/go-ci-workflow.md
+++ b/docs/go-ci-workflow.md
@@ -160,7 +160,7 @@ jobs:
 ## Related Workflows
 
 - [Go Security](./go-security-workflow.md) - Comprehensive security scanning
-- [Go Release](./go-release-workflow.md) - Automated release creation
+- [Go Release](./go-release-workflow.md) - Service release umbrella (semantic-release + Docker + GitOps)
 
 ---
 

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -1,0 +1,101 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>go-pr-validation</h1></td>
+  </tr>
+</table>
+
+Umbrella reusable workflow for Go service repositories. A caller references this single workflow and it orchestrates everything a Go service PR needs:
+
+1. **PR metadata** — title, source branch, size, labels (delegates to `pr-validation.yml`).
+2. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
+3. **Go analysis** — lint, tests, coverage and build (delegates to `go-pr-analysis.yml`), opt-in via `run_go_analysis`.
+4. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
+
+The `go-analysis` and `security` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`) for branch protection, regardless of the internal matrix job names.
+
+## Inputs
+
+| Input | Description | Type | Default |
+|-------|-------------|------|---------|
+| `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
+| `run_security` | Run the security scan pipeline | boolean | `true` |
+| `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
+| `pr_title_types` | Allowed commit types (pipe-separated) | string | conventional set |
+| `pr_title_scopes` | Allowed scopes (pipe-separated, empty = any) | string | `''` |
+| `require_scope` | Require scope in PR title | boolean | `false` |
+| `enable_auto_labeler` | Auto-label by changed files | boolean | `true` |
+| `labeler_config_path` | Path to labeler config | string | `.github/labeler.yml` |
+| `enforce_source_branches` | Enforce source branches into protected branches | boolean | `true` |
+| `allowed_source_branches` | Allowed source branches (pipe-separated, `*` prefix) | string | `develop\|release-candidate\|hotfix/*` |
+| `target_branches_for_source_check` | Target branches requiring source validation | string | `main` |
+| `go_version` | Go version | string | `1.23` |
+| `golangci_lint_version` | GolangCI-Lint version | string | `v1.62.2` |
+| `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
+| `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
+| `go_private_modules` | GOPRIVATE pattern for private modules | string | `''` |
+| `enable_integration_tests` | Enable integration tests | boolean | `false` |
+| `system_packages` | apt packages to install for CGO repos | string | `''` |
+| `ignore_file` | Path to Trivy ignore file | string | `''` |
+| `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
+| `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
+| `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
+
+## Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `MANAGE_TOKEN` | Token for private Go module access and PR operations | No |
+| `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+
+## Usage
+
+```yaml
+name: PR Validation
+on:
+  pull_request:
+    branches: [develop, release-candidate, main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  validate:
+    # Testing: @develop or @feat/<branch> · Production: pinned @vX.Y.Z
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@v1
+    with:
+      go_version: "1.26.4"
+      golangci_lint_version: "v2.12.2"
+      coverage_threshold: 79
+      fail_on_coverage_threshold: true
+      go_private_modules: "github.com/LerianStudio/*"
+      ignore_file: ".trivyignore.yaml"
+      shared_paths: |
+        go.mod
+        go.sum
+        internal/
+        pkg/
+        migrations/
+        Dockerfile
+        Makefile
+    secrets: inherit
+```
+
+## Branch protection
+
+Require the aggregator checks `Go Analysis` and `Security` (plus the PR metadata checks from `pr-validation.yml`). These names are stable even when the underlying analysis matrix changes.
+
+## Related
+
+- [go-pr-analysis](./go-pr-analysis-workflow.md) — the Go analysis pipeline this umbrella calls
+- [pr-security-scan](./pr-security-scan-workflow.md) — the security pipeline this umbrella calls
+- [pr-validation](./pr-validation.md) — the PR metadata validation this umbrella calls
+- [go-release](./go-release-workflow.md) — the matching service release umbrella

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -11,8 +11,9 @@ Umbrella reusable workflow for Go service repositories. A caller references this
 2. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
 3. **Go analysis** — lint, tests, coverage and build (delegates to `go-pr-analysis.yml`), opt-in via `run_go_analysis`.
 4. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
+5. **Lerian lib version check** — fails when a direct Lerian library is behind its latest stable release (delegates to `lerian-lib-version-check.yml`), opt-in via `run_lib_version_check`.
 
-The `go-analysis` and `security` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`) for branch protection, regardless of the internal matrix job names.
+The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success).
 
 ## Inputs
 
@@ -22,7 +23,11 @@ The `go-analysis` and `security` pipelines each have a `*-gate` aggregator job t
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
+| `run_lib_version_check` | Run the Lerian library version check | boolean | `true` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
+| `lib_version_go_mod_path` | Path to go.mod for the Lerian lib check | string | `go.mod` |
+| `lib_version_check_indirect` | Also check transitive (indirect) Lerian deps | boolean | `false` |
+| `lib_version_comment_on_pr` | Post/update a sticky PR comment with the lib version table | boolean | `true` |
 | `pr_title_types` | Allowed commit types (pipe-separated) | string | conventional set |
 | `pr_title_scopes` | Allowed scopes (pipe-separated, empty = any) | string | `''` |
 | `require_scope` | Require scope in PR title | boolean | `false` |
@@ -49,6 +54,7 @@ The `go-analysis` and `security` pipelines each have a `*-gate` aggregator job t
 |--------|-------------|----------|
 | `MANAGE_TOKEN` | Token for private Go module access and PR operations | No |
 | `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+| `LERIAN_LIB_READ_TOKEN` | Read token for private Lerian libs in the lib version check (falls back to `GITHUB_TOKEN`) | No |
 
 ## Usage
 
@@ -91,7 +97,7 @@ jobs:
 
 ## Branch protection
 
-Require the aggregator checks `Go Analysis` and `Security` (plus the PR metadata checks from `pr-validation.yml`). These names are stable even when the underlying analysis matrix changes.
+Require the aggregator checks `Go Analysis`, `Security` and `Lib Version` (plus the PR metadata checks from `pr-validation.yml`). These names are stable even when the underlying analysis matrix changes.
 
 ## Related
 

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -1,239 +1,97 @@
-# Go Release Workflow
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>go-release</h1></td>
+  </tr>
+</table>
 
-Automated release creation workflow using GoReleaser. Builds multi-platform binaries, creates GitHub releases with changelogs, and optionally publishes Docker images and updates Homebrew formulas.
+Umbrella reusable workflow for Go **service** repositories (deployable apps that ship as container images). A caller references this single workflow and it drives the full release pipeline, branching on the pushed ref:
 
-## Features
+- **Branch push** → change gate (`src/config/non-doc-changes`) → semantic release (`release.yml`). Documentation-only pushes skip the release.
+- **Tag push** → container build & push (`build.yml`) → GitOps update (`gitops-update.yml`), gated on the build actually producing images.
 
-- GoReleaser integration (supports both OSS and Pro)
-- Multi-platform binary builds (Linux, macOS, Windows, ARM)
-- GitHub release creation with changelogs
-- Optional Docker multi-arch image builds
-- Optional Homebrew formula updates
-- Configurable test execution before release
-- Release notifications
-- Support for custom GoReleaser configurations
-
-## Usage
-
-### Basic Usage
-
-```yaml
-name: Release
-on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-```
-
-### With Docker Publishing
-
-```yaml
-name: Release
-on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-    with:
-      enable_docker: true
-      docker_registry: 'ghcr.io'
-      docker_platforms: 'linux/amd64,linux/arm64'
-    secrets: inherit
-```
-
-> **Note**: Requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets in repository.
-
-### With Homebrew Formula
-
-```yaml
-name: Release
-on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-    with:
-      enable_homebrew: true
-      homebrew_tap_repo: 'myorg/homebrew-tap'
-    secrets: inherit
-```
-
-> **Note**: Requires `TAP_GITHUB_TOKEN` secret with write access to tap repository.
-
-### Full Configuration
-
-```yaml
-name: Release
-on:
-  push:
-    tags:
-      - 'v*.*.*'
-
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-    with:
-      go_version: '1.23'
-      goreleaser_distribution: 'goreleaser'
-      goreleaser_version: 'latest'
-      run_tests_before_release: true
-      enable_docker: true
-      docker_registry: 'ghcr.io'
-      docker_platforms: 'linux/amd64,linux/arm64,linux/arm/v7'
-      enable_homebrew: true
-      homebrew_tap_repo: 'myorg/homebrew-tap'
-      enable_notifications: true
-    secrets: inherit
-```
+> **Note** — As of v1.x this workflow hosts the service release pipeline (semantic-release + Docker build + GitOps). The previous GoReleaser-based binary release pipeline remains available in the Git history of this file.
 
 ## Inputs
 
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `runner_type` | GitHub runner type to use | No | `ubuntu-latest` |
-| `go_version` | Go version for release builds | No | `1.23` |
-| `goreleaser_distribution` | GoReleaser distribution (goreleaser or goreleaser-pro) | No | `goreleaser` |
-| `goreleaser_version` | GoReleaser version | No | `latest` |
-| `goreleaser_args` | Additional GoReleaser arguments | No | `release --clean` |
-| `run_tests_before_release` | Run tests before release | No | `true` |
-| `test_cmd` | Test command to execute | No | `go test -v ./...` |
-| `enable_homebrew` | Enable Homebrew formula update | No | `false` |
-| `homebrew_tap_repo` | Homebrew tap repository (owner/repo) | No | `''` |
-| `enable_docker` | Enable Docker image build and push | No | `false` |
-| `docker_registry` | Docker registry URL | No | `ghcr.io` |
-| `docker_platforms` | Docker platforms (comma-separated) | No | `linux/amd64,linux/arm64` |
-| `docker_tags` | Docker image tags configuration | No | Semver + latest |
-| `enable_notifications` | Enable release notifications | No | `false` |
-| `enable_cosign_sign` | Sign Docker images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller | No | `true` |
+| Input | Description | Type | Default |
+|-------|-------------|------|---------|
+| `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `dry_run` | Reserved (downstream workflows have no dry-run mode yet) | boolean | `false` |
+| `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
+| `semantic_version` | semantic-release version | string | `23.0.8` |
+| `enable_changelog` | Generate CHANGELOG.md via GPT after a successful release | boolean | `false` |
+| `enable_major_tag` | Force-update the floating major tag (e.g. `v1`) | boolean | `false` |
+| `stable_releases_only` | Only generate changelogs for stable releases | boolean | `true` |
+| `enable_dockerhub` | Push image to DockerHub | boolean | `true` |
+| `enable_ghcr` | Push image to GitHub Container Registry | boolean | `false` |
+| `enable_gitops_artifacts` | Upload GitOps artifacts for the downstream update | boolean | `false` |
+| `app_name` | Override app/image name (single-app mode) | string | `''` (repo name) |
+| `docker_build_args` | Newline-separated Docker build args | string | `''` |
+| `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
+| `enable_gitops_update` | Run the gitops-update job on tag push | boolean | `true` |
+| `gitops_repository` | GitOps repository to update (org/repo) | string | `LerianStudio/midaz-firmino-gitops` |
+| `gitops_artifact_pattern` | Pattern to download GitOps artifacts | string | `''` |
+| `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
+| `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
+| `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 
 ## Secrets
 
 | Secret | Description | Required |
 |--------|-------------|----------|
-| `github_token` | GitHub token for releases | No (defaults to `GITHUB_TOKEN`) |
-| `tap_github_token` | Token for Homebrew tap updates | No (required if `enable_homebrew` is true) |
-| `docker_username` | Docker registry username | No (defaults to `github.actor` if using GHCR) |
-| `docker_password` | Docker registry password/token | No (defaults to `GITHUB_TOKEN` if using GHCR) |
-| `goreleaser_key` | GoReleaser Pro license key | No (only for goreleaser-pro) |
+| `MANAGE_TOKEN` | Token for release commits, tags and private module access | No |
+| `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+| `HELM_REPO_TOKEN` | Token for dispatching Helm chart updates (when enabled in build) | No |
 
-## Jobs
-
-### release
-Main release job that runs GoReleaser.
-
-### homebrew (optional)
-Updates Homebrew formula in tap repository.
-
-### docker (optional)
-Builds and pushes multi-architecture Docker images.
-
-### notify (optional)
-Sends release notifications.
-
-## Example Configurations
-
-### Minimal (GoReleaser OSS)
+## Usage
 
 ```yaml
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-```
+name: Release Pipeline
+on:
+  push:
+    branches: [main, release-candidate, develop]
+    tags: ['**']
 
-### With GoReleaser Pro
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
-```yaml
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-    with:
-      goreleaser_distribution: 'goreleaser-pro'
-    secrets: inherit
-```
-
-> **Note**: Requires `GORELEASER_KEY` secret with your GoReleaser Pro license.
-
-### Skip Tests (Fast Release)
-
-```yaml
-jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
-    with:
-      run_tests_before_release: false
-```
-
-## Image Signing (cosign)
-
-When Docker is enabled, container images are signed by default using [Sigstore cosign](https://github.com/sigstore/cosign) with keyless (OIDC) signing.
-
-### Caller permissions
-
-Callers **must** grant `id-token: write` for signing to work:
-
-```yaml
 permissions:
+  id-token: write
   contents: write
+  issues: write
+  pull-requests: write
   packages: write
-  id-token: write   # required for cosign keyless signing
-```
 
-### Disabling signing
-
-```yaml
 jobs:
-  release:
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1.0.0
+  pipeline:
+    # Testing: @develop or @feat/<branch> · Production: pinned @vX.Y.Z
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1
     with:
-      enable_docker: true
-      enable_cosign_sign: false
+      enable_changelog: ${{ github.ref == 'refs/heads/main' }}
+      enable_ghcr: true
+      enable_gitops_artifacts: true
+      gitops_artifact_pattern: "gitops-tags-my-service"
+      gitops_yaml_key_mappings: '{"my-service.tag": ".api.image.tag"}'
+      shared_paths: |
+        go.mod
+        go.sum
+        internal/
+        pkg/
+        migrations/
+        Dockerfile
+        Makefile
     secrets: inherit
 ```
 
-### Verifying signatures
+## Permissions
 
-```bash
-cosign verify \
-  --certificate-identity-regexp="^https://github\.com/LerianStudio/.+/.github/workflows/.+@refs/(heads|tags)/.+$" \
-  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-  ghcr.io/myorg/my-app@sha256:abc123...
-```
+The single caller job must grant the union of what the internal jobs need: `id-token: write`, `contents: write`, `packages: write`, `pull-requests: write`, `issues: write`.
 
-## Release Process
+## Related
 
-1. Create tag: `git tag v1.0.0 && git push --tags`
-2. Workflow triggers: On tag push matching `v*.*.*`
-3. Tests run: (if enabled) Verify everything works
-4. GoReleaser builds: Creates binaries for all platforms
-5. GitHub release: Created with changelog and downloads
-6. Docker images: (if enabled) Published to registry
-7. Homebrew formula: (if enabled) Updated in tap repo
-8. Notification: (if enabled) Summary of release status
-
-## Tips
-
-1. Test GoReleaser locally: `goreleaser release --snapshot --clean`
-2. Pin workflow version: Use `@v1.0.0` instead of `@v1.0.0`
-3. CHANGELOG: GoReleaser generates from commits and PRs
-4. Draft releases: Use GoReleaser's `draft: true` for manual approval
-5. Custom builds: Configure `.goreleaser.yml` for your needs
-
-## Related Workflows
-
-- [Go CI](./go-ci-workflow.md) - Continuous integration testing
-- [Go Security](./go-security-workflow.md) - Security scanning
-
----
-
-**Last Updated:** 2025-11-22
-**Version:** 1.0.0
+- [release](./release-workflow.md) — semantic-release pipeline this umbrella calls
+- [build](./build-workflow.md) — container build & push this umbrella calls
+- [gitops-update](./gitops-update-workflow.md) — GitOps update this umbrella calls
+- [go-pr-validation](./go-pr-validation.md) — the matching PR validation umbrella

--- a/docs/go-security-workflow.md
+++ b/docs/go-security-workflow.md
@@ -191,7 +191,7 @@ jobs:
 ## Related Workflows
 
 - [Go CI](./go-ci-workflow.md) - Continuous integration testing
-- [Go Release](./go-release-workflow.md) - Automated release creation
+- [Go Release](./go-release-workflow.md) - Service release umbrella (semantic-release + Docker + GitOps)
 
 ---
 

--- a/docs/typescript-release-workflow.md
+++ b/docs/typescript-release-workflow.md
@@ -329,7 +329,7 @@ No version bump, but included in changelog.
 ## Related Workflows
 
 - [Release Workflow](release-workflow.md) - Generic release workflow (Go/other languages)
-- [Go Release](go-release-workflow.md) - Go-specific release with GoReleaser
+- [Go Release](go-release-workflow.md) - Go service release umbrella (semantic-release + Docker + GitOps)
 - [TypeScript CI](typescript-ci-workflow.md) - TypeScript continuous integration
 
 ---

--- a/src/config/non-doc-changes/README.md
+++ b/src/config/non-doc-changes/README.md
@@ -1,0 +1,53 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>non-doc-changes</h1></td>
+  </tr>
+</table>
+
+Detects whether a pull request or push contains changes beyond documentation/meta files. Use it to gate expensive pipelines (analysis, security, release) so documentation-only changes don't trigger a full run.
+
+It auto-detects the event:
+
+- `pull_request` / `pull_request_target` — lists changed files via `gh api repos/{repo}/pulls/{n}/files` (removed files excluded).
+- `push` — diffs `before...after` via `gh api repos/{repo}/compare`. A first push (empty/zero base ref) returns `code=true`.
+
+A changed file "counts" unless it matches one of the `ignore-globs` patterns. If every changed file matches an ignore pattern, `code=false`.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github-token` | GitHub token for gh CLI access (read on contents and pull requests) | Yes | |
+| `ignore-globs` | Space-separated glob patterns treated as documentation/meta | No | `*.md docs/* .github/* LICENSE* .gitignore` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `code` | `true` when at least one changed file is not matched by `ignore-globs`; `false` otherwise |
+
+## Usage as composite step
+
+```yaml
+jobs:
+  changes:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
+    steps:
+      - name: Non-doc change gate
+        id: gate
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        with:
+          github-token: ${{ github.token }}
+          ignore-globs: "*.md docs/* .github/* LICENSE* .gitignore"
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+```

--- a/src/config/non-doc-changes/action.yml
+++ b/src/config/non-doc-changes/action.yml
@@ -1,0 +1,73 @@
+name: Non-Doc Changes Gate
+description: Detects whether a pull request or push contains changes beyond documentation/meta files, for gating expensive CI pipelines.
+
+inputs:
+  github-token:
+    description: GitHub token used for gh CLI access (needs read access to the repository contents and pull requests).
+    required: true
+  ignore-globs:
+    description: 'Space-separated glob patterns treated as documentation/meta. When every changed file matches one of these, the gate returns code=false.'
+    required: false
+    default: '*.md docs/* .github/* LICENSE* .gitignore'
+
+outputs:
+  code:
+    description: 'true when at least one changed file is NOT matched by ignore-globs (a real code change); false otherwise.'
+    value: ${{ steps.detect.outputs.code }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect non-doc changes
+      id: detect
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        IGNORE_GLOBS: ${{ inputs.ignore-globs }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        BEFORE: ${{ github.event.before }}
+        AFTER: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        # ----------------- Collect changed files -----------------
+        if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
+          if ! files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate \
+              --jq '.[] | select(.status != "removed") | .filename'); then
+            echo "::error::Failed to list changed files for PR #${PR_NUMBER}"
+            exit 1
+          fi
+        else
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "First push or missing base ref — assuming a code change."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! files=$(gh api "repos/${REPO}/compare/${BEFORE}...${AFTER}" --jq '.files[].filename'); then
+            echo "::error::Failed to fetch push diff ${BEFORE}...${AFTER}"
+            exit 1
+          fi
+        fi
+
+        # ----------------- Match against ignore globs -----------------
+        read -ra ignore_patterns <<< "$IGNORE_GLOBS"
+        code=false
+        while IFS= read -r file; do
+          [ -z "$file" ] && continue
+          ignored=false
+          for glob in "${ignore_patterns[@]}"; do
+            # shellcheck disable=SC2254
+            case "$file" in
+              $glob) ignored=true; break ;;
+            esac
+          done
+          if [ "$ignored" = false ]; then
+            code=true
+            break
+          fi
+        done <<< "$files"
+
+        echo "Non-doc changes detected: $code"
+        echo "code=$code" >> "$GITHUB_OUTPUT"

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -346,7 +346,7 @@ runs:
         fi
 
     - name: Post sticky PR comment
-      if: ${{ inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ always() && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         REPORT_PATH: ${{ steps.check.outputs.report_path }}

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -193,6 +193,13 @@ runs:
             return 0
           fi
 
+          if [[ "${http_code}" != "200" ]]; then
+            log "::warning title=Cannot read LerianStudio/${repo}::Releases API returned HTTP ${http_code}. Check that LERIAN_LIB_READ_TOKEN has Contents:read and is approved by the org."
+            LATEST_CACHE[${cache_key}]=""
+            echo ""
+            return 0
+          fi
+
           local tags
           tags=$(echo "${releases_json}" | jq -r '.[]? | select(.draft==false) | select(.prerelease==false) | .tag_name' 2>/dev/null || true)
 

--- a/src/validate/result-gate/README.md
+++ b/src/validate/result-gate/README.md
@@ -1,0 +1,45 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>result-gate</h1></td>
+  </tr>
+</table>
+
+Fails the job unless an upstream job `result` is `success` or `skipped`. Used as the final aggregation step over a multi-job reusable pipeline (called with `uses:`), so branch protection can require a single stable check name instead of the pipeline's internal job names.
+
+Pair it with `if: always()` on the gate job so the gate evaluates even when the upstream pipeline failed.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `result` | The `needs.<job>.result` value to evaluate (`success`, `failure`, `cancelled`, `skipped`) | Yes | |
+| `label` | Human-readable name of the gated pipeline, used in log output | No | `pipeline` |
+
+## Usage as composite step
+
+```yaml
+jobs:
+  go-analysis:
+    uses: ./.github/workflows/go-pr-analysis.yml
+    secrets: inherit
+
+  go-analysis-gate:
+    name: Go Analysis
+    needs: [go-analysis]
+    if: always()
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Aggregate Go Analysis result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        with:
+          result: ${{ needs.go-analysis.result }}
+          label: Go Analysis
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/validate/result-gate/action.yml
+++ b/src/validate/result-gate/action.yml
@@ -1,0 +1,27 @@
+name: Result Gate
+description: Fails the job unless an upstream job result is success or skipped. Provides a single stable status-check name for branch protection over a multi-job reusable pipeline.
+
+inputs:
+  result:
+    description: The needs.<job>.result value to evaluate (success, failure, cancelled, skipped).
+    required: true
+  label:
+    description: Human-readable name of the gated pipeline, used in log output.
+    required: false
+    default: pipeline
+
+runs:
+  using: composite
+  steps:
+    - name: Evaluate result
+      shell: bash
+      env:
+        RESULT: ${{ inputs.result }}
+        LABEL: ${{ inputs.label }}
+      run: |
+        if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
+          echo "${LABEL}: ${RESULT}"
+          exit 0
+        fi
+        echo "::error::${LABEL} pipeline result: ${RESULT}"
+        exit 1


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds two **umbrella** reusable workflows so a Go service repository references a single workflow per concern (PR validation, release) instead of wiring multiple reusables + gate/aggregator boilerplate in every caller. Both build on two new shared composites.

**New workflow — `go-pr-validation.yml`** orchestrates, in one place:
- PR metadata validation (delegates to `pr-validation.yml`)
- a non-doc change gate that skips heavy pipelines on docs-only PRs
- the Go analysis pipeline (`go-pr-analysis.yml`), opt-in via `run_go_analysis`
- the security scan pipeline (`pr-security-scan.yml`), opt-in via `run_security`
- stable aggregator checks (`Go Analysis`, `Security`) for branch protection

**Reworked workflow — `go-release.yml`** is repurposed from the GoReleaser binary flow into a **service release umbrella**:
- branch push → non-doc change gate → semantic release (`release.yml`)
- tag push → container build & push (`build.yml`) → GitOps update (`gitops-update.yml`)

**New composites**
- `src/config/non-doc-changes` — reports whether a PR/push touches anything beyond docs/meta (auto-detects PR vs push); replaces shell duplicated across callers.
- `src/validate/result-gate` — exposes a single stable status check over a multi-job reusable pipeline.

Docs (`docs/go-pr-validation.md`, `docs/go-release-workflow.md`, cross-links), `.github/labeler.yml` and `CONTRIBUTING.md` updated accordingly.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

`go-release.yml` was repurposed from the GoReleaser binary-release flow to the service-release umbrella. Consumers are **pinned by tag** (`@v1.x.x`), so existing callers are frozen on the prior content and are **not affected at runtime**; the GoReleaser flow remains recoverable in git history. No input contract is broken for the service-release use case. New behavior in `go-pr-validation.yml` is opt-in (`run_go_analysis` / `run_security` default-gated by change detection). Released additively on v1.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validated locally with `actionlint` (workflows), `yamllint`, and `shellcheck` (composite shell) — all clean. Caller-repo validation (go-boilerplate-ddd) will follow in a separate PR once a tag is published.

**Caller repo / workflow run:** _pending — separate go-boilerplate-ddd PR after release_

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable Go PR validation and Go release umbrella workflows with configurable toggles, non-doc change gating, and aggregated pipeline result gates; added a guarded library-version check and composite actions for change detection and result gating.

* **Documentation**
  * Added/updated docs for Go PR validation, Go release umbrella, security workflow, non-doc change gate, and contributing scopes.

* **Chores**
  * Updated CI labeler rules and workflow interfaces/permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->