### PR TITLE
fix(go-release): forward strip_prefix and flatten in s3_uploads entries

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -160,7 +160,7 @@ on:
 
       # ----------------- S3 Upload (s3-upload.yml) -----------------
       s3_uploads:
-        description: 'JSON array of S3 upload entries run after build on tag push, each forwarded to s3-upload.yml. Each object: {"s3_bucket": "...", "file_pattern": "...", "s3_prefix": "..."} (s3_prefix optional). Empty = no upload (default).'
+        description: 'JSON array of S3 upload entries run after build on tag push, each forwarded to s3-upload.yml. Each object: {"s3_bucket": "...", "file_pattern": "...", "s3_prefix": "...", "strip_prefix": "...", "flatten": true|false} (only s3_bucket and file_pattern are required; flatten defaults to true). Empty = no upload (default).'
         type: string
         default: ''
       # ----------------- API Dog E2E (api-dog-e2e-tests.yml) -----------------
@@ -298,6 +298,8 @@ jobs:
       s3_bucket: ${{ matrix.upload.s3_bucket }}
       file_pattern: ${{ matrix.upload.file_pattern }}
       s3_prefix: ${{ matrix.upload.s3_prefix }}
+      strip_prefix: ${{ matrix.upload.strip_prefix }}
+      flatten: ${{ toJSON(matrix.upload.flatten) == 'false' && 'false' || 'true' }}
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
   # ----------------- Extra Builds (tag push, opt-in) -----------------

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -127,7 +127,7 @@ jobs:
 
 ## S3 migrations upload
 
-Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. Each entry runs as a parallel [s3-upload](./s3-upload.md) matrix leg and is independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional); the remaining `s3-upload.yml` knobs (`flatten`, `strip_prefix`, `aws_region`) keep their defaults, and the target environment folder is auto-detected from the tag (`-beta.` → development, `-rc.` → staging, `vX.Y.Z` → production).
+Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. Each entry runs as a parallel [s3-upload](./s3-upload.md) matrix leg and is independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional), `strip_prefix` (optional — removes that prefix from the source path so keys land under `s3_prefix` directly), and `flatten` (optional, defaults to `true`; set `false` to preserve the directory structure). The target environment folder is auto-detected from the tag (`-beta.` → development, `-rc.` → staging, `vX.Y.Z` → production).
 
 All entries share the `AWS_MIGRATIONS_ROLE_ARN` secret (forwarded to `s3-upload.yml`'s `AWS_ROLE_ARN`); map it explicitly in the caller.
 ## ApiDog E2E tests
@@ -159,7 +159,9 @@ jobs:
           {
             "s3_bucket": "lerian-migration-files",
             "file_pattern": "components/ledger/migrations/transaction/*.sql",
-            "s3_prefix": "ledger/transaction/postgresql"
+            "s3_prefix": "ledger/transaction/postgresql",
+            "strip_prefix": "components/ledger/migrations/transaction",
+            "flatten": false
           }
         ]
     secrets:


### PR DESCRIPTION
## Description

Follow-up to #442 / #447 (which added `s3_uploads` to `go-release.yml`). The `s3_upload` job only forwarded `s3_bucket`, `file_pattern` and `s3_prefix` to `s3-upload.yml`, so two commonly needed fields were unreachable — forcing midaz and lerian-notification to keep standalone `s3-migrations.yml` workarounds:

- **`strip_prefix`** — removes the local directory prefix from the source path, so `components/ledger/migrations/onboarding/0001.sql` → `<prefix>/0001.sql` instead of `<prefix>/components/ledger/migrations/onboarding/0001.sql`.
- **`flatten`** — preserve vs. flatten the directory structure.

This PR forwards both from each `s3_uploads` entry:

```yaml
strip_prefix: ${{ matrix.upload.strip_prefix }}
flatten: ${{ toJSON(matrix.upload.flatten) == 'false' && 'false' || 'true' }}
```

`strip_prefix` is a plain string (omitted → `''` → `s3-upload.yml` default). `flatten` is a boolean whose `s3-upload.yml` default is `true`, and the issue needs an explicit `false` to be honoured. A naive `${{ matrix.upload.flatten || true }}` can't do that — in GitHub Actions both an omitted key (`''`) and an explicit `false` coerce to falsy, so it would force `true`. Comparing the JSON serialization (`toJSON(...)` → `'null'` for omitted, `'false'`/`'true'` for explicit) distinguishes the three cases: omitted/true → `true` (preserves current behaviour), explicit `false` → `false`.

Files:
- `.github/workflows/go-release.yml` — forward `strip_prefix` and `flatten` in the `s3_upload` job; updated the `s3_uploads` input description.
- `docs/go-release-workflow.md` — documented both keys and added them to the example.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Entries that omit `strip_prefix`/`flatten` behave exactly as before (`strip_prefix` empty, `flatten` true — the `s3-upload.yml` defaults).

## Testing

- [x] YAML syntax validated locally
- [x] Traced the `flatten` expression for all three cases: omitted (`toJSON(null)='null'` → `true`), explicit `false` → `false`, explicit `true` → `true`
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified existing `s3_uploads` entries (3-field) still work unchanged
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on midaz (entry with `strip_prefix` + `flatten: false`) and lerian-notification._

## Related Issues

Closes #456
