### PR TITLE
feat(go-release): add opt-in ApiDog E2E test job after gitops-update

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -154,6 +154,20 @@ on:
         type: boolean
         default: false
 
+      # ----------------- API Dog E2E (api-dog-e2e-tests.yml) -----------------
+      enable_apidog_e2e:
+        description: 'Run the ApiDog E2E test job on tag push after a successful gitops-update'
+        type: boolean
+        default: false
+      apidog_runner_type:
+        description: 'Runner for the ApiDog E2E test job. Needs reach to the deployed environment, so it defaults to firmino-lxc-runners rather than the build runner.'
+        type: string
+        default: 'firmino-lxc-runners'
+      apidog_auto_detect_environment:
+        description: 'Auto-detect the ApiDog environment from the tag (beta -> dev, rc -> stg). When false, the manual APIDOG_ENVIRONMENT_ID secret is used.'
+        type: boolean
+        default: true
+
       # ----------------- Shared -----------------
       shared_paths:
         description: 'Newline-separated path patterns that trigger a release/build for all components.'
@@ -169,6 +183,16 @@ on:
       SLACK_WEBHOOK_URL:
         required: false
       HELM_REPO_TOKEN:
+        required: false
+      APIDOG_TEST_SCENARIO_ID:
+        required: false
+      APIDOG_ACCESS_TOKEN:
+        required: false
+      APIDOG_DEV_ENVIRONMENT_ID:
+        required: false
+      APIDOG_STG_ENVIRONMENT_ID:
+        required: false
+      APIDOG_ENVIRONMENT_ID:
         required: false
 
 permissions:
@@ -266,3 +290,18 @@ jobs:
       configmap_updates: ${{ inputs.configmap_updates }}
       enable_docker_login: ${{ inputs.enable_docker_login }}
     secrets: inherit
+
+  # ----------------- API Dog E2E Tests (tag push, post-gitops, opt-in) -----------------
+  api_dog_e2e_tests:
+    needs: [update_gitops]
+    if: github.ref_type == 'tag' && inputs.enable_apidog_e2e && needs.update_gitops.result == 'success'
+    uses: ./.github/workflows/api-dog-e2e-tests.yml
+    with:
+      runner_type: ${{ inputs.apidog_runner_type }}
+      auto_detect_environment: ${{ inputs.apidog_auto_detect_environment }}
+    secrets:
+      test_scenario_id: ${{ secrets.APIDOG_TEST_SCENARIO_ID }}
+      apidog_access_token: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+      dev_environment_id: ${{ secrets.APIDOG_DEV_ENVIRONMENT_ID }}
+      stg_environment_id: ${{ secrets.APIDOG_STG_ENVIRONMENT_ID }}
+      environment_id: ${{ secrets.APIDOG_ENVIRONMENT_ID }}

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -50,6 +50,9 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
 | `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
+| `enable_apidog_e2e` | Run the ApiDog E2E test job on tag push after a successful gitops-update | boolean | `false` |
+| `apidog_runner_type` | Runner for the ApiDog E2E test job (needs reach to the deployed environment) | string | `firmino-lxc-runners` |
+| `apidog_auto_detect_environment` | Auto-detect the ApiDog environment from the tag (beta → dev, rc → stg); when `false`, uses `APIDOG_ENVIRONMENT_ID` | boolean | `true` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 
@@ -60,6 +63,11 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `MANAGE_TOKEN` | Token for release commits, tags and private module access | No |
 | `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
 | `HELM_REPO_TOKEN` | Token for dispatching Helm chart updates (when enabled in build) | No |
+| `APIDOG_TEST_SCENARIO_ID` | ApiDog test scenario ID (required when `enable_apidog_e2e`) | No |
+| `APIDOG_ACCESS_TOKEN` | ApiDog access token (required when `enable_apidog_e2e`) | No |
+| `APIDOG_DEV_ENVIRONMENT_ID` | ApiDog dev environment ID (used for beta tags in auto-detect mode) | No |
+| `APIDOG_STG_ENVIRONMENT_ID` | ApiDog staging environment ID (used for rc tags in auto-detect mode) | No |
+| `APIDOG_ENVIRONMENT_ID` | ApiDog environment ID for manual mode (`apidog_auto_detect_environment: false`) | No |
 
 ## Usage
 
@@ -102,6 +110,28 @@ jobs:
     secrets: inherit
 ```
 
+## ApiDog E2E tests
+
+Set `enable_apidog_e2e: true` to run [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) on tag push after a successful `update_gitops`. The job is skipped on branch pushes and when the gitops update did not succeed.
+
+Because the underlying workflow expects fixed secret names (`test_scenario_id`, `apidog_access_token`, …), the ApiDog secrets **cannot** be passed via `secrets: inherit` — map them explicitly to the `APIDOG_*` secrets this workflow declares. With `apidog_auto_detect_environment: true` (default), the tag type selects the environment (`-beta.` → `APIDOG_DEV_ENVIRONMENT_ID`, `-rc.` → `APIDOG_STG_ENVIRONMENT_ID`); the underlying workflow errors on tags that are neither beta nor rc, so enable it only for repos that tag pre-release. For manual mode set `apidog_auto_detect_environment: false` and provide `APIDOG_ENVIRONMENT_ID`.
+
+```yaml
+jobs:
+  pipeline:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1
+    with:
+      enable_gitops_artifacts: true
+      enable_apidog_e2e: true
+    secrets:
+      MANAGE_TOKEN: ${{ secrets.MANAGE_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      APIDOG_TEST_SCENARIO_ID: ${{ secrets.MIDAZ_APIDOG_TEST_SCENARIO_ID }}
+      APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+      APIDOG_DEV_ENVIRONMENT_ID: ${{ secrets.MIDAZ_APIDOG_DEV_ENVIRONMENT_ID }}
+      APIDOG_STG_ENVIRONMENT_ID: ${{ secrets.MIDAZ_APIDOG_STG_ENVIRONMENT_ID }}
+```
+
 ## Permissions
 
 The single caller job must grant the union of what the internal jobs need: `id-token: write`, `contents: write`, `packages: write`, `pull-requests: write`, `issues: write`.
@@ -111,4 +141,5 @@ The single caller job must grant the union of what the internal jobs need: `id-t
 - [release](./release-workflow.md) — semantic-release pipeline this umbrella calls
 - [build](./build-workflow.md) — container build & push this umbrella calls
 - [gitops-update](./gitops-update-workflow.md) — GitOps update this umbrella calls
+- [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) — optional post-gitops E2E tests this umbrella calls
 - [go-pr-validation](./go-pr-validation.md) — the matching PR validation umbrella


### PR DESCRIPTION
## Description

`midaz` runs ApiDog E2E tests after its gitops update succeeds, using the existing `api-dog-e2e-tests.yml` reusable workflow. The consolidated `go-release.yml` had no post-gitops hook for that, blocking midaz from migrating off the standalone `build.yml`.

This PR adds an **opt-in** ApiDog E2E job to `go-release.yml` on the tag-push path, after `update_gitops`.

Workflow(s) affected:
- `.github/workflows/go-release.yml`
  - New inputs: `enable_apidog_e2e` (boolean, default `false`), `apidog_runner_type` (string, default `firmino-lxc-runners`), `apidog_auto_detect_environment` (boolean, default `true`).
  - New secrets (all `required: false`): `APIDOG_TEST_SCENARIO_ID`, `APIDOG_ACCESS_TOKEN`, `APIDOG_DEV_ENVIRONMENT_ID`, `APIDOG_STG_ENVIRONMENT_ID`, `APIDOG_ENVIRONMENT_ID`.
  - New job `api_dog_e2e_tests` — `needs: [update_gitops]`, `if: github.ref_type == 'tag' && inputs.enable_apidog_e2e && needs.update_gitops.result == 'success'`, calling `api-dog-e2e-tests.yml` with the ApiDog secrets mapped explicitly.
- `docs/go-release-workflow.md` — input/secret rows + an "ApiDog E2E tests" section with a caller example.

> Note on secrets: `api-dog-e2e-tests.yml` expects fixed lowercase secret names (`test_scenario_id`, `apidog_access_token`, …), so they **cannot** be passed via `secrets: inherit` (name mismatch). The umbrella declares `APIDOG_*` secrets and maps them explicitly; callers map their repo-specific secrets to those names (documented). `apidog_auto_detect_environment` (default true) selects the environment from the tag (`-beta.` → dev, `-rc.` → stg); the underlying workflow errors on non-beta/rc tags, so enable it only for repos that tag pre-release. `environment_id` is forwarded so manual mode (`apidog_auto_detect_environment: false`) also works.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The job is opt-in (`enable_apidog_e2e` defaults to `false`) and all new secrets are optional. Existing callers are unaffected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to be validated on `midaz` with `enable_apidog_e2e: true` against this branch (also depends on #442)._

## Related Issues

Closes #443


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional API Dog end-to-end testing support for tag releases, with configurable runner selection and automatic environment detection based on release tags.

* **Documentation**
  * Added comprehensive documentation for the new E2E testing feature, including setup instructions, configuration details, and practical usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->