### PR TITLE
fix(lerian-lib-version): post PR comment even when check fails

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -346,7 +346,7 @@ runs:
         fi
 
     - name: Post sticky PR comment
-      if: ${{ inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ always() && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         REPORT_PATH: ${{ steps.check.outputs.report_path }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When the lib-version check detects outdated libraries and exits with code 1, the "Post sticky PR comment" step was silently skipped — because composite action steps do not run after a failed step unless `always()` is specified. The PR comment was left showing the stale result from the previous run (e.g. `5 unknown`) instead of the real result (`3 outdated`), making it impossible to understand the failure without digging through job logs.

**Fix:** add `always()` to the `if:` condition of the "Post sticky PR comment" step so the comment is posted regardless of whether the check passed or failed.

```yaml
# before
if: ${{ inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}

# after
if: ${{ always() && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
```

Follows #411 (retry without auth), #412 (MANAGE_TOKEN for comment token), #413 (log non-200 HTTP codes).

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — validates via go-boilerplate-ddd PR #47 after merge_

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability to ensure pull request comments post correctly, even when previous workflow steps encounter failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->