### PR TITLE
chore(release): develop to main

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -159,6 +159,10 @@ on:
         description: 'Newline-separated path patterns that trigger a release/build for all components.'
         type: string
         default: ''
+      release_single_app:
+        description: 'Force single-app mode for the release job even when filter_paths is set. Use for repos with one version tag but multiple Docker images.'
+        type: boolean
+        default: false
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
         type: string
@@ -210,7 +214,7 @@ jobs:
       enable_major_tag: ${{ inputs.enable_major_tag }}
       stable_releases_only: ${{ inputs.stable_releases_only }}
       shared_paths: ${{ inputs.shared_paths }}
-      filter_paths: ${{ inputs.filter_paths }}
+      filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}
     secrets: inherit
 
   # ----------------- Build (tag push) -----------------

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -12,6 +12,15 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 
 > **Note** — As of v1.x this workflow hosts the service release pipeline (semantic-release + Docker build + GitOps). The previous GoReleaser-based binary release pipeline remains available in the Git history of this file.
 
+### Repository layouts
+
+`filter_paths` drives both the release matrix and the build matrix, which covers two layouts:
+
+- **Single app** — `filter_paths` empty: one semantic-release tag, one image.
+- **Per-component monorepo** — `filter_paths` set: each changed component gets its own release tag and its own image.
+
+A third layout needs `release_single_app: true`: **one semantic-release tag for the whole repo, but one image per component**. Set `filter_paths` to the component prefixes (so the tag-push build still produces N images) and `release_single_app: true` so the branch-push release ignores `filter_paths` and runs once from the repo root. Without it, each component spawns a parallel `Semantic Release` job and they race to tag the same branch.
+
 ## Inputs
 
 | Input | Description | Type | Default |
@@ -52,6 +61,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
+| `release_single_app` | Force single-app mode for the release job even when `filter_paths` is set (one version tag, many images) | boolean | `false` |
 
 ## Secrets
 

--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -117,13 +117,18 @@ runs:
           # Normal case - diff between commits
           FILES=$(git diff --name-only "$EVENT_BEFORE" "$EVENT_SHA")
         fi
-        printf "files<<EOF\n%s\nEOF\n" "$FILES" >> "$GITHUB_OUTPUT"
+        # Hand the file list off via a temp file and export only its path. Passing the
+        # full list through the consuming step's env (FILES) overflows ARG_MAX on large
+        # diffs — execve fails with E2BIG ("Argument list too long") and bash never starts.
+        FILES_PATH="$RUNNER_TEMP/changed-paths-files.txt"
+        printf '%s\n' "$FILES" > "$FILES_PATH"
+        printf "files_path=%s\n" "$FILES_PATH" >> "$GITHUB_OUTPUT"
 
     - name: Extract changed directories
       id: dirs
       shell: bash
       env:
-        FILES: ${{ steps.changed.outputs.files }}
+        FILES_PATH: ${{ steps.changed.outputs.files_path }}
         FILTER_PATHS: ${{ inputs.filter-paths }}
         SHARED_PATHS: ${{ inputs.shared-paths }}
         PATH_LEVEL: ${{ inputs.path-level }}
@@ -136,6 +141,11 @@ runs:
         CONSOLIDATE_TO_ROOT: ${{ inputs.consolidate-to-root }}
         CONSOLIDATE_KEEP_DIRS: ${{ inputs.consolidate-keep-dirs }}
       run: |
+        # Read the file list from the temp file (see "Get changed files"). Command
+        # substitution strips the trailing newline, so an empty diff yields empty FILES
+        # and the -z guard below still fires.
+        FILES=$(cat "$FILES_PATH")
+
         # Single app fallback: when filter_paths is empty and fallback_app_name is set,
         # return a single-item matrix without detecting changes
         if [[ ( -z "$FILTER_PATHS" || "$FILTER_PATHS" == "[]" ) && -n "$FALLBACK_APP_NAME" ]]; then


### PR DESCRIPTION
Promotes the `changed-paths` ARG_MAX overflow fix (#437) to a stable release.

Cuts **v1.35.1** and — via `self-release`'s `enable_major_tag` on main — advances the floating **`v1`** major tag to include the fix. This unblocks consumers pinned to `changed-paths@v1` (e.g. LerianStudio/midaz#2154), whose CI currently E2BIGs on large diffs.

Delta over main: the fix commit + 2 backmerge bookkeeping chores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflow to improve stability and reliability when processing file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->