### PR TITLE
fix(security): make prerelease-check annotation branch-aware

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -233,6 +233,8 @@ jobs:
         with:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
+          target-branch: ${{ github.base_ref }}
+          block-branches: ${{ inputs.prerelease_block_branches }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post Security Scan Results to PR

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -13,6 +13,8 @@ Composite action that scans dependency files for unstable version pins. Only sta
 |---|---|:---:|---|
 | `scan-ref` | Directory to scan for pre-release versions | No | `.` |
 | `app-name` | Application name for reporting context | No | `''` |
+| `target-branch` | PR target branch (e.g. `github.base_ref`). Selects the annotation level (see below). Empty = warning | No | `''` |
+| `block-branches` | Comma-separated branches where pre-release pins annotate as error. Must match the downstream gate | No | `release-candidate,main` |
 
 ## Outputs
 
@@ -21,6 +23,10 @@ Composite action that scans dependency files for unstable version pins. Only sta
 | `has-findings` | `true` if unstable versions were detected |
 | `findings-count` | Number of unstable version findings |
 | `artifact-file` | Path to the JSON findings file for consumption by `pr-security-reporter` |
+
+## Annotation level
+
+This action never fails the job itself — it only reports. The summary annotation level mirrors the branch policy so it does not contradict a downstream branch-aware gate: when `target-branch` is one of `block-branches`, findings annotate as `::error::`; otherwise (including an empty/unknown `target-branch`) they annotate as `::warning::`. Per-finding line annotations are always warnings. Enforcement (`exit 1`) belongs to the consuming workflow's gate, not to this action.
 
 ## What it scans
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: 'Application name for reporting context'
     required: false
     default: ''
+  target-branch:
+    description: 'PR target branch (e.g. github.base_ref). Selects the annotation level: pre-release pins annotate as error on blocking branches, warning elsewhere. Empty = warning.'
+    required: false
+    default: ''
+  block-branches:
+    description: 'Comma-separated branches where pre-release pins are blocking (annotated as error). Must match the downstream gate. Default: release-candidate,main.'
+    required: false
+    default: 'release-candidate,main'
 
 outputs:
   has-findings:
@@ -31,6 +39,8 @@ runs:
       env:
         SCAN_DIR: ${{ inputs.scan-ref }}
         APP_NAME: ${{ inputs.app-name }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        BLOCK_BRANCHES: ${{ inputs.block-branches }}
       run: |
         # Matches x.y.z-<letter...> — any semver with a pre-release suffix starting
         # with a letter (alpha, beta, rc, dev, preview, canary, snapshot, etc.).
@@ -110,7 +120,25 @@ runs:
           LABEL=""
           [ -n "$APP_NAME" ] && LABEL=" ($APP_NAME)"
 
-          echo "::error::Found $COUNT unstable version pin(s)${LABEL}. Only stable versions (x.y.z) and SHA-based pins are allowed."
+          # Annotation level mirrors the downstream branch-aware gate: error on
+          # blocking branches (where the pin hard-fails the job), warning
+          # elsewhere (advisory). An empty/unknown target branch is non-blocking.
+          IS_BLOCKING=false
+          IFS=',' read -ra BLOCK_LIST <<< "$BLOCK_BRANCHES"
+          for branch in "${BLOCK_LIST[@]}"; do
+            branch=$(echo "$branch" | xargs)
+            if [ -n "$TARGET_BRANCH" ] && [ "$TARGET_BRANCH" = "$branch" ]; then
+              IS_BLOCKING=true
+              break
+            fi
+          done
+
+          MSG="Found $COUNT unstable version pin(s)${LABEL}. Only stable versions (x.y.z) and SHA-based pins are allowed."
+          if [ "$IS_BLOCKING" = "true" ]; then
+            echo "::error::$MSG"
+          else
+            echo "::warning::$MSG"
+          fi
 
           # Build JSON array of findings for the reporter step.
           {


### PR DESCRIPTION
## Description

Closes the residual half of #425. The pre-release **exit-code** behaviour was already branch-aware (warn on `develop`, fail on `release-candidate`/`main` via the workflow gate), but the `prerelease-check` composite still emitted an `::error::` **annotation** unconditionally (`src/security/prerelease-check/action.yml`), regardless of target branch.

That branch-blind `::error::` contradicted the downstream gate (which says the pin is *allowed* on `develop`) and is exactly what caused the triage confusion in the original report: on `underwriter` PR #31 (base `develop`, pinned `pr-security-scan.yml@v1.28.7` — which already had the exit-code fix), the job's `exit 1` came from a genuine Trivy CVE on the RC dependency, while the red `prerelease-check` annotation made it look like the pre-release pin caused the failure.

This PR makes the annotation level mirror the branch policy:
- `target-branch` ∈ `block-branches` (default `release-candidate,main`) → `::error::`
- otherwise (including an empty/unknown branch) → `::warning::`

Enforcement (`exit 1`) stays in the workflow's `Gate - Fail on Pre-release Versions` step — unchanged. Only the annotation level moves.

Workflow(s)/action(s) affected:
- `src/security/prerelease-check/action.yml` — new `target-branch` / `block-branches` inputs; the summary annotation is emitted as `::error::` on blocking branches and `::warning::` elsewhere. Per-finding line annotations remain warnings.
- `.github/workflows/pr-security-scan.yml` — passes `target-branch: ${{ github.base_ref }}` and `block-branches: ${{ inputs.prerelease_block_branches }}` to the composite.
- `src/security/prerelease-check/README.md` — documents the two inputs and the annotation-level behaviour.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None to enforcement. One behavioural nuance: callers invoking `prerelease-check@v1` **without** passing `target-branch` will see the summary annotation downgrade from `::error::` to `::warning::` when the branch is unknown. This is annotation-only (it never set `exit 1`), and the real blocking still lives in the consuming workflow's branch-aware gate. The `pr-security-scan` workflow always supplies `github.base_ref`, so on PRs: `develop` → warning, `release-candidate`/`main` → error.

## Testing

- [x] YAML syntax validated locally (action + workflow)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on a `develop` PR carrying a pre-release pin (annotation should be a warning, job green) and an `rc`/`main` PR (annotation error, job red)._

## Related Issues

Closes #425
