### PR TITLE
feat(go-release): derive gitops app_name, commit prefix and artifact pattern from app_name_prefix

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -56,7 +56,7 @@ on:
         type: boolean
         default: false
       app_name:
-        description: 'Override app/image name (single-app mode). Defaults to repository name.'
+        description: 'Override app/image name. Used by the build (single-app mode) and as the gitops-update deploy name; when empty the gitops deploy name falls back to app_name_prefix, then the repository name.'
         type: string
         default: ''
       docker_build_args:
@@ -130,7 +130,7 @@ on:
         type: boolean
         default: true
       commit_message_prefix:
-        description: 'Prefix for the GitOps commit message (defaults to repository name when empty)'
+        description: 'Prefix for the GitOps commit message. When empty, falls back to app_name_prefix, then the repository name.'
         type: string
         default: ''
       deploy_in_firmino:
@@ -256,10 +256,11 @@ jobs:
     with:
       runner_type: ${{ inputs.gitops_runner_type }}
       gitops_repository: ${{ inputs.gitops_repository }}
-      artifact_pattern: ${{ inputs.gitops_artifact_pattern }}
+      app_name: ${{ inputs.app_name || inputs.app_name_prefix }}
+      artifact_pattern: ${{ inputs.gitops_artifact_pattern || format('gitops-tags-{0}*', github.event.repository.name) }}
       yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
       enable_argocd_sync: ${{ inputs.enable_argocd_sync }}
-      commit_message_prefix: ${{ inputs.commit_message_prefix }}
+      commit_message_prefix: ${{ inputs.commit_message_prefix || inputs.app_name_prefix }}
       deploy_in_firmino: ${{ inputs.deploy_in_firmino }}
       deploy_in_clotilde: ${{ inputs.deploy_in_clotilde }}
       use_dynamic_mapping: ${{ inputs.use_dynamic_mapping }}

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -26,7 +26,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `enable_dockerhub` | Push image to DockerHub | boolean | `true` |
 | `enable_ghcr` | Push image to GitHub Container Registry (requires `MANAGE_TOKEN`) | boolean | `true` |
 | `enable_gitops_artifacts` | Upload GitOps artifacts for the downstream update | boolean | `false` |
-| `app_name` | Override app/image name (single-app mode) | string | `''` (repo name) |
+| `app_name` | Override app/image name (build single-app mode + gitops deploy name). Empty → gitops name derives from `app_name_prefix`, then repo name | string | `''` |
 | `docker_build_args` | Newline-separated Docker build args | string | `''` |
 | `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
 | `app_name_prefix` | Prefix for app names in monorepo (e.g. `midaz` -> `midaz-agent`) | string | `''` |
@@ -40,11 +40,11 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `helm_values_key_mappings` | JSON mapping of component names to values.yaml keys | string | `''` |
 | `enable_gitops_update` | Run the gitops-update job on tag push | boolean | `true` |
 | `gitops_repository` | GitOps repository to update (org/repo) | string | `LerianStudio/midaz-firmino-gitops` |
-| `gitops_artifact_pattern` | Pattern to download GitOps artifacts | string | `''` |
+| `gitops_artifact_pattern` | Pattern to download GitOps artifacts. Empty → `gitops-tags-<repo-name>*` | string | `''` |
 | `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
 | `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `firmino-lxc-runners` |
 | `enable_argocd_sync` | Trigger ArgoCD sync after updating the GitOps repo | boolean | `true` |
-| `commit_message_prefix` | Prefix for the GitOps commit message (defaults to repo name when empty) | string | `''` |
+| `commit_message_prefix` | Prefix for the GitOps commit message. Empty → `app_name_prefix`, then repo name | string | `''` |
 | `deploy_in_firmino` | Force-off override for Firmino; set `false` to suppress deployment even when the manifest includes the app | boolean | `true` |
 | `deploy_in_clotilde` | Force-off override for Clotilde; set `false` to suppress deployment even when the manifest includes the app | boolean | `true` |
 | `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
@@ -52,6 +52,8 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
+
+> **Derived gitops defaults** — to slim down gitops/helm plugin callers, three gitops-update inputs derive from `app_name_prefix` / the repo name when left unset: `commit_message_prefix` → `app_name_prefix`; the gitops deploy `app_name` → `app_name_prefix`; `gitops_artifact_pattern` → `gitops-tags-<repo-name>*`. Set any of them explicitly to override (e.g. a repo whose deploy app name differs from its `app_name_prefix`, or a monorepo needing a different artifact suffix). All derivations fall back to the repository name when `app_name_prefix` is also empty, preserving the previous behavior.
 
 ## Secrets
 


### PR DESCRIPTION
## Description

Follow-up DX cleanup (depends on #432, already merged) for the gitops/helm plugin standardization. Several `gitops-update` inputs were repeated in every plugin caller despite being mechanically derivable from `app_name_prefix` or the repository name. This PR makes `go-release.yml` derive sensible defaults so callers only pass the truly repo-specific inputs.

Derivations (umbrella-level only; `gitops-update.yml` unchanged), all overridable, applied only when the input is unset:

- `commit_message_prefix` → `app_name_prefix`
- gitops deploy `app_name` → `app_name_prefix` (new passthrough — `update_gitops` did not forward `app_name` before, so it used the repo name)
- `artifact_pattern` → `gitops-tags-<repo-name>*`

All three fall back to the repository name when `app_name_prefix` is also empty, preserving the previous behavior. The `*` is kept on the artifact pattern to match the current effective default (`gitops-update` already appended it), so monorepo repos relying on the implicit wildcard do not regress.

Workflow(s) affected:
- `.github/workflows/go-release.yml` — `update_gitops` `with:` now derives `app_name`, `artifact_pattern`, `commit_message_prefix`; descriptions of `app_name` and `commit_message_prefix` updated. The build job's `app_name` passthrough is unchanged (build only uses it in single-app mode).
- `docs/go-release-workflow.md` — updated the three input rows and added a "Derived gitops defaults" note.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None for the common case (repo name == `app_name_prefix`, which holds for the standardized plugins). Caveat to be aware of: for a repo where `app_name_prefix` is set, differs from the repo name, and no explicit `app_name`/`commit_message_prefix` is provided, the gitops deploy name and commit prefix now derive from `app_name_prefix` instead of the repo name — which is the intended behavior (4/5 plugins) and remains overridable (e.g. `plugin-identity` sets `app_name` explicitly to deploy `plugin-access-manager`).

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to be validated on a gitops plugin (e.g. `plugin-fees`) against this branch._

## Related Issues

Closes #434
