### PR TITLE
fix(go-release): add release_single_app for single-release multi-build monorepos

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -159,6 +159,10 @@ on:
         description: 'Newline-separated path patterns that trigger a release/build for all components.'
         type: string
         default: ''
+      release_single_app:
+        description: 'Force single-app mode for the release job even when filter_paths is set. Use for repos with one version tag but multiple Docker images.'
+        type: boolean
+        default: false
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
         type: string
@@ -210,7 +214,7 @@ jobs:
       enable_major_tag: ${{ inputs.enable_major_tag }}
       stable_releases_only: ${{ inputs.stable_releases_only }}
       shared_paths: ${{ inputs.shared_paths }}
-      filter_paths: ${{ inputs.filter_paths }}
+      filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}
     secrets: inherit
 
   # ----------------- Build (tag push) -----------------

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -12,6 +12,15 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 
 > **Note** — As of v1.x this workflow hosts the service release pipeline (semantic-release + Docker build + GitOps). The previous GoReleaser-based binary release pipeline remains available in the Git history of this file.
 
+### Repository layouts
+
+`filter_paths` drives both the release matrix and the build matrix, which covers two layouts:
+
+- **Single app** — `filter_paths` empty: one semantic-release tag, one image.
+- **Per-component monorepo** — `filter_paths` set: each changed component gets its own release tag and its own image.
+
+A third layout needs `release_single_app: true`: **one semantic-release tag for the whole repo, but one image per component**. Set `filter_paths` to the component prefixes (so the tag-push build still produces N images) and `release_single_app: true` so the branch-push release ignores `filter_paths` and runs once from the repo root. Without it, each component spawns a parallel `Semantic Release` job and they race to tag the same branch.
+
 ## Inputs
 
 | Input | Description | Type | Default |
@@ -52,6 +61,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
+| `release_single_app` | Force single-app mode for the release job even when `filter_paths` is set (one version tag, many images) | boolean | `false` |
 
 ## Secrets
 


### PR DESCRIPTION
## Description

`go-release.yml` forwards a single `filter_paths` input to **both** the internal `release` job and the internal `build` job. For repos with N components in `filter_paths`, the `release` job builds an N-entry matrix and spawns N parallel `Semantic Release` jobs that race to tag the same branch and collide (real incident: `plugin-br-pix-switch`, 10 components, single version tag).

This PR adds a non-breaking boolean input `release_single_app` (default `false`). When `true`, the `release` job runs in single-app mode (one semantic-release for the whole repo, `working_dir: .`, app name = repo name) while the `build` job keeps using `filter_paths` to produce one Docker image per component.

This unlocks a third repository layout: **one semantic-release tag + one image per component**.

Workflow(s) affected:
- `.github/workflows/go-release.yml` — new `release_single_app` input; the `release` job now receives `filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}`. The `build` job is unchanged.
- `docs/go-release-workflow.md` — documents the input and the new "Repository layouts" section.

> Note: the expression proposed in the issue (`inputs.release_single_app && '' || inputs.filter_paths`) does not work — in GitHub Actions an empty string is falsy, so `true && '' || filter_paths` always falls through to `filter_paths`. The implemented form puts the empty string on the `||` default (`!inputs.release_single_app && inputs.filter_paths || ''`), which correctly yields `''` when `release_single_app` is `true`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The new input defaults to `false`, preserving the current behavior for every existing caller.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to be validated on `plugin-br-pix-switch` with `release_single_app: true` against this branch._

## Related Issues

Closes #438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `release_single_app` workflow configuration option (boolean, default `false`) to support releasing single applications while preventing path filtering race conditions.

* **Documentation**
  * Expanded release workflow documentation to cover three supported Go service repository release/build layouts: single app deployments, per-component monorepo structures, and single semantic-release tag with multiple image generation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->