### PR TITLE
fix(lerian-lib-version): use MANAGE_TOKEN for PR comment in nested reusable context

### DIFF
--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -45,6 +45,12 @@ on:
           `lib-license-go`. When unset, the default GITHUB_TOKEN is used and private libs will be
           reported as "unknown".
         required: false
+      MANAGE_TOKEN:
+        description: |
+          Org-scoped PAT with pull-requests:write on the caller repository. Used to post or update
+          the sticky PR comment. Required when this workflow is called as a nested reusable, because
+          github.token in that context is scoped to the shared-workflows repo, not the caller.
+        required: false
 
     outputs:
       has_outdated:
@@ -80,6 +86,7 @@ jobs:
         uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@develop
         with:
           github-token: ${{ secrets.LERIAN_LIB_READ_TOKEN || github.token }}
+          comment-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           go-mod-path: ${{ inputs.go_mod_path }}
           ignore-file: ${{ inputs.ignore_file }}
           check-indirect: ${{ inputs.check_indirect && 'true' || 'false' }}

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -23,7 +23,7 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 | `ignore-file`     | Path to optional `.lerianstudiolibignore` file. Missing file is a warning, not a failure.       | No       | `.lerianstudiolibignore`   |
 | `check-indirect`  | Also check transitive (`// indirect`) deps.                                                     | No       | `false`                    |
 | `comment-on-pr`   | Post or update a sticky comment on the PR with the result table.                                | No       | `true`                     |
-| `comment-token`   | Token used to post/update the sticky PR comment. Falls back to `github-token` when empty. Pass `MANAGE_TOKEN` when calling from a nested reusable workflow, because `github.token` in that context is scoped to the shared-workflows repo, not the caller. | No | `""` |
+| `comment-token`   | Token used to post/update the sticky PR comment. Falls back to `github-token` when empty. Must be an org-scoped PAT (e.g., `MANAGE_TOKEN`) with pull-requests:write when calling from a nested reusable workflow, because `github.token` in that context is scoped to the shared-workflows repo, not the caller. | No | `""` |
 | `dry-run`         | Verbose log of all resolved versions; never fails the build.                                    | No       | `false`                    |
 
 ## Outputs

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -23,6 +23,7 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 | `ignore-file`     | Path to optional `.lerianstudiolibignore` file. Missing file is a warning, not a failure.       | No       | `.lerianstudiolibignore`   |
 | `check-indirect`  | Also check transitive (`// indirect`) deps.                                                     | No       | `false`                    |
 | `comment-on-pr`   | Post or update a sticky comment on the PR with the result table.                                | No       | `true`                     |
+| `comment-token`   | Token used to post/update the sticky PR comment. Falls back to `github-token` when empty. Pass `MANAGE_TOKEN` when calling from a nested reusable workflow, because `github.token` in that context is scoped to the shared-workflows repo, not the caller. | No | `""` |
 | `dry-run`         | Verbose log of all resolved versions; never fails the build.                                    | No       | `false`                    |
 
 ## Outputs

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Post or update a sticky comment on the PR with the result table.
     required: false
     default: "true"
+  comment-token:
+    description: Token used to post the sticky PR comment. Must have pull-requests:write on the caller repo. Defaults to github-token when unset.
+    required: false
+    default: ""
   dry-run:
     description: Verbose log of all resolved versions; never fails the build.
     required: false
@@ -341,7 +345,7 @@ runs:
         REPORT_PATH: ${{ steps.check.outputs.report_path }}
         DRY_RUN: ${{ inputs.dry-run }}
       with:
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ inputs.comment-token || inputs.github-token }}
         script: |
           const fs = require('fs');
           const path = process.env.REPORT_PATH;


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When `lerian-lib-version-check.yml` is called as a **nested reusable workflow** (e.g. from `go-pr-validation.yml`, which is itself called from a caller repo), `github.token` inside the reusable is scoped to the `shared-workflows` repository — not the caller. The "Post sticky PR comment" step was using that token, which returned HTTP 404 when trying to list or post comments on a PR in the caller repo (e.g. `go-boilerplate-ddd`), failing the entire job.

**Fix:**
- Added `comment-token` input to the `lerian-lib-version` composite action. The PR comment step now uses `inputs.comment-token || inputs.github-token`, keeping the release-fetch token (`LERIAN_LIB_READ_TOKEN || github.token`) separate from the comment-posting token.
- Added `MANAGE_TOKEN` secret declaration to `lerian-lib-version-check.yml`. It is passed as `comment-token: ${{ secrets.MANAGE_TOKEN || github.token }}` to the composite. `MANAGE_TOKEN` is an org-scoped PAT with `pull-requests:write` on all LerianStudio repositories and flows through the `secrets: inherit` chain from the caller.

**Observed failure (go-boilerplate-ddd #47, attempt 3):**
```
GET /repos/LerianStudio/go-boilerplate-ddd/issues/47/comments?per_page=100 - 404
##[error]Unhandled error: HttpError: Not Found
```

Follows #411 (retry without auth on 404 for lib-fetch).

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — will validate via go-boilerplate-ddd PR #47 after merge_

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional dedicated token input to control authentication when posting/updating sticky PR comments from nested reusable workflows, with a fallback to the default token.
* **Documentation**
  * Updated docs to describe the new optional token input, its fallback behavior, and guidance on required token scope for nested reusable workflow usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->