### PR TITLE
fix(build): pre-flight tag existence check + restore continue-on-signing-failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ on:
         description: 'GHCR organization name (defaults to repository owner)'
         type: string
         default: ''
+      on_existing_tag:
+        description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push, still emit GitOps artifacts for an idempotent re-run), or "warn" (warn and build anyway).'
+        type: string
+        default: 'fail'
       dockerfile_name:
         description: 'Name of the Dockerfile'
         type: string
@@ -311,7 +315,67 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION from tag: $TAG"
 
+      - name: Pre-flight tag existence check
+        id: preflight
+        env:
+          ON_EXISTING_TAG: ${{ inputs.on_existing_tag }}
+          ENABLE_DOCKERHUB: ${{ inputs.enable_dockerhub }}
+          ENABLE_GHCR: ${{ inputs.enable_ghcr }}
+          DOCKERHUB_ORG: ${{ inputs.dockerhub_org }}
+          GHCR_ORG: ${{ inputs.ghcr_org || steps.normalize.outputs.owner_lower }}
+          APP_NAME: ${{ matrix.app.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -uo pipefail
+
+          MODE="${ON_EXISTING_TAG:-fail}"
+          case "$MODE" in
+            fail|skip|warn) ;;
+            *) echo "::error::Invalid on_existing_tag '$MODE' (must be: fail, skip, warn)"; exit 1 ;;
+          esac
+
+          # Image tag matches what docker/metadata-action publishes (semver without leading 'v').
+          TAG="${VERSION#v}"
+          EXISTING=""
+
+          # `docker manifest inspect` reuses the registry logins from earlier steps and
+          # returns non-zero when the tag is absent. A non-existence/error result is
+          # treated as "not present" so a flaky check never blocks a legitimate build.
+          if [ "$ENABLE_DOCKERHUB" = "true" ]; then
+            REF="${DOCKERHUB_ORG}/${APP_NAME}:${TAG}"
+            if docker manifest inspect "$REF" >/dev/null 2>&1; then
+              EXISTING="${EXISTING}${EXISTING:+, }docker.io/${REF}"
+            fi
+          fi
+          if [ "$ENABLE_GHCR" = "true" ]; then
+            REF="ghcr.io/${GHCR_ORG}/${APP_NAME}:${TAG}"
+            if docker manifest inspect "$REF" >/dev/null 2>&1; then
+              EXISTING="${EXISTING}${EXISTING:+, }${REF}"
+            fi
+          fi
+
+          SHOULD_BUILD=true
+          if [ -n "$EXISTING" ]; then
+            case "$MODE" in
+              fail)
+                echo "::error::Tag ${TAG} already exists (${EXISTING}). Registry tags are immutable; aborting before rebuild. Use on_existing_tag: skip for idempotent re-runs."
+                exit 1
+                ;;
+              skip)
+                echo "::warning::Tag ${TAG} already exists (${EXISTING}) — skipping build/push (idempotent re-run)."
+                SHOULD_BUILD=false
+                ;;
+              warn)
+                echo "::warning::Tag ${TAG} already exists (${EXISTING}) — building anyway (push may fail on immutable registries)."
+                ;;
+            esac
+          else
+            echo "Tag ${TAG} not present in enabled registries — proceeding with build."
+          fi
+          echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
+
       - name: Docker metadata
+        if: steps.preflight.outputs.should_build != 'false'
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
@@ -320,6 +384,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
 
       - name: Build and push Docker image
+        if: steps.preflight.outputs.should_build != 'false'
         id: build-push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
@@ -339,7 +404,7 @@ jobs:
 
       # ----------------- Cosign Image Signing -----------------
       - name: Build cosign image references
-        if: inputs.enable_cosign_sign
+        if: inputs.enable_cosign_sign && steps.preflight.outputs.should_build != 'false'
         id: cosign-refs
         env:
           DIGEST: ${{ steps.build-push.outputs.digest }}
@@ -367,9 +432,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Sign container images with cosign
-        if: inputs.enable_cosign_sign
+        if: inputs.enable_cosign_sign && steps.preflight.outputs.should_build != 'false'
         id: cosign-sign
-        continue-on-error: ${{ inputs.continue_gitops_on_signing_failure }}
+        continue-on-error: ${{ inputs.continue_gitops_on_signing_failure || false }}
         uses: LerianStudio/github-actions-shared-workflows/src/security/cosign-sign@v1
         with:
           image-refs: ${{ steps.cosign-refs.outputs.refs }}
@@ -377,7 +442,7 @@ jobs:
           initial-delay: ${{ inputs.cosign_initial_delay }}
 
       - name: Report cosign signing status
-        if: inputs.enable_cosign_sign && steps.cosign-sign.outcome == 'failure'
+        if: inputs.enable_cosign_sign && steps.preflight.outputs.should_build != 'false' && steps.cosign-sign.outcome == 'failure'
         env:
           REFS: ${{ steps.cosign-refs.outputs.refs }}
           DIGEST: ${{ steps.build-push.outputs.digest }}

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -102,6 +102,7 @@ jobs:
 | `enable_ghcr` | boolean | `true` | Enable pushing to GitHub Container Registry (requires `MANAGE_TOKEN`) |
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `ghcr_org` | string | `''` | GHCR organization (defaults to repository owner) |
+| `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push, still emit GitOps artifacts for an idempotent re-run), `warn` (warn and build anyway) |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
 | `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
 | `build_context` | string | `.` | Docker build context |
@@ -122,6 +123,16 @@ Uses `secrets: inherit` pattern. Required secrets:
 | `DOCKER_PASSWORD` | DockerHub password/token | `enable_dockerhub: true` |
 | `MANAGE_TOKEN` | GitHub token for GHCR | `enable_ghcr: true` |
 | `SLACK_WEBHOOK_URL` | Slack webhook for notifications | Optional |
+
+## Tag Immutability and Re-runs
+
+Before building, the workflow checks whether the target image tag already exists in each enabled registry (via `docker manifest inspect`, reusing the registry logins). This avoids a full rebuild that would only fail at push time on registries with tag immutability enabled. Behaviour is controlled by `on_existing_tag`:
+
+- **`fail`** (default): abort early with a clear error instead of rebuilding then failing at push.
+- **`skip`**: skip the build/push but still emit the GitOps tag artifacts (from the version), so a re-run remains idempotent for the downstream GitOps update.
+- **`warn`**: emit a warning and build anyway (push may still fail on immutable registries).
+
+A non-existent tag (or a check that errors out, e.g. transient registry issues) is treated as "not present" so the check never blocks a legitimate build.
 
 ## Platform Build Strategy
 


### PR DESCRIPTION
## Description

Fixes the two root causes of the `tenant-manager` `2.2.0-beta.6` two-attempt failure ([run](https://github.com/LerianStudio/tenant-manager/actions/runs/27234829990)) — both confirmed from the run's job annotations.

**Attempt #2 — wasted rebuild on an immutable tag.** A re-run rebuilt the image (~19s) then failed at push because DockerHub tag immutability rejected the already-published tag. New `on_existing_tag` input adds a pre-flight existence check (via `docker manifest inspect`, reusing the registry logins) **before** the build:
- `fail` (default): abort early with a clear error instead of rebuilding then failing at push.
- `skip`: skip build/push but still emit the GitOps tag artifacts (from the version) so a re-run stays idempotent for the downstream GitOps update.
- `warn`: warn and build anyway.

A non-existent tag — or a check that errors (transient registry issues) — is treated as "not present", so the check never blocks a legitimate build.

**Attempt #1 secondary error — broken `continue_gitops_on_signing_failure`.** When cosign signing failed, the job died with `The template is not valid … build.yml@v1.31.0 (Line: 372, Col: 28): Unexpected value ''` / `an error occurred when attempting to determine whether to continue on error`. Root cause (verified): a `workflow_call` boolean input interpolated into a step-level `continue-on-error` renders empty when evaluated at failure time — a known GitHub Actions quirk — so the very feature meant to tolerate a Sigstore/Rekor outage was itself broken at the moment of failure. Fixed by coercing to a guaranteed boolean: `continue-on-error: ${{ inputs.continue_gitops_on_signing_failure || false }}`.

Files:
- `.github/workflows/build.yml` — new `on_existing_tag` input; pre-flight tag check step; `should_build` gating of metadata/build-push/cosign steps (GitOps artifact steps stay so `skip` remains idempotent); `continue-on-error` boolean coercion.
- `docs/build-workflow.md` — `on_existing_tag` row + "Tag Immutability and Re-runs" section.

## Scope / relationship to #421

#421 is an umbrella covering several loosely-related fixes. This PR delivers the two **incident root-cause** fixes (attempt #1 template error, attempt #2 tag check). The remaining items are split into focused issues:
- #450 — cosign retry resilience (jitter + higher `cosign_max_attempts` default).
- #451 — optional `cleanup_on_failure` for pushed images (high-risk, originally a suggestion).

#421 will be closed as superseded by this PR + #450 + #451.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

`on_existing_tag` defaults to **`fail`**, so a re-run whose target tag already exists now fails fast before building. Previously such a re-run either failed at push (immutable registries — same red, just later) or **overwrote** the tag (mutable registries). Repos that intentionally re-push/overwrite a tag must set `on_existing_tag: warn` (or `skip`).

This propagates to `go-release.yml` callers, which call `build.yml` without `on_existing_tag` and therefore inherit `fail`. `go-release` does not yet expose a passthrough to override it; that can be added as a follow-up if a caller needs `skip`/`warn`.

## Testing

- [x] YAML syntax validated locally
- [x] Rendered and reviewed the pre-flight shell script; verified `should_build` gating across metadata/build-push/cosign while GitOps artifact steps remain (idempotent `skip`)
- [x] Root cause of the line-372 template error confirmed against the actual tenant-manager run annotations (not assumed)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on a re-run against an already-published tag (fail/skip/warn) and a cosign-failure path (continue-on-error no longer template-errors)._

## Related Issues

Part of #421 (closed as superseded). Follow-ups: #450, #451.
