### PR TITLE
fix(go-pr-validation): expose and forward filter_paths and path_level

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -106,8 +106,8 @@ on:
         default: ''
       path_level:
         description: 'Directory depth level to extract the component name from filter_paths'
-        type: string
-        default: '2'
+        type: number
+        default: 2
       coverage_threshold:
         description: 'Minimum coverage percentage required (0-100)'
         type: number

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -100,6 +100,14 @@ on:
         description: 'Prefix used to namespace coverage/build artifacts'
         type: string
         default: ''
+      filter_paths:
+        description: 'Newline-separated component path prefixes for monorepo per-component analysis. Empty = single-app root analysis.'
+        type: string
+        default: ''
+      path_level:
+        description: 'Directory depth level to extract the component name from filter_paths'
+        type: string
+        default: '2'
       coverage_threshold:
         description: 'Minimum coverage percentage required (0-100)'
         type: number
@@ -226,6 +234,8 @@ jobs:
       golangci_lint_version: ${{ inputs.golangci_lint_version }}
       golangci_lint_args: ${{ inputs.golangci_lint_args }}
       app_name_prefix: ${{ inputs.app_name_prefix }}
+      filter_paths: ${{ inputs.filter_paths }}
+      path_level: ${{ inputs.path_level }}
       coverage_threshold: ${{ inputs.coverage_threshold }}
       fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
       go_private_modules: ${{ inputs.go_private_modules }}

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -41,7 +41,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `golangci_lint_args` | Extra arguments passed to golangci-lint (e.g. `--timeout=5m`) | string | `--timeout=5m` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
 | `filter_paths` | Newline-separated component path prefixes for monorepo per-component analysis (lint/tests/coverage); empty = single-app root analysis | string | `''` |
-| `path_level` | Directory depth level to extract the component name from `filter_paths` | string | `2` |
+| `path_level` | Directory depth level to extract the component name from `filter_paths` | number | `2` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `true` |
 | `go_private_modules` | GOPRIVATE pattern for private modules | string | `''` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -40,6 +40,8 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `golangci_lint_version` | GolangCI-Lint version | string | `v1.62.2` |
 | `golangci_lint_args` | Extra arguments passed to golangci-lint (e.g. `--timeout=5m`) | string | `--timeout=5m` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
+| `filter_paths` | Newline-separated component path prefixes for monorepo per-component analysis (lint/tests/coverage); empty = single-app root analysis | string | `''` |
+| `path_level` | Directory depth level to extract the component name from `filter_paths` | string | `2` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `true` |
 | `go_private_modules` | GOPRIVATE pattern for private modules | string | `''` |


### PR DESCRIPTION
## Description

`go-pr-validation.yml` forwards `shared_paths` and `app_name_prefix` to `go-pr-analysis.yml` but does not expose `filter_paths` or `path_level`. `go-pr-analysis.yml` already consumes both (it feeds them to the `changed-paths` composite to build its per-component matrix), so without the passthrough a monorepo migrating to the umbrella collapses to a single root analysis instead of per-component Build/Tests/Lint/Coverage.

This PR exposes `filter_paths` and `path_level` on the umbrella and forwards them to the Go analysis pipeline.

Files:
- `.github/workflows/go-pr-validation.yml` — new `filter_paths` (string, default `''`) and `path_level` (string, default `'2'`) inputs, forwarded to `go-pr-analysis.yml`.
- `docs/go-pr-validation.md` — input rows.

### Example caller (midaz)

```yaml
with:
  app_name_prefix: "midaz"
  filter_paths: |
    components/crm
    components/ledger
  shared_paths: |
    go.mod
    go.sum
    pkg/
    Makefile
```

Restores per-component checks (`Go Analysis / Tests (midaz-crm)`, `(midaz-ledger)`, …) for midaz, fetcher, reporter.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Both inputs default to their current effective values (`filter_paths: ''` → single-app root analysis, `path_level: '2'`), so existing callers are unaffected.

## Testing

- [x] YAML syntax validated locally
- [x] Confirmed `go-pr-analysis.yml` already consumes `filter_paths`/`path_level` (forwarded to the `changed-paths` composite that builds the matrix)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Verified existing callers (no `filter_paths`) are unaffected
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on midaz with `filter_paths` (per-component analysis appears) vs. a single-app repo (unchanged)._

## Related Issues

Closes #465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional, monorepo-aware inputs to the Go PR analysis workflow to control which component paths are analyzed and how component names are derived.

* **Documentation**
  * Updated the Go PR validation documentation to describe the new `filter_paths` and `path_level` inputs, including their defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->