### PR TITLE
fix(go-pr-analysis): ship default .ignorecoverunit coverage exclusions

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -521,8 +521,31 @@ jobs:
             IGNORE_FILE="$GITHUB_WORKSPACE/.ignorecoverunit"
             echo "Using .ignorecoverunit from repository root"
           else
-            echo "No .ignorecoverunit file found, using full coverage"
-            exit 0
+            # No repo-provided file — fall back to the shared module default so
+            # common non-unit-testable paths (mocks, cmd/bootstrap, generated
+            # API docs, e2e suites, testutil) are excluded out of the box.
+            # A repo opts out by committing an empty .ignorecoverunit.
+            IGNORE_FILE="$RUNNER_TEMP/.ignorecoverunit.default"
+            cat > "$IGNORE_FILE" <<'DEFAULT_IGNORECOVERUNIT'
+          # Auto-generated mocks
+          *_mock.go
+
+          # Bootstrap / entrypoints
+          /bootstrap/
+          /cmd/
+          bootstrap.go
+
+          # Generated API docs
+          /api/
+
+          # E2E and integration test directories
+          /test/e2e/
+          /tests/e2e/
+
+          # Testutil helpers
+          /internal/testutil/
+          DEFAULT_IGNORECOVERUNIT
+            echo "No .ignorecoverunit file found — applying shared module default exclusions"
           fi
 
           echo "Filtering coverage with .ignorecoverunit patterns..."

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -305,10 +305,27 @@ swagger.go
 - Lines starting with `#` are comments
 - Empty lines are ignored
 
+### Default exclusions
+
+When a repo does **not** provide its own `.ignorecoverunit`, the shared workflow applies a built-in default so the most common non-unit-testable paths are excluded out of the box:
+
+```
+*_mock.go
+/bootstrap/
+/cmd/
+bootstrap.go
+/api/
+/test/e2e/
+/tests/e2e/
+/internal/testutil/
+```
+
+Precedence (first match wins): working-directory `.ignorecoverunit` → repository-root `.ignorecoverunit` → built-in default. A repo-provided file fully replaces the default (the two are not merged). To opt out of all exclusions and report full coverage, commit an **empty** `.ignorecoverunit`.
+
 ### How It Works
 
-1. After tests run and generate `coverage.txt`, the workflow checks for `.ignorecoverunit`
-2. If found, patterns are converted to regex and used to filter coverage data
+1. After tests run and generate `coverage.txt`, the workflow looks for `.ignorecoverunit` (working dir, then repo root); if neither exists it uses the built-in default above
+2. Patterns are converted to regex and used to filter coverage data
 3. Filtered coverage is used for threshold checks and PR comments
 4. Works regardless of whether Makefile or direct Go commands were used
 


### PR DESCRIPTION
## Description

`go-pr-analysis` supports a `.ignorecoverunit` file to exclude non-unit-testable paths (mocks, bootstrap/cmd, generated API docs, e2e suites, testutil) from coverage reporting, but the shared module shipped **no default** — every repo had to discover and maintain its own file, and repos without one reported false-low coverage on those paths.

This PR ships a built-in default: when a repo provides no `.ignorecoverunit`, the `Filter coverage with .ignorecoverunit` step now falls back to a sensible default set instead of reporting full (noisy) coverage.

Default patterns:
```
*_mock.go
/bootstrap/
/cmd/
bootstrap.go
/api/
/test/e2e/
/tests/e2e/
/internal/testutil/
```

Precedence (unchanged ordering, default appended last): working-directory `.ignorecoverunit` → repository-root `.ignorecoverunit` → built-in default. A repo-provided file fully replaces the default (no merge). Opt-out of all exclusions = commit an **empty** `.ignorecoverunit` (empty patterns → full coverage, existing behavior).

Workflow(s) affected:
- `.github/workflows/go-pr-analysis.yml` — the "no file found" branch now writes the default patterns to `$RUNNER_TEMP/.ignorecoverunit.default` and filters with them.
- `docs/go-pr-analysis-workflow.md` — documents the default set, precedence, and the empty-file opt-out.

Design note: the default is **embedded inline** in the workflow rather than committed as a canonical file and fetched. `go-pr-analysis.yml` is a reusable workflow that runs on the caller's checkout and does not have this repo's files available without an extra checkout; inlining keeps a single source of truth with no added checkout/network dependency.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None for the coverage gate. Behavioural nuance: repos **without** a `.ignorecoverunit` will now exclude the default paths, so reported coverage shifts (generally **up**, since excluded paths are typically low-coverage) — making the `fail_on_coverage_threshold` gate (default 80%) *less* likely to fail, never more. This is the intended noise reduction. Repos wanting the previous full-coverage behaviour commit an empty `.ignorecoverunit`.

## Testing

- [x] YAML syntax validated locally
- [x] Simulated the heredoc → pattern-extraction → coverage-filter pipeline locally (only genuine unit files survive; mocks/cmd/testutil/e2e excluded)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified existing behaviour preserved (repo-provided file still takes precedence; empty file = full coverage)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on a Go repo without its own `.ignorecoverunit` (default applied) and one with its own file (override preserved)._

## Related Issues

Closes #424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverage analysis now applies default exclusion patterns for auto-generated code, test utilities, and similar files when no custom configuration is provided.

* **Documentation**
  * Updated documentation to clarify coverage exclusion defaults, configuration file precedence, and customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->