### PR TITLE
fix(go-pr-validation): forward filter_paths and path_level to security scan

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -101,7 +101,7 @@ on:
         type: string
         default: ''
       filter_paths:
-        description: 'Newline-separated component path prefixes for monorepo per-component analysis. Empty = single-app root analysis.'
+        description: 'Newline-separated component path prefixes for monorepo per-component analysis and security scanning. Empty = single-app root run. When set for the security scan, leave dockerfile_path empty so each component Dockerfile is discovered.'
         type: string
         default: ''
       path_level:
@@ -269,6 +269,8 @@ jobs:
       dockerfile_path: ${{ inputs.dockerfile_path }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
+      filter_paths: ${{ inputs.filter_paths }}
+      path_level: ${{ format('{0}', inputs.path_level) }}
       shared_paths: ${{ inputs.shared_paths }}
     secrets: inherit
 

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -40,7 +40,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `golangci_lint_version` | GolangCI-Lint version | string | `v1.62.2` |
 | `golangci_lint_args` | Extra arguments passed to golangci-lint (e.g. `--timeout=5m`) | string | `--timeout=5m` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
-| `filter_paths` | Newline-separated component path prefixes for monorepo per-component analysis (lint/tests/coverage); empty = single-app root analysis | string | `''` |
+| `filter_paths` | Newline-separated component path prefixes for monorepo per-component analysis (lint/tests/coverage) **and** security scanning; empty = single-app root run. When using it for security, leave `dockerfile_path` empty so each component Dockerfile is discovered | string | `''` |
 | `path_level` | Directory depth level to extract the component name from `filter_paths` | number | `2` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `true` |


### PR DESCRIPTION
## Description

Companion to #465 (which forwarded `filter_paths`/`path_level` to `go-pr-analysis.yml`). The umbrella still didn't forward them to `pr-security-scan.yml`, so a monorepo migrating to `go-pr-validation` ran a single root security scan instead of per-component scans (`pr-security-scan.yml` already supports per-component scanning when `filter_paths` is set — it discovers each component's Dockerfile via its matrix).

This PR forwards `filter_paths` and `path_level` (the inputs already added by #465) to the security job.

Files:
- `.github/workflows/go-pr-validation.yml` — `security` job now forwards `filter_paths` and `path_level`; the `filter_paths` input description broadened to cover security too.
- `docs/go-pr-validation.md` — updated the `filter_paths` row.

### Type note (`path_level`)

`path_level` is typed `number` on the umbrella (aligned with `go-pr-analysis.yml` in #465), but `pr-security-scan.yml` types it as `string`. To avoid an actionlint type error, the forward stringifies it: `path_level: ${{ format('{0}', inputs.path_level) }}`. The underlying type inconsistency between `go-pr-analysis.yml` (number) and `pr-security-scan.yml` (string) is left as a possible follow-up — aligning `pr-security-scan.yml` to `number` would touch a workflow with direct callers and is out of scope here.

### `dockerfile_path` interaction

When `filter_paths` is set, each component's Dockerfile is discovered via the scan matrix. The `dockerfile_path` override (#462) still takes precedence if both are set, so callers should use `filter_paths` **or** `dockerfile_path`, not both — documented in the `filter_paths` description. Changing that precedence is out of scope.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `filter_paths` defaults to `''` (single-app root scan, unchanged) and no new inputs are introduced — only an additional forward of the existing inputs to the security job.

## Testing

- [x] YAML syntax validated locally
- [x] Confirmed `pr-security-scan.yml` accepts `filter_paths` (string) and `path_level` (string); stringified the number `path_level` via `format()` to satisfy actionlint
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Verified existing single-app callers (no `filter_paths`) are unaffected
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on midaz with `filter_paths` (per-component `security_scan` legs appear) vs. a single-app repo (unchanged)._

## Related Issues

Closes #469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security scanning pipeline now supports per-component filtering to align with analysis pipeline capabilities.

* **Documentation**
  * Updated `filter_paths` input documentation to clarify it applies to both analysis and security scanning; added guidance that `dockerfile_path` should remain empty for component Dockerfile discovery during security scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->