### PR TITLE
feat(go-release): expose helm-dispatch and gitops-update inputs for multi-cluster deploy

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -134,11 +134,11 @@ on:
         type: string
         default: ''
       deploy_in_firmino:
-        description: 'Deploy to the firmino cluster'
+        description: 'Force-off override for Firmino. Set to false to suppress deployment even if the manifest includes this app on Firmino.'
         type: boolean
         default: true
       deploy_in_clotilde:
-        description: 'Deploy to the clotilde cluster'
+        description: 'Force-off override for Clotilde. Set to false to suppress deployment even if the manifest includes this app on Clotilde.'
         type: boolean
         default: true
       use_dynamic_mapping:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -67,6 +67,42 @@ on:
         description: 'Sign container images with cosign keyless (OIDC) signing after push'
         type: boolean
         default: true
+      app_name_prefix:
+        description: 'Prefix for app names in monorepo (e.g., "midaz" -> "midaz-agent")'
+        type: string
+        default: ''
+      app_name_overrides:
+        description: 'Explicit app name mappings in "path:name" format. Overrides default extraction for matched paths.'
+        type: string
+        default: ''
+      dockerhub_org:
+        description: 'DockerHub organization name'
+        type: string
+        default: 'lerianstudio'
+      path_level:
+        description: 'Directory depth level to extract app name (e.g., 2 -> "apps/agent")'
+        type: string
+        default: '2'
+      build_context_from_working_dir:
+        description: 'Use the component working_dir as Docker build context instead of the repo root.'
+        type: boolean
+        default: false
+      enable_helm_dispatch:
+        description: 'Dispatch to the Helm repository for chart updates after build'
+        type: boolean
+        default: false
+      helm_chart:
+        description: 'Helm chart name to update (required when enable_helm_dispatch is true)'
+        type: string
+        default: ''
+      helm_detect_env_changes:
+        description: 'Detect new environment variables for Helm during dispatch'
+        type: boolean
+        default: true
+      helm_values_key_mappings:
+        description: 'JSON mapping of component names to values.yaml keys (e.g., {"my-app": "api"})'
+        type: string
+        default: ''
 
       # ----------------- GitOps Update (gitops-update.yml) -----------------
       enable_gitops_update:
@@ -85,6 +121,38 @@ on:
         description: 'JSON object mapping artifact names to YAML keys (e.g., {"app.tag": ".api.image.tag"})'
         type: string
         default: ''
+      gitops_runner_type:
+        description: 'Runner for the gitops-update (deploy) job. Deploy needs cluster access, so this defaults to firmino-lxc-runners rather than the build runner.'
+        type: string
+        default: 'firmino-lxc-runners'
+      enable_argocd_sync:
+        description: 'Trigger ArgoCD sync after updating the GitOps repository'
+        type: boolean
+        default: true
+      commit_message_prefix:
+        description: 'Prefix for the GitOps commit message (defaults to repository name when empty)'
+        type: string
+        default: ''
+      deploy_in_firmino:
+        description: 'Deploy to the firmino cluster'
+        type: boolean
+        default: true
+      deploy_in_clotilde:
+        description: 'Deploy to the clotilde cluster'
+        type: boolean
+        default: true
+      use_dynamic_mapping:
+        description: 'Use dynamic artifact-to-YAML key mapping in gitops-update'
+        type: boolean
+        default: false
+      configmap_updates:
+        description: 'JSON object mapping artifact names to configmap keys (helmfile layout only)'
+        type: string
+        default: ''
+      enable_docker_login:
+        description: 'Log in to DockerHub in the gitops-update job (for private image digest reads)'
+        type: boolean
+        default: false
 
       # ----------------- Shared -----------------
       shared_paths:
@@ -160,8 +228,17 @@ jobs:
       enable_ghcr: ${{ inputs.enable_ghcr }}
       enable_gitops_artifacts: ${{ inputs.enable_gitops_artifacts }}
       app_name: ${{ inputs.app_name }}
+      app_name_prefix: ${{ inputs.app_name_prefix }}
+      app_name_overrides: ${{ inputs.app_name_overrides }}
+      dockerhub_org: ${{ inputs.dockerhub_org }}
+      path_level: ${{ inputs.path_level }}
+      build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       docker_build_args: ${{ inputs.docker_build_args }}
       enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      enable_helm_dispatch: ${{ inputs.enable_helm_dispatch }}
+      helm_chart: ${{ inputs.helm_chart }}
+      helm_detect_env_changes: ${{ inputs.helm_detect_env_changes }}
+      helm_values_key_mappings: ${{ inputs.helm_values_key_mappings }}
       shared_paths: ${{ inputs.shared_paths }}
       filter_paths: ${{ inputs.filter_paths }}
     secrets: inherit
@@ -177,8 +254,15 @@ jobs:
       packages: write
     uses: ./.github/workflows/gitops-update.yml
     with:
-      runner_type: ${{ inputs.runner_type }}
+      runner_type: ${{ inputs.gitops_runner_type }}
       gitops_repository: ${{ inputs.gitops_repository }}
       artifact_pattern: ${{ inputs.gitops_artifact_pattern }}
       yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
+      enable_argocd_sync: ${{ inputs.enable_argocd_sync }}
+      commit_message_prefix: ${{ inputs.commit_message_prefix }}
+      deploy_in_firmino: ${{ inputs.deploy_in_firmino }}
+      deploy_in_clotilde: ${{ inputs.deploy_in_clotilde }}
+      use_dynamic_mapping: ${{ inputs.use_dynamic_mapping }}
+      configmap_updates: ${{ inputs.configmap_updates }}
+      enable_docker_login: ${{ inputs.enable_docker_login }}
     secrets: inherit

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -45,8 +45,8 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `firmino-lxc-runners` |
 | `enable_argocd_sync` | Trigger ArgoCD sync after updating the GitOps repo | boolean | `true` |
 | `commit_message_prefix` | Prefix for the GitOps commit message (defaults to repo name when empty) | string | `''` |
-| `deploy_in_firmino` | Deploy to the firmino cluster | boolean | `true` |
-| `deploy_in_clotilde` | Deploy to the clotilde cluster | boolean | `true` |
+| `deploy_in_firmino` | Force-off override for Firmino; set `false` to suppress deployment even when the manifest includes the app | boolean | `true` |
+| `deploy_in_clotilde` | Force-off override for Clotilde; set `false` to suppress deployment even when the manifest includes the app | boolean | `true` |
 | `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
 | `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -29,10 +29,27 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `app_name` | Override app/image name (single-app mode) | string | `''` (repo name) |
 | `docker_build_args` | Newline-separated Docker build args | string | `''` |
 | `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
+| `app_name_prefix` | Prefix for app names in monorepo (e.g. `midaz` -> `midaz-agent`) | string | `''` |
+| `app_name_overrides` | Explicit `path:name` app name mappings | string | `''` |
+| `dockerhub_org` | DockerHub organization name | string | `lerianstudio` |
+| `path_level` | Directory depth level to extract app name | string | `2` |
+| `build_context_from_working_dir` | Use the component working_dir as Docker build context | boolean | `false` |
+| `enable_helm_dispatch` | Dispatch to the Helm repository for chart updates after build | boolean | `false` |
+| `helm_chart` | Helm chart name to update (required when `enable_helm_dispatch`) | string | `''` |
+| `helm_detect_env_changes` | Detect new environment variables for Helm during dispatch | boolean | `true` |
+| `helm_values_key_mappings` | JSON mapping of component names to values.yaml keys | string | `''` |
 | `enable_gitops_update` | Run the gitops-update job on tag push | boolean | `true` |
 | `gitops_repository` | GitOps repository to update (org/repo) | string | `LerianStudio/midaz-firmino-gitops` |
 | `gitops_artifact_pattern` | Pattern to download GitOps artifacts | string | `''` |
 | `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
+| `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `firmino-lxc-runners` |
+| `enable_argocd_sync` | Trigger ArgoCD sync after updating the GitOps repo | boolean | `true` |
+| `commit_message_prefix` | Prefix for the GitOps commit message (defaults to repo name when empty) | string | `''` |
+| `deploy_in_firmino` | Deploy to the firmino cluster | boolean | `true` |
+| `deploy_in_clotilde` | Deploy to the clotilde cluster | boolean | `true` |
+| `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
+| `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
+| `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Exposes the helm-dispatch and multi-cluster gitops inputs on `go-release.yml` and forwards them to the internal `build.yml` and `gitops-update.yml` jobs, so the gitops/helm plugins (`plugin-fees`, `plugin-identity`, `plugin-br-pix-indirect-btg`, `plugin-br-pix-switch`, `br-spb-bc-correios`) can adopt the consolidated `go-release` model without losing their deploy (helm dispatch, firmino/clotilde rollout, ArgoCD sync).

**Forwarded to `build.yml`:** `app_name_prefix`, `app_name_overrides`, `dockerhub_org`, `path_level`, `build_context_from_working_dir`, `enable_helm_dispatch`, `helm_chart`, `helm_detect_env_changes`, `helm_values_key_mappings`.

**Forwarded to `gitops-update.yml`:** `gitops_runner_type`, `enable_argocd_sync`, `commit_message_prefix`, `deploy_in_firmino`, `deploy_in_clotilde`, `use_dynamic_mapping`, `configmap_updates`, `enable_docker_login`.

Two corrections vs. the issue proposal:
- `enable_docker_login` is a `gitops-update.yml` input (not `build.yml`), so it is wired as a gitops pass-through.
- `gitops_runner_type` is a new go-release input mapped to the gitops-update `runner_type`.

Opinionated defaults to declutter callers (values identical across all 5 target repos; analysis-backed): `gitops_repository=LerianStudio/midaz-firmino-gitops`, `enable_argocd_sync=true`, `helm_detect_env_changes=true`, and **`gitops_runner_type=firmino-lxc-runners`**. Per-repo values (`app_name_prefix`, `helm_chart`, `helm_values_key_mappings`, `gitops_artifact_pattern`, `gitops_yaml_key_mappings`, etc.) stay caller-set.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

The new inputs are all optional and their defaults match the downstream defaults — non-breaking for the build/helm pass-throughs.

One behavioral change to call out: **`gitops_runner_type` defaults to `firmino-lxc-runners`** (not the build runner). Any existing `go-release` caller that runs the gitops-update job and relied on it using `runner_type` (blacksmith) will now run it on `firmino-lxc-runners`. This matches operational reality (deploy needs cluster-access runners) and the 5 target repos. To keep the build runner, set `gitops_runner_type` explicitly.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- to validate: point one of br-spb-bc-correios / plugin-fees at go-release@this-branch and confirm helm dispatch + firmino/clotilde + ArgoCD sync run as before -->

## Related Issues

Closes #432


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new configuration options to the Go release workflow for more flexible monorepo naming, Docker build context and registry selection, optional Helm dispatch, and enhanced GitOps/ArgoCD deployment controls (including environment-specific deploy toggles and mapping strategies).
  * Updated workflow wiring so tag-triggered build and GitOps update jobs pass through the new settings.

* **Documentation**
  * Updated the go-release workflow documentation to list the new build and deployment inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->