### PR TITLE
fix(lerian-lib-version): exclude pre-release tags when resolving latest

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -167,8 +167,9 @@ runs:
           fi
 
           # We page through up to 100 releases and pick the highest stable tag that
-          # matches the requested major (when set). Pre-releases are excluded by the
-          # `prerelease == false` filter applied via jq.
+          # matches the requested major (when set). Pre-releases are excluded both by
+          # the `prerelease == false` API flag and by a tag-name filter below, since
+          # the flag is not reliable (a -beta/-rc release may be published with it unset).
           local http_code
           local releases_json
           http_code=$(curl -sS -o "${RUNNER_TEMP:-/tmp}/releases.json" -w '%{http_code}' \
@@ -202,6 +203,11 @@ runs:
 
           local tags
           tags=$(echo "${releases_json}" | jq -r '.[]? | select(.draft==false) | select(.prerelease==false) | .tag_name' 2>/dev/null || true)
+
+          # Belt-and-suspenders: drop any pre-release tag name (e.g. v2.7.0-beta.8)
+          # even when the GitHub release's `prerelease` flag was not set. Per semver,
+          # a hyphen after the patch denotes a pre-release; keep stable vMAJOR.MINOR.PATCH only.
+          tags=$(printf '%s\n' "${tags}" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true)
 
           if [[ -z "${tags}" ]]; then
             LATEST_CACHE[${cache_key}]=""


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Fixes the Lerian library version check (`src/validate/lerian-lib-version`) so it never picks a **pre-release** tag as the "latest" version.

`resolve_latest` filtered releases using only the GitHub Release `prerelease` boolean (`select(.prerelease==false)`). That flag is not reliable — a `-beta`/`-rc` release can be published with it unset, then passes the filter and ranks above the latest stable via `sort -V`. Observed downstream (`plugin-br-payments#171`): `midaz-sdk-golang/v2` showed `Latest = v2.7.0-beta.8`, producing a false `Outdated` row.

The fix adds a tag-name filter so only stable `vMAJOR.MINOR.PATCH` tags are considered, as a belt-and-suspenders alongside the existing flag filter. The inline comment is updated to reflect both filters.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. No input/output changes; behavior is corrective (stops treating pre-releases as the latest stable).

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- to validate: run go-pr-validation@this-branch on a repo depending on midaz-sdk-golang/v2; Latest should resolve to the latest stable v2.x, not v2.7.0-beta.8 -->

## Related Issues

Closes #430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version filtering to improve reliability in selecting stable releases by implementing additional validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->