### PR TITLE
fix(lerian-lib-version): honor ignore-pin before the releases API call

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -286,21 +286,26 @@ runs:
             continue
           fi
 
-          latest=$(resolve_latest "${repo}" "${major_filter}")
-
-          if [[ -z "${latest}" ]]; then
-            UNKNOWN=$((UNKNOWN+1))
-            printf '| `%s` | `%s` | _unknown_ | Could not resolve latest release |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
-            log "::warning title=Could not resolve latest release::Failed to fetch latest stable release for LerianStudio/${repo}"
-            continue
-          fi
-
-          # Pinned ignore: latest target becomes the pinned version
-          target="${latest}"
+          # A pin takes precedence over the releases API: when a lib is pinned
+          # via .lerianstudiolibignore, compare against the pin and skip the API
+          # call entirely, so the pin is still honoured even if the API is
+          # degraded (non-200). Only unpinned libs depend on resolve_latest.
           marker_suffix=""
           if [[ -n "${IGNORE_PIN[${short_path}]:-}" ]]; then
             target="${IGNORE_PIN[${short_path}]}"
+            latest="${target}"
             marker_suffix=" (pinned)"
+          else
+            latest=$(resolve_latest "${repo}" "${major_filter}")
+
+            if [[ -z "${latest}" ]]; then
+              UNKNOWN=$((UNKNOWN+1))
+              printf '| `%s` | `%s` | _unknown_ | Could not resolve latest release |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
+              log "::warning title=Could not resolve latest release::Failed to fetch latest stable release for LerianStudio/${repo}"
+              continue
+            fi
+
+            target="${latest}"
           fi
 
           if ver_ge "${current}" "${target}"; then


### PR DESCRIPTION
## Description

In `src/validate/lerian-lib-version/action.yml`, the per-dependency loop calls `resolve_latest()` **before** checking the `IGNORE_PIN` map. When the GitHub Releases API returns a non-200 (`resolve_latest` → `""`), the loop hits `[[ -z "${latest}" ]]` and `continue`s, so the `IGNORE_PIN` branch is never reached. A lib pinned via `.lerianstudiolibignore` (e.g. `lib-commons/v5@v5.3.0`) is then reported as `_unknown_` instead of being compared against its pinned minimum — breaking the documented contract ("pin to a specific version — only fail if behind THIS version, not latest") whenever the API is degraded.

## Fix

Check `IGNORE_PIN` first. When a pin exists, use it as the target and skip the API call entirely; only unpinned libs depend on `resolve_latest`:

```bash
if [[ -n "${IGNORE_PIN[${short_path}]:-}" ]]; then
  target="${IGNORE_PIN[${short_path}]}"
  latest="${target}"
  marker_suffix=" (pinned)"
else
  latest=$(resolve_latest "${repo}" "${major_filter}")
  if [[ -z "${latest}" ]]; then
    UNKNOWN=$((UNKNOWN+1)); ...; continue
  fi
  target="${latest}"
fi
```

The downstream `ver_ge` comparison is unchanged. This realigns the code with the contract already documented in the action README (an ignore-pin rule compares against the pin, not latest).

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. For pinned libs with a healthy API the result is identical (the API result was already overridden by the pin), and unpinned libs are unchanged. The fix only corrects the degraded-API case for pinned libs. No README change needed — the README already documents the pinned-comparison contract.

## Testing

- [x] YAML syntax validated locally
- [x] Extracted the step script and ran `bash -n` (no syntax errors)
- [x] Traced both branches: pinned (skips API, compares against pin, marked `(pinned)`) and unpinned (resolve_latest, `_unknown_` + `continue` on API error — unchanged)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate with a configured pin while the releases API is unavailable (lib should be evaluated against the pin, not `_unknown_`)._

## Related Issues

Closes #418
