### PR TITLE
fix(lerian-lib-version): log non-200 HTTP code from releases API

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -193,6 +193,13 @@ runs:
             return 0
           fi
 
+          if [[ "${http_code}" != "200" ]]; then
+            log "::warning title=Cannot read LerianStudio/${repo}::Releases API returned HTTP ${http_code}. Check that LERIAN_LIB_READ_TOKEN has Contents:read and is approved by the org."
+            LATEST_CACHE[${cache_key}]=""
+            echo ""
+            return 0
+          fi
+
           local tags
           tags=$(echo "${releases_json}" | jq -r '.[]? | select(.draft==false) | select(.prerelease==false) | .tag_name' 2>/dev/null || true)
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When the GitHub Releases API returns a non-200, non-404 status (e.g. HTTP 403 from a fine-grained PAT that lacks org approval or has insufficient scope), the composite silently fell through to `tags=""` and surfaced only the generic "Failed to fetch latest stable release" warning — making root-cause diagnosis impossible.

**Fix:** add an explicit check after the 404 branch. Any HTTP code that is not 200 now emits a targeted warning:

```
::warning::Releases API returned HTTP 403. Check that LERIAN_LIB_READ_TOKEN has Contents:read and is approved by the org.
```

This surfaces the real cause (403 from an unapproved fine-grained PAT vs. 404 from a private repo vs. 200 with empty releases) without changing existing behavior for healthy runs.

Follows #411 (retry without auth on 404) and #412 (MANAGE_TOKEN for PR comments).

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — validates after merge via go-boilerplate-ddd PR #47_

## Related Issues

Closes #