### PR TITLE
feat(validate): add lerian-lib-version-check reusable workflow and composite action

### DIFF
--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -1,0 +1,87 @@
+name: "Lerian Library Version Check"
+
+# Reusable workflow that enforces up-to-date LerianStudio Go libraries on PRs.
+#
+# Fails when:
+#   - the service has zero LerianStudio direct deps in go.mod (company-standards violation), or
+#   - one or more direct LerianStudio deps are behind the latest stable release (no entry in .lerianstudiolibignore).
+#
+# A missing .lerianstudiolibignore file produces a warning, not a failure.
+# Posts a sticky PR comment with the result table.
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'GitHub runner type to use'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      go_mod_path:
+        description: 'Path to go.mod relative to the repo root'
+        type: string
+        default: 'go.mod'
+      ignore_file:
+        description: 'Path to optional .lerianstudiolibignore file. Missing file is a warning, not a failure.'
+        type: string
+        default: '.lerianstudiolibignore'
+      check_indirect:
+        description: 'Also check transitive (// indirect) deps'
+        type: boolean
+        default: false
+      comment_on_pr:
+        description: 'Post / update a sticky comment on the PR with the result table'
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Verbose log of all resolved versions; never fails the build'
+        type: boolean
+        default: false
+
+    secrets:
+      LERIAN_LIB_READ_TOKEN:
+        description: |
+          Optional org-scoped PAT (or GitHub App token) with read access to private LerianStudio
+          repositories. Required only when go.mod depends on internal/private Lerian libs such as
+          `lib-license-go`. When unset, the default GITHUB_TOKEN is used and private libs will be
+          reported as "unknown".
+        required: false
+
+    outputs:
+      has_outdated:
+        description: 'true if at least one direct Lerian lib is behind latest stable'
+        value: ${{ jobs.check.outputs.has_outdated }}
+      outdated_count:
+        description: 'Number of outdated direct Lerian libs'
+        value: ${{ jobs.check.outputs.outdated_count }}
+      has_lerian_libs:
+        description: 'true if at least one Lerian lib was detected in go.mod'
+        value: ${{ jobs.check.outputs.has_lerian_libs }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Lerian Library Version Check
+    runs-on: ${{ inputs.runner_type }}
+    outputs:
+      has_outdated: ${{ steps.check.outputs.has_outdated }}
+      outdated_count: ${{ steps.check.outputs.outdated_count }}
+      has_lerian_libs: ${{ steps.check.outputs.has_lerian_libs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Validate Lerian library versions
+        id: check
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@develop
+        with:
+          github-token: ${{ secrets.LERIAN_LIB_READ_TOKEN || github.token }}
+          go-mod-path: ${{ inputs.go_mod_path }}
+          ignore-file: ${{ inputs.ignore_file }}
+          check-indirect: ${{ inputs.check_indirect && 'true' || 'false' }}
+          comment-on-pr: ${{ inputs.comment_on_pr && 'true' || 'false' }}
+          dry-run: ${{ inputs.dry_run && 'true' || 'false' }}

--- a/docs/lerian-lib-version-check.md
+++ b/docs/lerian-lib-version-check.md
@@ -1,0 +1,195 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>lerian-lib-version-check</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that enforces up-to-date LerianStudio Go libraries in every consumer service. It is intended to run on pull requests as a blocking check, alongside the standard PR analysis pipeline.
+
+## Why
+
+LerianStudio libraries (`lib-commons`, `lib-auth`, `lib-license-go`, …) evolve quickly. Apps that fall behind drift from organisation standards, miss bug fixes and security patches, and force reviewers to manually check dependency freshness on every PR. A Go service with **no** Lerian dependencies at all is, by definition, off-standard.
+
+This workflow turns those expectations into a CI gate.
+
+## Features
+
+- **Strict latest-stable enforcement** — every direct Lerian dep must be on the latest stable GitHub release.
+- **Standards gate** — services with no Lerian libs in `go.mod` fail the check.
+- **Sticky PR comment** — a single comment is created and updated in place with a status table.
+- **`.lerianstudiolibignore`** — gitignore-style exemption file for temporary skips or version pins.
+- **Soft missing-file behaviour** — a missing ignore file produces a warning, not a failure.
+- **Dry-run mode** — verbose log of all resolved versions, never fails.
+- **Pre-release skipping** — `-beta`, `-rc`, and draft releases are ignored when picking the latest stable.
+
+## Architecture
+
+```
+lerian-lib-version-check.yml (reusable workflow)
+   ↓
+src/validate/lerian-lib-version (composite action)
+   ↓
+   1. Parse go.mod for github.com/LerianStudio/* direct deps
+   2. Load .lerianstudiolibignore (if present)
+   3. For each lib: GET /repos/LerianStudio/<repo>/releases (paged, stable only)
+   4. Compare current vs latest using semver (sort -V)
+   5. Build markdown report, write step summary
+   6. Upsert sticky PR comment (via actions/github-script)
+   7. Exit non-zero if outdated or no Lerian libs detected
+```
+
+## Usage
+
+### Basic
+
+```yaml
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lerian-lib-version-check:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
+```
+
+### Custom configuration
+
+```yaml
+jobs:
+  lerian-lib-version-check:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
+    with:
+      go_mod_path: services/api/go.mod
+      ignore_file: .config/.lerianstudiolibignore
+      check_indirect: false
+      comment_on_pr: true
+      dry_run: false
+```
+
+### Gating downstream jobs
+
+```yaml
+jobs:
+  lerian-lib-version-check:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
+
+  deploy:
+    needs: lerian-lib-version-check
+    if: needs.lerian-lib-version-check.outputs.has_outdated == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All Lerian deps are current — safe to deploy."
+```
+
+## Inputs
+
+| Name             | Type    | Default                     | Description                                                                                  |
+|------------------|---------|-----------------------------|----------------------------------------------------------------------------------------------|
+| `runner_type`    | string  | `blacksmith-4vcpu-ubuntu-2404` | Runner label                                                                              |
+| `go_mod_path`    | string  | `go.mod`                    | Path to `go.mod` relative to the repo root                                                   |
+| `ignore_file`    | string  | `.lerianstudiolibignore`    | Path to the optional ignore file. Missing file produces a warning, not a failure.            |
+| `check_indirect` | boolean | `false`                     | Also check transitive (`// indirect`) deps                                                   |
+| `comment_on_pr`  | boolean | `true`                      | Post / update a sticky comment on the PR with the result table                               |
+| `dry_run`        | boolean | `false`                     | Verbose log of all resolved versions; never fails the build                                  |
+
+## Secrets
+
+| Name                    | Required | Description                                                                                                                                                                       |
+|-------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LERIAN_LIB_READ_TOKEN` | No       | Org-scoped PAT or GitHub App token with read access to **private** LerianStudio repositories (e.g. `lib-license-go`). When unset, private libs are reported as `unknown` (warning, non-fatal). |
+
+### Private libraries
+
+Some Lerian libraries are internal repositories (e.g. `lib-license-go`). The default `GITHUB_TOKEN` from a consumer repo cannot read their releases — GitHub returns 404 for private repos the token has no access to. To enforce up-to-date checks on these libraries, pass an org-scoped read token via `secrets: inherit` or by mapping the secret explicitly:
+
+```yaml
+jobs:
+  lerian-lib-version-check:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
+    secrets:
+      LERIAN_LIB_READ_TOKEN: ${{ secrets.LERIAN_ORG_READ_TOKEN }}
+```
+
+Without the secret, the workflow still runs and enforces freshness on all **public** Lerian libs; private libs are marked `unknown` with a warning in the step summary.
+
+## Outputs
+
+| Name              | Description                                                          |
+|-------------------|----------------------------------------------------------------------|
+| `has_outdated`    | `true` if at least one direct Lerian lib is behind latest stable     |
+| `outdated_count`  | Number of outdated direct Lerian libs                                |
+| `has_lerian_libs` | `true` if at least one Lerian lib was detected in `go.mod`           |
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write   # to post / update the sticky comment
+```
+
+## Failure modes
+
+| Condition                                                | Behavior                                            |
+|----------------------------------------------------------|-----------------------------------------------------|
+| App has no Lerian libs in `go.mod`                       | Fail — violates company standards                   |
+| One or more direct Lerian libs are outdated              | Fail — bump or add to ignore file                   |
+| `.lerianstudiolibignore` does not exist                  | Warning in log, proceed normally                    |
+| Lib matched by ignore-skip rule                          | Skipped, marked _skipped_ in the report             |
+| Lib matched by ignore-pin rule (`lib@vX.Y.Z`)            | Compared against the pin, marked _pinned_           |
+| GitHub API cannot resolve latest release                 | Warning in log, marked _unknown_, does not fail     |
+| `dry_run: true`                                          | Verbose report, never fails                         |
+
+## `.lerianstudiolibignore` format
+
+Gitignore-style, one rule per line. Lines starting with `#` are comments. Use the short module path (strip `github.com/LerianStudio/`).
+
+```
+# Skip a lib entirely (no version check)
+lib-auth/v2
+
+# Pin to a specific version — only fail if behind THIS version, not latest
+lib-commons/v5@v5.3.0
+
+# Unversioned module (v0/v1)
+lib-foo
+```
+
+## Sticky PR comment
+
+The action posts (and updates) a single comment marked with `<!-- lerian-lib-version-check -->`. Re-runs update the same comment in place — no duplicate threads accumulate across pushes.
+
+Example:
+
+```
+## Lerian Library Version Check
+
+| Library              | Current | Latest | Status      |
+|----------------------|---------|--------|-------------|
+| `lib-commons/v5`     | `v5.1.0`| `v5.5.0`| Outdated   |
+| `lib-auth/v2`        | `v2.7.0`| `v2.8.0`| Outdated   |
+| `lib-license-go/v2`  | `v2.3.5`| `v2.3.5`| Current    |
+| `lib-foo/v1`         | `v1.0.0`| _skipped_ | Skipped (ignore file) |
+
+**2 outdated** | **1 current** | **1 skipped** | **0 unknown**
+
+> Bump the outdated libraries, or add temporary entries to `.lerianstudiolibignore`.
+```
+
+## Limitations
+
+- **Go only.** TypeScript (`package.json`) and Helm (`Chart.yaml`) support is out of scope for the initial release.
+- **Module-path → repo-name** mapping assumes the repo name equals the last non-`/vN` path segment. Modules whose repo name differs from the module path are not currently supported.
+- **Public repos only.** The workflow uses the default `GITHUB_TOKEN`; all `LerianStudio/*` repos that produce stable tagged releases work out of the box.
+
+## Related
+
+- Issue [#408](https://github.com/LerianStudio/github-actions-shared-workflows/issues/408) — original problem statement.

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -1,0 +1,110 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>lerian-lib-version</h1></td>
+  </tr>
+</table>
+
+Validates that a Go service uses up-to-date LerianStudio libraries.
+
+The action parses `go.mod`, fetches the latest **stable** GitHub release for every direct `github.com/LerianStudio/*` dependency, compares versions, and fails when:
+
+- any direct Lerian library is behind its latest stable release, **or**
+- the service has **no** Lerian libraries at all (company-standards violation).
+
+A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` file at the repo root allows temporary skips or version pins.
+
+## Inputs
+
+| Input             | Description                                                                                     | Required | Default                    |
+|-------------------|-------------------------------------------------------------------------------------------------|----------|----------------------------|
+| `github-token`    | GitHub token used to read LerianStudio releases and post the PR comment. Use an org-scoped PAT to also read private Lerian repos (e.g. `lib-license-go`). | Yes      |                            |
+| `go-mod-path`     | Path to `go.mod` relative to the repo root.                                                     | No       | `go.mod`                   |
+| `ignore-file`     | Path to optional `.lerianstudiolibignore` file. Missing file is a warning, not a failure.       | No       | `.lerianstudiolibignore`   |
+| `check-indirect`  | Also check transitive (`// indirect`) deps.                                                     | No       | `false`                    |
+| `comment-on-pr`   | Post or update a sticky comment on the PR with the result table.                                | No       | `true`                     |
+| `dry-run`         | Verbose log of all resolved versions; never fails the build.                                    | No       | `false`                    |
+
+## Outputs
+
+| Output             | Description                                                                       |
+|--------------------|-----------------------------------------------------------------------------------|
+| `has_outdated`     | `true` if at least one direct Lerian lib is behind latest stable.                 |
+| `outdated_count`   | Number of outdated direct Lerian libs.                                            |
+| `has_lerian_libs`  | `true` if at least one Lerian lib was detected in `go.mod`.                       |
+| `report_path`      | Filesystem path to the generated markdown report (for downstream use).            |
+
+## Behavior matrix
+
+| Condition                                                | Result                                                    |
+|----------------------------------------------------------|-----------------------------------------------------------|
+| `go.mod` not found at `go-mod-path`                      | **Fail** with `::error`                                   |
+| No `github.com/LerianStudio/*` deps in `go.mod`          | **Fail** — service must use at least one Lerian library    |
+| One or more direct Lerian libs are outdated              | **Fail** unless `dry-run: true`                            |
+| `.lerianstudiolibignore` does not exist                  | `::warning` — proceed normally                             |
+| A lib is matched by an ignore-skip rule                  | Skipped, marked _skipped_ in the report                    |
+| A lib is matched by an ignore-pin rule (`lib@vX.Y.Z`)    | Compared against the pin instead of latest, marked _pinned_ |
+| Latest stable release cannot be resolved (API error)     | `::warning` — marked _unknown_, does not fail              |
+
+## `.lerianstudiolibignore` format
+
+Gitignore-style, one rule per line. Lines starting with `#` are comments.
+
+```
+# Skip the lib entirely (no version check at all)
+lib-auth/v2
+
+# Pin to a specific version — only fail if behind THIS version, not latest
+lib-commons/v5@v5.3.0
+
+# Skip an unversioned module path (v0/v1 modules)
+lib-foo
+```
+
+Use the **short module path** (strip `github.com/LerianStudio/`).
+
+## Usage as composite step
+
+```yaml
+jobs:
+  lerian-lib-check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check Lerian library versions
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@v1.x.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Usage as reusable workflow
+
+Prefer the reusable workflow for a one-line integration:
+
+```yaml
+jobs:
+  lerian-lib-check:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
+    permissions:
+      contents: read
+      pull-requests: write
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write   # to post / update the sticky comment
+```
+
+## Implementation notes
+
+- The action uses pure Bash + `actions/github-script` — no extra runtime is required on the runner.
+- Repo names are derived from the module path by stripping `github.com/LerianStudio/` and any trailing `/vN` major-version suffix.
+- Latest stable resolution paginates up to 100 releases and excludes drafts and pre-releases (`-beta`, `-rc`).
+- Latest-release lookups are cached per repo within a single run to minimise API calls.
+- Repo-name resolution assumes one repo per module. Modules whose repo name differs from the path segment are not currently supported.

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -1,0 +1,372 @@
+name: Validate LerianStudio Library Versions
+description: |
+  Parses go.mod for github.com/LerianStudio/* direct dependencies, compares each
+  against the latest stable release on GitHub, and fails when any are outdated or
+  when no Lerian libs are detected (company-standards violation). Honors an
+  optional .lerianstudiolibignore file (gitignore-style) for temporary pins or
+  full skips. Posts a sticky PR comment with a status table.
+
+inputs:
+  github-token:
+    description: GitHub token used to query LerianStudio repo releases and post the PR comment.
+    required: true
+  go-mod-path:
+    description: Path to go.mod (relative to repo root).
+    required: false
+    default: "go.mod"
+  ignore-file:
+    description: Path to optional .lerianstudiolibignore file (relative to repo root). Missing file is a warning, not a failure.
+    required: false
+    default: ".lerianstudiolibignore"
+  check-indirect:
+    description: Also check transitive (// indirect) dependencies. Off by default.
+    required: false
+    default: "false"
+  comment-on-pr:
+    description: Post or update a sticky comment on the PR with the result table.
+    required: false
+    default: "true"
+  dry-run:
+    description: Verbose log of all resolved versions; never fails the build.
+    required: false
+    default: "false"
+
+outputs:
+  has_outdated:
+    description: "true if at least one direct Lerian lib is behind the latest stable release."
+    value: ${{ steps.check.outputs.has_outdated }}
+  outdated_count:
+    description: Number of outdated direct Lerian libs.
+    value: ${{ steps.check.outputs.outdated_count }}
+  has_lerian_libs:
+    description: "true if at least one Lerian lib was detected in go.mod."
+    value: ${{ steps.check.outputs.has_lerian_libs }}
+  report_path:
+    description: Filesystem path to the generated markdown report (for downstream use).
+    value: ${{ steps.check.outputs.report_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Verify go.mod exists
+      shell: bash
+      env:
+        GO_MOD_PATH: ${{ inputs.go-mod-path }}
+      run: |
+        if [[ ! -f "${GO_MOD_PATH}" ]]; then
+          echo "::error title=go.mod not found::Expected go.mod at '${GO_MOD_PATH}'. This composite only supports Go projects."
+          exit 1
+        fi
+
+    - name: Parse Lerian dependencies, resolve latest releases, compare
+      id: check
+      shell: bash
+      env:
+        GO_MOD_PATH: ${{ inputs.go-mod-path }}
+        IGNORE_FILE: ${{ inputs.ignore-file }}
+        CHECK_INDIRECT: ${{ inputs.check-indirect }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        REPORT_PATH="${RUNNER_TEMP:-/tmp}/lerian-lib-report.md"
+        : > "${REPORT_PATH}"
+
+        log() { echo "$@"; }
+        debug() { if [[ "${DRY_RUN}" == "true" ]]; then echo "::debug::$*"; fi; }
+
+        # ---------- 1. Parse go.mod ----------
+        # Collect lines like:
+        #   github.com/LerianStudio/lib-commons/v5 v5.1.0
+        #   github.com/LerianStudio/lib-commons/v2 v2.9.1 // indirect
+        # awk strips the leading 'require (' block markers and trailing comments.
+        log "Parsing ${GO_MOD_PATH} for LerianStudio dependencies..."
+        DEPS_RAW=$(awk '
+          /^require[[:space:]]*\(/ { in_block=1; next }
+          in_block && /^\)/        { in_block=0; next }
+          {
+            line=$0
+            # strip leading whitespace
+            sub(/^[[:space:]]+/, "", line)
+            # only consider lines that start with the module path
+            if (line ~ /^github\.com\/LerianStudio\//) print line
+          }
+        ' "${GO_MOD_PATH}")
+
+        if [[ -z "${DEPS_RAW}" ]]; then
+          # No Lerian libs at all — company standards violation
+          echo "has_lerian_libs=false" >> "${GITHUB_OUTPUT}"
+          echo "has_outdated=false" >> "${GITHUB_OUTPUT}"
+          echo "outdated_count=0" >> "${GITHUB_OUTPUT}"
+          echo "report_path=${REPORT_PATH}" >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "## Lerian Library Version Check"
+            echo
+            echo "**No \`github.com/LerianStudio/*\` dependencies found in \`${GO_MOD_PATH}\`.**"
+            echo
+            echo "Every Lerian Go service is expected to depend on at least one Lerian library (typically \`lib-commons\`). This is a company-standards requirement."
+            echo
+            echo "If this repository is genuinely exempt, please raise it with the platform team."
+          } >> "${REPORT_PATH}"
+
+          echo "::error title=No Lerian libraries found::No github.com/LerianStudio/* dependencies in ${GO_MOD_PATH}. Every Lerian Go service must use at least one Lerian library."
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            log "DRY RUN: would fail. Continuing."
+          else
+            exit 1
+          fi
+        fi
+
+        echo "has_lerian_libs=true" >> "${GITHUB_OUTPUT}"
+
+        # ---------- 2. Load ignore file (optional) ----------
+        # Format:
+        #   # comment
+        #   lib-name/vN                  -> skip entirely
+        #   lib-name/vN@vX.Y.Z           -> pin: only fail if current < pinned target
+        declare -A IGNORE_SKIP=()       # key: module path  -> "1"
+        declare -A IGNORE_PIN=()        # key: module path  -> pinned version (vX.Y.Z)
+
+        if [[ -f "${IGNORE_FILE}" ]]; then
+          log "Loading ignore rules from ${IGNORE_FILE}"
+          while IFS= read -r raw || [[ -n "${raw}" ]]; do
+            line="${raw%%#*}"
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            [[ -z "${line}" ]] && continue
+            if [[ "${line}" == *"@"* ]]; then
+              mod="${line%@*}"
+              pin="${line##*@}"
+              IGNORE_PIN["${mod}"]="${pin}"
+              debug "ignore-pin: ${mod} -> ${pin}"
+            else
+              IGNORE_SKIP["${line}"]="1"
+              debug "ignore-skip: ${line}"
+            fi
+          done < "${IGNORE_FILE}"
+        else
+          echo "::warning title=Ignore file not found::Optional ignore file '${IGNORE_FILE}' not found. Proceeding without ignore rules."
+        fi
+
+        # ---------- 3. Resolve latest stable release per repo (cache by repo name) ----------
+        declare -A LATEST_CACHE=()
+
+        resolve_latest() {
+          local repo="$1"
+          local major_filter="$2"   # e.g. "v5" or "" for v0/v1 modules
+          local cache_key="${repo}::${major_filter}"
+          if [[ -n "${LATEST_CACHE[${cache_key}]:-}" ]]; then
+            echo "${LATEST_CACHE[${cache_key}]}"
+            return 0
+          fi
+
+          # We page through up to 100 releases and pick the highest stable tag that
+          # matches the requested major (when set). Pre-releases are excluded by the
+          # `prerelease == false` filter applied via jq.
+          local http_code
+          local releases_json
+          http_code=$(curl -sS -o "${RUNNER_TEMP:-/tmp}/releases.json" -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/LerianStudio/${repo}/releases?per_page=100" 2>/dev/null || echo "000")
+          releases_json=$(cat "${RUNNER_TEMP:-/tmp}/releases.json" 2>/dev/null || echo "[]")
+
+          if [[ "${http_code}" == "404" ]]; then
+            log "::warning title=Cannot read LerianStudio/${repo}::Repository is not accessible with the current token (HTTP 404). If it is a private repo, provide the LERIAN_LIB_READ_TOKEN secret."
+            LATEST_CACHE[${cache_key}]=""
+            echo ""
+            return 0
+          fi
+
+          local tags
+          tags=$(echo "${releases_json}" | jq -r '.[]? | select(.draft==false) | select(.prerelease==false) | .tag_name' 2>/dev/null || true)
+
+          if [[ -z "${tags}" ]]; then
+            LATEST_CACHE[${cache_key}]=""
+            echo ""
+            return 0
+          fi
+
+          local filtered="${tags}"
+          if [[ -n "${major_filter}" ]]; then
+            filtered=$(echo "${tags}" | awk -v m="${major_filter}." '$0 ~ "^"m {print}')
+            if [[ -z "${filtered}" ]]; then
+              # fall back: some libs publish only un-prefixed (no /vN module)
+              filtered="${tags}"
+            fi
+          fi
+
+          local latest
+          latest=$(echo "${filtered}" | sed 's/^v//' | sort -V | tail -n1)
+          if [[ -n "${latest}" ]]; then
+            latest="v${latest}"
+          fi
+          LATEST_CACHE[${cache_key}]="${latest}"
+          echo "${latest}"
+        }
+
+        # semver compare: returns 0 if $1 >= $2, 1 otherwise
+        ver_ge() {
+          local a="${1#v}" b="${2#v}"
+          [[ "${a}" == "${b}" ]] && return 0
+          local first
+          first=$(printf '%s\n%s\n' "${a}" "${b}" | sort -V | head -n1)
+          [[ "${first}" == "${b}" ]]
+        }
+
+        # ---------- 4. Iterate, compare, build report ----------
+        OUTDATED=0
+        CURRENT=0
+        SKIPPED=0
+        UNKNOWN=0
+
+        # Use a temp file for the table rows so we control ordering and avoid heredoc quoting traps.
+        ROWS_FILE="${RUNNER_TEMP:-/tmp}/lerian-rows.txt"
+        : > "${ROWS_FILE}"
+
+        while IFS= read -r dep_line; do
+          [[ -z "${dep_line}" ]] && continue
+          # split: <module> <version> [// indirect]
+          module=$(echo "${dep_line}" | awk '{print $1}')
+          current=$(echo "${dep_line}" | awk '{print $2}')
+          is_indirect="false"
+          if echo "${dep_line}" | grep -q "// indirect"; then
+            is_indirect="true"
+          fi
+
+          if [[ "${is_indirect}" == "true" && "${CHECK_INDIRECT}" != "true" ]]; then
+            debug "skip indirect: ${module} ${current}"
+            continue
+          fi
+
+          # short_path = lib-commons/v5    (strip github.com/LerianStudio/)
+          short_path="${module#github.com/LerianStudio/}"
+
+          # repo + major filter
+          if [[ "${short_path}" =~ ^([^/]+)/(v[0-9]+)$ ]]; then
+            repo="${BASH_REMATCH[1]}"
+            major_filter="${BASH_REMATCH[2]}"
+          else
+            repo="${short_path%%/*}"
+            major_filter=""
+          fi
+
+          # Ignore rules
+          if [[ -n "${IGNORE_SKIP[${short_path}]:-}" ]]; then
+            SKIPPED=$((SKIPPED+1))
+            printf '| `%s` | `%s` | _skipped_ | Skipped (ignore file) |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
+            continue
+          fi
+
+          latest=$(resolve_latest "${repo}" "${major_filter}")
+
+          if [[ -z "${latest}" ]]; then
+            UNKNOWN=$((UNKNOWN+1))
+            printf '| `%s` | `%s` | _unknown_ | Could not resolve latest release |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
+            log "::warning title=Could not resolve latest release::Failed to fetch latest stable release for LerianStudio/${repo}"
+            continue
+          fi
+
+          # Pinned ignore: latest target becomes the pinned version
+          target="${latest}"
+          marker_suffix=""
+          if [[ -n "${IGNORE_PIN[${short_path}]:-}" ]]; then
+            target="${IGNORE_PIN[${short_path}]}"
+            marker_suffix=" (pinned)"
+          fi
+
+          if ver_ge "${current}" "${target}"; then
+            CURRENT=$((CURRENT+1))
+            printf '| `%s` | `%s` | `%s` | Current%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
+          else
+            OUTDATED=$((OUTDATED+1))
+            printf '| `%s` | `%s` | `%s` | Outdated%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
+          fi
+        done <<< "${DEPS_RAW}"
+
+        # ---------- 5. Build markdown report ----------
+        {
+          echo "## Lerian Library Version Check"
+          echo
+          echo "| Library | Current | Latest | Status |"
+          echo "|---------|---------|--------|--------|"
+          cat "${ROWS_FILE}"
+          echo
+          echo "**${OUTDATED} outdated** | **${CURRENT} current** | **${SKIPPED} skipped** | **${UNKNOWN} unknown**"
+          echo
+          if [[ "${OUTDATED}" -gt 0 ]]; then
+            echo "> Bump the outdated libraries, or add temporary entries to \`${IGNORE_FILE}\`."
+          fi
+        } >> "${REPORT_PATH}"
+
+        # Step summary
+        cat "${REPORT_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+
+        # Outputs
+        {
+          echo "outdated_count=${OUTDATED}"
+          if [[ "${OUTDATED}" -gt 0 ]]; then
+            echo "has_outdated=true"
+          else
+            echo "has_outdated=false"
+          fi
+          echo "report_path=${REPORT_PATH}"
+        } >> "${GITHUB_OUTPUT}"
+
+        # Final verdict
+        if [[ "${OUTDATED}" -gt 0 ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            log "::warning title=Outdated Lerian libraries detected::${OUTDATED} direct dependency(ies) are behind latest stable. (dry-run, not failing)"
+          else
+            echo "::error title=Outdated Lerian libraries::${OUTDATED} direct dependency(ies) are behind latest stable. Bump them, or add to ${IGNORE_FILE}."
+            exit 1
+          fi
+        fi
+
+    - name: Post sticky PR comment
+      if: ${{ inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        REPORT_PATH: ${{ steps.check.outputs.report_path }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const path = process.env.REPORT_PATH;
+          if (!path || !fs.existsSync(path)) {
+            core.info(`No report file at ${path}; skipping PR comment.`);
+            return;
+          }
+          const marker = '<!-- lerian-lib-version-check -->';
+          const dryRunBanner = process.env.DRY_RUN === 'true'
+            ? '> _Dry run — no failures enforced._\n\n'
+            : '';
+          const body = `${marker}\n${dryRunBanner}${fs.readFileSync(path, 'utf8')}`;
+
+          const { owner, repo } = context.repo;
+          const issue_number = context.payload.pull_request?.number;
+          if (!issue_number) {
+            core.info('Not a pull_request event; skipping comment.');
+            return;
+          }
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner, repo, issue_number, per_page: 100,
+          });
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner, repo, comment_id: existing.id, body,
+            });
+            core.info(`Updated sticky comment #${existing.id}.`);
+          } else {
+            await github.rest.issues.createComment({
+              owner, repo, issue_number, body,
+            });
+            core.info('Created sticky comment.');
+          }


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds a new reusable workflow **`lerian-lib-version-check.yml`** plus its underlying composite action **`src/validate/lerian-lib-version/`** that enforces up-to-date LerianStudio Go libraries in every consumer service.

**Why:** Across the organisation, services routinely fall behind on `lib-commons`, `lib-auth`, `lib-license-go`, etc., drifting from company standards and missing security/observability fixes. There is currently no CI gate to prevent this drift, and no signal at all when a service uses *zero* Lerian libs (also a standards violation). See #408 for the full problem statement.

**What it does:**

1. Parses `go.mod` for `github.com/LerianStudio/*` **direct** dependencies (indirect excluded by default; opt-in via `check_indirect`).
2. Fetches the latest **stable** GitHub release for each lib (drafts and pre-releases are filtered out).
3. Compares versions using semver (`sort -V`) and fails the PR when:
   - any direct Lerian lib is behind the latest stable release, **or**
   - the service has **no** Lerian libs at all in `go.mod`.
4. Respects an optional `.lerianstudiolibignore` file (gitignore-style) for temporary skips or version pins. A missing ignore file is a `::warning`, not a failure.
5. Posts/updates a sticky PR comment (`<!-- lerian-lib-version-check -->`) with a status table.
6. Supports an optional secret `LERIAN_LIB_READ_TOKEN` so private LerianStudio repos (e.g. `lib-license-go`) can also be checked. Without the secret, private libs are reported as `unknown` with a warning.

**Files added:**

| File | Purpose |
|---|---|
| `.github/workflows/lerian-lib-version-check.yml` | Reusable workflow (single entry point for callers) |
| `src/validate/lerian-lib-version/action.yml` | Composite action with the parsing/comparison/comment logic |
| `src/validate/lerian-lib-version/README.md` | Composite action reference |
| `docs/lerian-lib-version-check.md` | Public docs (matches existing `docs/*-workflow.md` style) |

**Example caller usage:**

```yaml
jobs:
  lerian-lib-version-check:
    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/lerian-lib-version-check.yml@v1.x.x
    secrets:
      LERIAN_LIB_READ_TOKEN: ${{ secrets.LERIAN_ORG_READ_TOKEN }}  # optional; required only for private Lerian libs
```

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. This is a brand-new reusable workflow and composite action — no existing workflow or composite is touched. Consumers opt in explicitly by adding the job to their PR pipeline.

## Testing

- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(open(...))"` on both new YAML files)
- [x] **End-to-end dry run executed inside `ubuntu:24.04`** (the same OS family as `blacksmith-4vcpu-ubuntu-2404`) against a real consumer `go.mod` (`plugin-br-pix-indirect-btg`). Validated:
  - All three direct Lerian deps detected and resolved correctly
    - `lib-auth/v2` `v2.7.0` → latest `v2.8.0` (outdated)
    - `lib-license-go/v2` `v2.3.2` → latest `v2.3.5` (outdated, requires `LERIAN_LIB_READ_TOKEN` because the repo is internal)
    - `lib-commons/v5` `v5.1.0` → latest `v5.5.0` (outdated)
  - Indirect `lib-commons/v2 v2.9.1 // indirect` correctly excluded by default
  - `.lerianstudiolibignore` rule `lib-auth/v2` → lib marked `_skipped_`
  - `.lerianstudiolibignore` rule `lib-commons/v5@v5.3.0` → lib marked `Outdated (pinned)` (because `v5.1.0 < v5.3.0`)
  - Missing ignore file → `::warning` emitted, workflow proceeds
  - `go.mod` with no Lerian deps → fails with explicit `::error` (company-standards branch)
  - HTTP 404 from private repo without token → `::warning` with instruction to set `LERIAN_LIB_READ_TOKEN`, lib marked `_unknown_`, workflow does not crash
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag _(will validate once this branch produces a beta tag, e.g. `v1.x.x-beta.1`)_
- [x] Verified all existing inputs still work with default values (no existing workflow/composite was modified)
- [x] Confirmed no secrets or tokens are printed in logs (token only used as `Authorization: Bearer` header; no `echo` of `GH_TOKEN` or response bodies)
- [x] Checked that unrelated workflows are not affected (no edits to existing files)

**Caller repo / workflow run:** _Will be added after the beta tag is published from `develop` and the workflow is wired into a consumer repo (e.g. `plugin-br-pix-indirect-btg`)._

### Security / AGENTS.md compliance

- Targets `develop`, not `main`
- All file extensions are `.yml`
- Third-party actions pinned by SHA with version comment (`actions/checkout@de0fac2…  # v6`, `actions/github-script@3a2844b7…  # v9.0.0`)
- Org-owned composite reference uses `@develop` for the initial release; will be bumped to `@v1.x.x` once the first stable tag exists
- Explicit `permissions:` block at workflow level (`contents: read`, `pull-requests: write`)
- All untrusted input flows through `env:` before reaching `run:` (`GH_TOKEN`, paths)
- `dry_run` input present, verbose-when-true / silent-when-false
- Boolean outputs (`has_outdated`, `outdated_count`, `has_lerian_libs`) so callers can gate downstream jobs

## Related Issues

Closes #408