### PR TITLE
fix(go-pr-validation): fail gates when the changes job errors

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Aggregate Go Analysis result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
-          result: ${{ needs.go-analysis.result }}
+          result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.go-analysis.result }}
           label: Go Analysis
 
   # ----------------- Security Scan -----------------
@@ -261,7 +261,7 @@ jobs:
       - name: Aggregate security result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
-          result: ${{ needs.security.result }}
+          result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.security.result }}
           label: Security
 
   # ----------------- Lerian Library Version Check -----------------
@@ -287,5 +287,5 @@ jobs:
       - name: Aggregate Lib Version result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
         with:
-          result: ${{ needs.lib-version.result }}
+          result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.lib-version.result }}
           label: Lib Version

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -13,7 +13,7 @@ Umbrella reusable workflow for Go service repositories. A caller references this
 4. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
 5. **Lerian lib version check** — fails when a direct Lerian library is behind its latest stable release (delegates to `lerian-lib-version-check.yml`), opt-in via `run_lib_version_check`.
 
-The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success).
+The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing — so broken change detection cannot let the required checks go green.
 
 ## Inputs
 


### PR DESCRIPTION
## Description

`go-pr-validation.yml` had a fail-open in its required status checks. When the `changes` (non-doc-changes detector) job fails — e.g. a transient GitHub API error in the composite — the downstream `go-analysis`, `security` and `lib-version` jobs are skipped (their `needs: changes` failed). The `*-gate` aggregators (`if: always()`) then receive `result: skipped`, and `result-gate` treats `skipped` as success (intentional, for docs-only PRs). Net effect: all required checks (`Go Analysis`, `Security`, `Lib Version`) go **green** even though change detection never ran.

This PR makes the aggregators propagate a non-success `changes` result instead of passing:

```yaml
result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.<pipeline>.result }}
```

- `changes` succeeded → `false && … || needs.<pipeline>.result` → normal pipeline result (unchanged behaviour, incl. docs-only skip → pass).
- `changes` failed/cancelled → `true && 'failure' || …` → `'failure'` → gate fails.

`needs.changes.result` is always a non-empty enum (`success`/`failure`/`cancelled`/`skipped`), so the GitHub Actions `A && B || C` idiom does not hit the empty-string pitfall here.

Files:
- `.github/workflows/go-pr-validation.yml` — apply the pattern to `go-analysis-gate`, `security-gate`, `lib-version-gate`.
- `docs/go-pr-validation.md` — note that a failed `changes` job is propagated by the aggregators.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The intended docs-only behaviour is preserved (when `changes` succeeds with `code=false`, pipelines skip and gates pass). The only behavioural change is that a **failed/cancelled** `changes` job now fails the gates instead of silently passing — which is the intended fix.

## Testing

- [x] YAML syntax validated locally
- [x] Traced the expression across all `changes.result` values (success / failure / cancelled / skipped); confirmed docs-only skip still passes and the empty-string `&&/||` pitfall does not apply (result is always a non-empty enum)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate by forcing a `changes`-job failure and confirming the gates go red._

## Related Issues

Closes #419
