### PR TITLE
fix(pr-security-scan): add dockerfile_path to scan component Dockerfiles

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -130,6 +130,10 @@ on:
         description: 'Build and scan a Docker image with Trivy. Set to false for repos without a root Dockerfile (e.g. monorepos with Dockerfiles under components/ or cmd/).'
         type: boolean
         default: true
+      dockerfile_path:
+        description: 'Explicit path to a single Dockerfile to build and scan (e.g. components/ledger/Dockerfile). Lets monorepos without a root Dockerfile keep enable_docker_scan: true.'
+        type: string
+        default: ''
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -252,6 +256,7 @@ jobs:
       runner_type: ${{ inputs.runner_type }}
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
+      dockerfile_path: ${{ inputs.dockerfile_path }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       shared_paths: ${{ inputs.shared_paths }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -59,6 +59,10 @@ on:
         description: 'Name of the Dockerfile'
         type: string
         default: 'Dockerfile'
+      dockerfile_path:
+        description: 'Explicit path to a single Dockerfile to build and scan (e.g. components/ledger/Dockerfile). Overrides the working_dir/dockerfile_name resolution; intended for single-Dockerfile repos without filter_paths.'
+        type: string
+        default: ''
       enable_docker_scan:
         description: 'Enable Docker image build and vulnerability scanning. Set to false for projects without Dockerfile (e.g., CLI tools)'
         type: boolean
@@ -161,7 +165,7 @@ jobs:
     env:
       DOCKERHUB_ORG: ${{ inputs.dockerhub_org }}
       APP_NAME: ${{ matrix.name }}
-      DOCKERFILE_PATH: ${{ matrix.working_dir == '.' && format('./{0}', inputs.dockerfile_name) || format('{0}/{1}', matrix.working_dir, inputs.dockerfile_name) }}
+      DOCKERFILE_PATH: ${{ inputs.dockerfile_path != '' && inputs.dockerfile_path || (matrix.working_dir == '.' && format('./{0}', inputs.dockerfile_name) || format('{0}/{1}', matrix.working_dir, inputs.dockerfile_name)) }}
 
     steps:
       # ----------------- Setup -----------------

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -47,6 +47,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `system_packages` | apt packages to install for CGO repos | string | `''` |
 | `ignore_file` | Path to Trivy ignore file | string | `''` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a root Dockerfile (monorepos with Dockerfiles under `components/`/`cmd/`) | boolean | `true` |
+| `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`); lets monorepos without a root Dockerfile keep `enable_docker_scan: true` | string | `''` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -191,6 +191,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `docker_registry` | string | `docker.io` | Docker registry URL |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
+| `dockerfile_path` | string | `''` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`). Overrides `working_dir`/`dockerfile_name`; for single-Dockerfile repos without `filter_paths` |
 | `enable_docker_scan` | boolean | `true` | Enable Docker image build and vulnerability scanning. Set to `false` for projects without Dockerfile (e.g., CLI tools) |
 | `enable_health_score` | boolean | `true` | Enable Docker Hub Health Score compliance checks (non-root user, CVEs, licenses) |
 | `enable_codeql` | boolean | `false` | Enable CodeQL static analysis. Requires `codeql_languages` to be set |


### PR DESCRIPTION
## Description

Follow-up to #459. Monorepos keep their Dockerfiles in component subdirectories (`components/ledger/Dockerfile`, `cmd/api/Dockerfile`, …), not at the repo root. `pr-security-scan.yml` resolved the Dockerfile as `working_dir/dockerfile_name` — which is `./Dockerfile` in single-app mode — so these repos had to set `enable_docker_scan: false` and never scanned their images for CVEs.

This PR adds a `dockerfile_path` input that points the scan at an explicit Dockerfile, so a monorepo can keep `enable_docker_scan: true` and scan a representative component image (base images / dependency layers are typically shared across components).

Files:
- `.github/workflows/pr-security-scan.yml` — new `dockerfile_path` input; `DOCKERFILE_PATH` now prefers it (`${{ inputs.dockerfile_path != '' && inputs.dockerfile_path || <working_dir/dockerfile_name> }}`). The Trivy image build/scan and the Dockerfile compliance checks both follow `DOCKERFILE_PATH`, so they pick up the override automatically. The build context stays the repo root.
- `.github/workflows/go-pr-validation.yml` — new `dockerfile_path` input forwarded to the security job (next to `enable_docker_scan` from #460).
- `docs/pr-security-scan-workflow.md`, `docs/go-pr-validation.md` — input rows.

### Example

```yaml
# midaz pr-validation.yml
with:
  enable_docker_scan: true
  dockerfile_path: components/ledger/Dockerfile
```

Scope: this implements the issue's primary request (a single representative `dockerfile_path`). The "Alternative" (a newline list / matrix over multiple Dockerfiles, one report per image) is a larger change and is left as a possible follow-up. `dockerfile_path` targets a single Dockerfile and is intended for repos without `filter_paths` — combining it with `filter_paths` would apply the same path to every matrix component.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `dockerfile_path` defaults to `''`, preserving the current `working_dir`/`dockerfile_name` resolution for every existing caller.

## Testing

- [x] YAML syntax validated locally (both workflows)
- [x] Traced the `DOCKERFILE_PATH` expression: set → uses the explicit path; empty → existing `working_dir/dockerfile_name` logic (no empty-string pitfall, since the override is non-empty when used)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Verified existing callers (no `dockerfile_path`) are unaffected
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on midaz with `enable_docker_scan: true` + `dockerfile_path: components/ledger/Dockerfile`._

## Related Issues

Closes #462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `dockerfile_path` parameter to security scanning workflows, enabling explicit specification of Dockerfile locations for repositories with custom or multiple Dockerfile paths.

* **Documentation**
  * Updated security workflow documentation to describe the new parameter and its configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->