### PR TITLE
feat(go-release): add opt-in S3 upload job after build for migration files

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -154,6 +154,12 @@ on:
         type: boolean
         default: false
 
+      # ----------------- S3 Upload (s3-upload.yml) -----------------
+      s3_uploads:
+        description: 'JSON array of S3 upload entries run after build on tag push, each forwarded to s3-upload.yml. Each object: {"s3_bucket": "...", "file_pattern": "...", "s3_prefix": "..."} (s3_prefix optional). Empty = no upload (default).'
+        type: string
+        default: ''
+
       # ----------------- Shared -----------------
       shared_paths:
         description: 'Newline-separated path patterns that trigger a release/build for all components.'
@@ -169,6 +175,8 @@ on:
       SLACK_WEBHOOK_URL:
         required: false
       HELM_REPO_TOKEN:
+        required: false
+      AWS_MIGRATIONS_ROLE_ARN:
         required: false
 
 permissions:
@@ -242,6 +250,26 @@ jobs:
       shared_paths: ${{ inputs.shared_paths }}
       filter_paths: ${{ inputs.filter_paths }}
     secrets: inherit
+
+  # ----------------- S3 Upload (tag push, post-build, opt-in) -----------------
+  s3_upload:
+    needs: [build]
+    if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result == 'success'
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        upload: ${{ fromJson(inputs.s3_uploads) }}
+    uses: ./.github/workflows/s3-upload.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      s3_bucket: ${{ matrix.upload.s3_bucket }}
+      file_pattern: ${{ matrix.upload.file_pattern }}
+      s3_prefix: ${{ matrix.upload.s3_prefix }}
+    secrets:
+      AWS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
 
   # ----------------- GitOps Update (tag push) -----------------
   update_gitops:

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -50,6 +50,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
 | `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
+| `s3_uploads` | JSON array of S3 upload entries run after build on tag push (see [S3 migrations upload](#s3-migrations-upload)) | string | `''` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 
@@ -60,6 +61,7 @@ Umbrella reusable workflow for Go **service** repositories (deployable apps that
 | `MANAGE_TOKEN` | Token for release commits, tags and private module access | No |
 | `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
 | `HELM_REPO_TOKEN` | Token for dispatching Helm chart updates (when enabled in build) | No |
+| `AWS_MIGRATIONS_ROLE_ARN` | IAM role ARN assumed by the S3 upload job (required when `s3_uploads` is set) | No |
 
 ## Usage
 
@@ -102,6 +104,36 @@ jobs:
     secrets: inherit
 ```
 
+## S3 migrations upload
+
+Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. Each entry runs as a parallel [s3-upload](./s3-upload.md) matrix leg and is independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional); the remaining `s3-upload.yml` knobs (`flatten`, `strip_prefix`, `aws_region`) keep their defaults, and the target environment folder is auto-detected from the tag (`-beta.` → development, `-rc.` → staging, `vX.Y.Z` → production).
+
+All entries share the `AWS_MIGRATIONS_ROLE_ARN` secret (forwarded to `s3-upload.yml`'s `AWS_ROLE_ARN`); map it explicitly in the caller.
+
+```yaml
+jobs:
+  pipeline:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@v1
+    with:
+      enable_gitops_artifacts: true
+      s3_uploads: |
+        [
+          {
+            "s3_bucket": "lerian-migration-files",
+            "file_pattern": "components/ledger/migrations/onboarding/*.sql",
+            "s3_prefix": "ledger/onboarding/postgresql"
+          },
+          {
+            "s3_bucket": "lerian-migration-files",
+            "file_pattern": "components/ledger/migrations/transaction/*.sql",
+            "s3_prefix": "ledger/transaction/postgresql"
+          }
+        ]
+    secrets:
+      MANAGE_TOKEN: ${{ secrets.MANAGE_TOKEN }}
+      AWS_MIGRATIONS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
+```
+
 ## Permissions
 
 The single caller job must grant the union of what the internal jobs need: `id-token: write`, `contents: write`, `packages: write`, `pull-requests: write`, `issues: write`.
@@ -111,4 +143,5 @@ The single caller job must grant the union of what the internal jobs need: `id-t
 - [release](./release-workflow.md) — semantic-release pipeline this umbrella calls
 - [build](./build-workflow.md) — container build & push this umbrella calls
 - [gitops-update](./gitops-update-workflow.md) — GitOps update this umbrella calls
+- [s3-upload](./s3-upload.md) — optional post-build S3 upload this umbrella calls
 - [go-pr-validation](./go-pr-validation.md) — the matching PR validation umbrella


### PR DESCRIPTION
## Description

`midaz` and `lerian-notification` cannot migrate to `go-release.yml` because their standalone `build.yml` includes an S3 upload step for SQL migration files (after `build`, using `AWS_MIGRATIONS_ROLE_ARN`), which `go-release.yml` did not support.

This PR adds an **opt-in** S3 upload job to `go-release.yml` on the tag-push path, after `build`. It uses a JSON-array input so a repo can run one or many uploads (midaz uploads two sets, lerian-notification one) — consistent with the `extra_builds` shape. The existing `s3-upload.yml` reusable workflow performs the actual upload.

Workflow(s) affected:
- `.github/workflows/go-release.yml`
  - New input `s3_uploads` (string, default `''`) — JSON array of `{s3_bucket, file_pattern, s3_prefix?}` entries.
  - New secret `AWS_MIGRATIONS_ROLE_ARN` (`required: false`), forwarded to `s3-upload.yml`'s `AWS_ROLE_ARN`.
  - New job `s3_upload` — `needs: [build]`, `if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result == 'success'`, `strategy.matrix.upload: ${{ fromJson(inputs.s3_uploads) }}`, calling `s3-upload.yml`.
- `docs/go-release-workflow.md` — input/secret rows + an "S3 migrations upload" section with the midaz example.

Design notes:
- **JSON matrix** (not scalar inputs) so midaz's two upload entries are covered with one API, consistent with `extra_builds`.
- **Gated on `needs.build.result == 'success'` only** (not `has_builds`): the upload reads repo files (migrations), not build artifacts, so it must not be tied to image production. It runs in parallel with `update_gitops`.
- **Per-entry fields** kept minimal (`s3_bucket`, `file_pattern`, `s3_prefix`); the other `s3-upload.yml` knobs (`flatten`, `strip_prefix`, `aws_region`, `environment_detection`) keep their defaults, which is exactly what the target repos use.
- **Secret name `AWS_MIGRATIONS_ROLE_ARN`** matches what both repos already use; it cannot be inherited (name mismatch with `s3-upload.yml`'s `AWS_ROLE_ARN`), so it's mapped explicitly — callers map it in their `secrets:` block.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The job is opt-in (`s3_uploads` defaults to `''`) and the new secret is optional. Existing callers are unaffected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to be validated on `midaz` (two migration sets) and `lerian-notification` against this branch._

## Related Issues

Closes #442
