### PR TITLE
fix(go-pr-analysis): silence gosec telemetry 403 and make-sec noise

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -96,6 +96,7 @@ on:
         default: ''
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
   security-events: write
@@ -267,7 +268,10 @@ jobs:
         working-directory: ${{ matrix.app.working_dir }}
         run: |
           if [[ -f "Makefile" ]] || [[ -f "makefile" ]] || [[ -f "GNUmakefile" ]]; then
-            if make -n sec >/dev/null 2>&1; then
+            if ! command -v gosec >/dev/null 2>&1; then
+              echo "Makefile present but gosec is not on PATH; skipping 'make sec' (the gosec action below is authoritative)"
+              echo "use_make=false" >> "$GITHUB_OUTPUT"
+            elif make -n sec >/dev/null 2>&1; then
               echo "Makefile with 'sec' target detected"
               echo "use_make=true" >> "$GITHUB_OUTPUT"
             else

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -325,6 +325,7 @@ swagger.go
 ## Permissions Required
 
 The workflow requires these permissions:
+- `actions: read` - To let the gosec action read the workflow run for status/telemetry
 - `contents: read` - To checkout code
 - `pull-requests: write` - To post coverage comments
 - `security-events: write` - To upload SARIF results


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `Security (<app>)` job of `go-pr-analysis.yml` emitted two spurious **error annotations** that confused consumers (e.g. go-boilerplate-ddd), even though they did not (by themselves) fail the job:

1. **`Resource not accessible by integration` (get-a-workflow-run)** — the `securego/gosec` action calls the GitHub API to gather run telemetry/status, which needs `actions: read`. The workflow's `permissions:` block didn't grant it, so the call returned 403 ("Will skip sending status report").
2. **`Process completed with exit code 2` / `gosec is not installed`** — the best-effort `Run Security (make)` step ran the repo's `make sec` target even on runners without `gosec` on PATH. It is `continue-on-error: true` (so non-fatal), but produced a red annotation on every run.

### Changes
- Add `actions: read` to the workflow-level `permissions:` so the gosec action's telemetry call succeeds.
- In `Detect Makefile sec target`, only set `use_make=true` when `gosec` is on PATH. When it isn't, `make sec` is skipped — the `securego/gosec` action remains the authoritative scan, so coverage is unchanged.

No input/output/secret changes. Behavior is otherwise identical.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only
- [ ] `ci`: Changes to self-CI
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `actions: read` is additive; the `make sec` step only changes when it runs (skipped when gosec is absent, which is the common CI case), and it was already `continue-on-error`.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validated locally with `actionlint` and `shellcheck` (the edited `detect-make` shell) — both clean.

**Caller repo / workflow run:** observed on go-boilerplate-ddd PR validation (umbrella) — the two annotations originate here, not in the umbrella wiring.

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow permissions to improve tool accessibility and added availability checks for security scanning.

* **Documentation**
  * Updated workflow permissions documentation to reflect required access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->