### PR TITLE
fix(changed-paths): hand changed-file list off via temp file to avoid ARG_MAX overflow

### DIFF
--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -117,13 +117,18 @@ runs:
           # Normal case - diff between commits
           FILES=$(git diff --name-only "$EVENT_BEFORE" "$EVENT_SHA")
         fi
-        printf "files<<EOF\n%s\nEOF\n" "$FILES" >> "$GITHUB_OUTPUT"
+        # Hand the file list off via a temp file and export only its path. Passing the
+        # full list through the consuming step's env (FILES) overflows ARG_MAX on large
+        # diffs — execve fails with E2BIG ("Argument list too long") and bash never starts.
+        FILES_PATH="$RUNNER_TEMP/changed-paths-files.txt"
+        printf '%s\n' "$FILES" > "$FILES_PATH"
+        printf "files_path=%s\n" "$FILES_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Extract changed directories
       id: dirs
       shell: bash
       env:
-        FILES: ${{ steps.changed.outputs.files }}
+        FILES_PATH: ${{ steps.changed.outputs.files_path }}
         FILTER_PATHS: ${{ inputs.filter-paths }}
         SHARED_PATHS: ${{ inputs.shared-paths }}
         PATH_LEVEL: ${{ inputs.path-level }}
@@ -136,6 +141,11 @@ runs:
         CONSOLIDATE_TO_ROOT: ${{ inputs.consolidate-to-root }}
         CONSOLIDATE_KEEP_DIRS: ${{ inputs.consolidate-keep-dirs }}
       run: |
+        # Read the file list from the temp file (see "Get changed files"). Command
+        # substitution strips the trailing newline, so an empty diff yields empty FILES
+        # and the -z guard below still fires.
+        FILES=$(cat "$FILES_PATH")
+
         # Single app fallback: when filter_paths is empty and fallback_app_name is set,
         # return a single-item matrix without detecting changes
         if [[ ( -z "$FILTER_PATHS" || "$FILTER_PATHS" == "[]" ) && -n "$FALLBACK_APP_NAME" ]]; then


### PR DESCRIPTION
## Problem

`src/config/changed-paths` passes the full changed-file list into the **environment** of the *Extract changed directories* step:

```yaml
env:
  FILES: ${{ steps.changed.outputs.files }}   # entire git-diff --name-only output
```

On a large diff that string exceeds the kernel's per-string `ARG_MAX` limit, so `execve` of the step's bash fails **before any script runs**:

```
##[error]An error occurred trying to start process '/usr/bin/bash' with working directory '...'. Argument list too long
```

The matrix output is never produced, `has_changes` never gets set, and **every downstream job is skipped** — lint, security, tests, coverage, build. The `filter_paths` / `path_level` / `ignore_dirs` logic can't help, because it lives *inside* the step that fails to start.

Hit in the wild by a monorepo-consolidation PR (`LerianStudio/midaz#2154`, ~2300 changed files) — both `go-pr-analysis` (Detect Changes) and `pr-security-scan` (prepare_matrix) failed identically, since both delegate here.

## Fix

Hand the file list off via a temp file instead of the environment:

- *Get changed files* writes the list to `$RUNNER_TEMP/changed-paths-files.txt` and exports only its **path** (small).
- *Extract changed directories* reads it back with `FILES=$(cat "$FILES_PATH")`.

Command substitution strips the trailing newline, so an empty diff still yields an empty `FILES` and the existing `-z "$FILES"` guard fires unchanged. **All extraction/filter logic is otherwise untouched** — this is a pure transport change.

The internal `files` step output was referenced in exactly one place; declared action outputs (`matrix`, `has_changes`) are unaffected.

## Verification

No local harness exists for this action, so verification is a focused transport check (run locally):
- 2300-path list round-trips intact through the file (~90 KB — the size that overflowed the env block);
- here-string consumption (`while read … <<< "$FILES"`) walks every one of the 2300 lines;
- empty-diff yields empty `FILES` so the `-z` guard still short-circuits.

`actionlint` clean on the two caller workflows.

## ⚠️ Required follow-up for this to reach consumers

Every reusable workflow references this action via the **floating `v1` major tag** (`changed-paths@v1`). That tag is currently **stale** — it points at `83d51369`, several releases behind `v1.35.0`. Consumers pinned to `@v1` (e.g. midaz) run the old, broken code regardless of which reusable-workflow version they pin.

**Cutting a release is not sufficient** — the `v1` major tag must be **advanced** to a commit containing this fix for `@v1` consumers to receive it. Bumping a downstream caller's outer pin will *not* help, because the inner reference is `@v1` in every version.

Steps to unblock midaz#2154:
1. Merge → promote to a **stable** release on `main`.
2. **Move the `v1` tag** to the released commit (this looks like a pre-existing gap — `v1` stopped tracking releases at `83d5136`).
3. Re-run midaz#2154 CI — no midaz change needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large file lists in the changed-paths action to prevent processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->