### PR TITLE
feat(go-release): support multiple build groups via extra_builds

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -103,6 +103,10 @@ on:
         description: 'JSON mapping of component names to values.yaml keys (e.g., {"my-app": "api"})'
         type: string
         default: ''
+      extra_builds:
+        description: 'JSON array of additional build groups, each forwarded to build.yml with its own config (filter_paths, path_level, app_name_overrides, build_context_from_working_dir, helm_*). Runs alongside the primary build on tag push; all groups feed the single gitops-update. Empty = one build only (default).'
+        type: string
+        default: ''
 
       # ----------------- GitOps Update (gitops-update.yml) -----------------
       enable_gitops_update:
@@ -243,10 +247,48 @@ jobs:
       filter_paths: ${{ inputs.filter_paths }}
     secrets: inherit
 
+  # ----------------- Extra Builds (tag push, opt-in) -----------------
+  extra_build:
+    if: github.ref_type == 'tag' && inputs.extra_builds != ''
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(inputs.extra_builds) }}
+    uses: ./.github/workflows/build.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      enable_dockerhub: ${{ inputs.enable_dockerhub }}
+      enable_ghcr: ${{ inputs.enable_ghcr }}
+      dockerhub_org: ${{ inputs.dockerhub_org }}
+      enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      enable_gitops_artifacts: ${{ matrix.group.enable_gitops_artifacts || true }}
+      filter_paths: ${{ matrix.group.filter_paths }}
+      shared_paths: ${{ matrix.group.shared_paths || inputs.shared_paths }}
+      path_level: ${{ matrix.group.path_level || inputs.path_level }}
+      app_name: ${{ matrix.group.app_name }}
+      app_name_prefix: ${{ matrix.group.app_name_prefix }}
+      app_name_overrides: ${{ matrix.group.app_name_overrides }}
+      build_context_from_working_dir: ${{ matrix.group.build_context_from_working_dir || false }}
+      docker_build_args: ${{ matrix.group.docker_build_args }}
+      enable_helm_dispatch: ${{ matrix.group.enable_helm_dispatch || false }}
+      helm_chart: ${{ matrix.group.helm_chart }}
+      helm_detect_env_changes: ${{ matrix.group.helm_detect_env_changes || true }}
+      helm_values_key_mappings: ${{ matrix.group.helm_values_key_mappings }}
+    secrets: inherit
+
   # ----------------- GitOps Update (tag push) -----------------
   update_gitops:
-    needs: [build]
-    if: github.ref_type == 'tag' && inputs.enable_gitops_update && needs.build.result == 'success' && needs.build.outputs.has_builds == 'true'
+    needs: [build, extra_build]
+    if: >-
+      github.ref_type == 'tag' && inputs.enable_gitops_update && !cancelled() &&
+      needs.build.result != 'failure' && needs.extra_build.result != 'failure' &&
+      ((needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
+       needs.extra_build.result == 'success')
     permissions:
       id-token: write
       contents: read

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -38,6 +38,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `helm_chart` | Helm chart name to update (required when `enable_helm_dispatch`) | string | `''` |
 | `helm_detect_env_changes` | Detect new environment variables for Helm during dispatch | boolean | `true` |
 | `helm_values_key_mappings` | JSON mapping of component names to values.yaml keys | string | `''` |
+| `extra_builds` | JSON array of additional build groups, each forwarded to `build.yml` with its own config; all feed the single gitops-update (see [Multiple build groups](#multiple-build-groups)) | string | `''` |
 | `enable_gitops_update` | Run the gitops-update job on tag push | boolean | `true` |
 | `gitops_repository` | GitOps repository to update (org/repo) | string | `LerianStudio/midaz-firmino-gitops` |
 | `gitops_artifact_pattern` | Pattern to download GitOps artifacts | string | `''` |
@@ -99,6 +100,49 @@ jobs:
         migrations/
         Dockerfile
         Makefile
+    secrets: inherit
+```
+
+## Multiple build groups
+
+By default `go-release` runs **one** `build.yml` call (driven by the top-level `filter_paths`/`app_name_*`/`build_context_from_working_dir` inputs) before the single `update_gitops`. Some repos ship images that need **different build configs in the same release** — e.g. an app + workers built from the repo root, plus a tool/mock image built with `build_context_from_working_dir: true`. These cannot be merged into one `build.yml` call.
+
+Set `extra_builds` to a JSON array of build groups. Each group runs a parallel `build.yml` matrix leg alongside the primary build, and every group uploads its GitOps tag artifacts into the same run, so the single `update_gitops` aggregates all of them. Per-group keys (all optional except `filter_paths`): `filter_paths`, `shared_paths`, `path_level`, `app_name`, `app_name_prefix`, `app_name_overrides`, `build_context_from_working_dir`, `docker_build_args`, `enable_gitops_artifacts` (defaults to `true`), `enable_helm_dispatch`, `helm_chart`, `helm_detect_env_changes`, `helm_values_key_mappings`. Registry/cosign/runner settings are inherited from the top-level inputs.
+
+> **Important** — `update_gitops` downloads artifacts by `gitops_artifact_pattern` (default `gitops-tags-<repo-name>*`). When an extra build produces an image whose name does **not** start with the repo name (e.g. `mock-btg-server`), set `gitops_artifact_pattern` to a wildcard that captures every image (e.g. `gitops-tags-*`), otherwise that image's tag artifact is skipped.
+
+```yaml
+jobs:
+  pipeline:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1
+    with:
+      # Primary build — app + 3 workers from the repo root
+      filter_paths: |
+        components/application
+        components/worker/webhook/inbound
+        components/worker/webhook/outbound
+        components/worker/reconciliation
+      path_level: '4'
+      app_name_prefix: "plugin-br-pix-indirect-btg"
+      app_name_overrides: |
+        components/application:
+        components/worker/webhook/inbound:worker-inbound
+        components/worker/webhook/outbound:worker-outbound
+        components/worker/reconciliation:worker-reconciliation
+      enable_gitops_artifacts: true
+      # Extra build — mock server with its own build context
+      extra_builds: |
+        [
+          {
+            "filter_paths": "tools/mock-btg-server",
+            "path_level": "2",
+            "app_name_overrides": "tools/mock-btg-server:mock-btg-server",
+            "build_context_from_working_dir": true
+          }
+        ]
+      # Wildcard so the mock image's artifact is also picked up
+      gitops_artifact_pattern: "gitops-tags-*"
+      gitops_yaml_key_mappings: '{"plugin-br-pix-indirect-btg.tag": ".pix.image.tag", "worker-inbound.tag": ".inbound.image.tag", "worker-outbound.tag": ".outbound.image.tag", "worker-reconciliation.tag": ".reconciliation.image.tag", "mock-btg-server.tag": ".mock.image.tag"}'
     secrets: inherit
 ```
 


### PR DESCRIPTION
## Description

`go-release.yml` invokes `build.yml` **exactly once** before `update_gitops`. That covers single-image services and monorepos where one `build.yml` call (via `filter_paths` + `app_name_overrides`) produces every image. It does **not** cover repos that need **two or more builds with different configs in the same release** — e.g. `plugin-br-pix-indirect-btg`, which builds an app + 3 workers from the repo root **and** a mock server with `build_context_from_working_dir: true`. The two builds can't be merged (different `path_level` / build context), and `update_gitops` needs the GitOps artifacts from both in the same run.

This PR adds an opt-in `extra_builds` input (JSON array). Each entry runs as a parallel `build.yml` matrix leg alongside the primary build, with its own config; every leg uploads its GitOps tag artifacts into the same run, so the single `update_gitops` aggregates all of them (it already downloads by `gitops_artifact_pattern` across the whole `run-id`).

Workflow(s) affected:
- `.github/workflows/go-release.yml`
  - New `extra_builds` input (string, default `''`).
  - New `extra_build` job — `if: github.ref_type == 'tag' && inputs.extra_builds != ''`, `strategy.matrix.group: ${{ fromJson(inputs.extra_builds) }}`, forwarding per-group config to `build.yml`. Registry/cosign/runner settings are inherited from the top-level inputs; booleans use `${{ matrix.group.x || <default> }}` so omitted keys don't break the typed inputs.
  - `update_gitops` now `needs: [build, extra_build]` and its `if:` runs when neither build failed and at least one produced artifacts. When `extra_builds` is empty the `extra_build` job is skipped and the condition collapses to today's behavior.
- `docs/go-release-workflow.md` — `extra_builds` row + a "Multiple build groups" section with the `plugin-br-pix-indirect-btg` example and the `gitops_artifact_pattern` wildcard note.

> Note: when an extra build produces an image whose name does not start with the repo name (e.g. `mock-btg-server`), the caller must set `gitops_artifact_pattern` to a wildcard (e.g. `gitops-tags-*`) so that image's tag artifact is picked up. Documented in the new section.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `extra_builds` defaults to `''`; absent the input, `go-release` runs exactly one build as today, and `update_gitops`'s gating is unchanged for that path.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to be validated on `plugin-br-pix-indirect-btg` (app + 3 workers + mock) against this branch._

## Related Issues

Closes #436
