### PR TITLE
fix(lerian-lib-version): retry releases fetch without auth on 404 for public repos

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -172,10 +172,18 @@ runs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/LerianStudio/${repo}/releases?per_page=100" 2>/dev/null || echo "000")
+
+          if [[ "${http_code}" == "404" ]]; then
+            http_code=$(curl -sS -o "${RUNNER_TEMP:-/tmp}/releases.json" -w '%{http_code}' \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/LerianStudio/${repo}/releases?per_page=100" 2>/dev/null || echo "000")
+          fi
+
           releases_json=$(cat "${RUNNER_TEMP:-/tmp}/releases.json" 2>/dev/null || echo "[]")
 
           if [[ "${http_code}" == "404" ]]; then
-            log "::warning title=Cannot read LerianStudio/${repo}::Repository is not accessible with the current token (HTTP 404). If it is a private repo, provide the LERIAN_LIB_READ_TOKEN secret."
+            log "::warning title=Cannot read LerianStudio/${repo}::Repository is private and not accessible. Provide the LERIAN_LIB_READ_TOKEN secret."
             LATEST_CACHE[${cache_key}]=""
             echo ""
             return 0


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `lerian-lib-version` composite fetches release data from `LerianStudio/*` repos using the provided token (defaulting to `github.token` when `LERIAN_LIB_READ_TOKEN` is not configured). A scoped `GITHUB_TOKEN` returns HTTP 404 on cross-repository API calls even for public repos, causing all public Lerian libs to be reported as `unknown` instead of being resolved.

**Fix:** when the authenticated request returns 404, the composite now retries the same request without the `Authorization` header. Public repos resolve correctly unauthenticated; private repos return 404 again and get the existing warning (`Repository is private and not accessible. Provide the LERIAN_LIB_READ_TOKEN secret.`).

This eliminates the `Warning: Failed to fetch latest stable release for LerianStudio/lib-*` noise for repos that haven't configured `LERIAN_LIB_READ_TOKEN`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — will validate via go-boilerplate-ddd PR #47 after merge_

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in library version validation to automatically retry API requests when encountering access issues, improving resilience for inaccessible repositories.
  * Updated error messages to provide clearer guidance when repository access fails during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->