### PR TITLE
fix(go-pr-validation): expose and forward enable_docker_scan

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -126,6 +126,10 @@ on:
         description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml)'
         type: string
         default: ''
+      enable_docker_scan:
+        description: 'Build and scan a Docker image with Trivy. Set to false for repos without a root Dockerfile (e.g. monorepos with Dockerfiles under components/ or cmd/).'
+        type: boolean
+        default: true
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -247,6 +251,7 @@ jobs:
     with:
       runner_type: ${{ inputs.runner_type }}
       ignore_file: ${{ inputs.ignore_file }}
+      enable_docker_scan: ${{ inputs.enable_docker_scan }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       shared_paths: ${{ inputs.shared_paths }}

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -46,6 +46,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `enable_integration_tests` | Enable integration tests | boolean | `false` |
 | `system_packages` | apt packages to install for CGO repos | string | `''` |
 | `ignore_file` | Path to Trivy ignore file | string | `''` |
+| `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a root Dockerfile (monorepos with Dockerfiles under `components/`/`cmd/`) | boolean | `true` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |


### PR DESCRIPTION
## Description

`go-pr-validation.yml` calls `pr-security-scan.yml` but does not forward `enable_docker_scan`, so it always runs with the default (`true`). For repos without a root `Dockerfile` (monorepos with Dockerfiles under `components/` or `cmd/`), the Trivy image build step fails with `failed to read dockerfile: open Dockerfile: no such file or directory`. `pr-security-scan.yml` already exposes `enable_docker_scan` — the umbrella just didn't pass it through.

This PR adds an `enable_docker_scan` input to the umbrella and forwards it to the security job.

Files:
- `.github/workflows/go-pr-validation.yml` — new `enable_docker_scan` input (boolean, default `true`) forwarded to `pr-security-scan.yml`.
- `docs/go-pr-validation.md` — input row.

Affected repos (no root Dockerfile) can now set `enable_docker_scan: false`: midaz, lerian-notification, fetcher, reporter.

Scope note: this is the issue's primary request (let callers disable the image scan). The author also suggested auto-detecting the Dockerfile inside `pr-security-scan.yml` — that's a larger, global change to a widely-used workflow (it would need per-component detection across the scan matrix, and risks silently dropping image-scan coverage), so it's intentionally left as a possible follow-up. The umbrella also does not forward `filter_paths`, so per-component image scanning in monorepos remains a separate enhancement.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The input defaults to `true`, preserving current behaviour for every existing caller.

## Testing

- [x] YAML syntax validated locally
- [x] Confirmed `pr-security-scan.yml` already accepts `enable_docker_scan` (the umbrella now forwards it)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on a monorepo without a root Dockerfile (e.g. midaz) with `enable_docker_scan: false`._

## Related Issues

Closes #459
