### PR TITLE
fix(go-release): run s3_upload inline instead of matrix over reusable workflow

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -293,6 +293,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Determine environment folder from tag
         id: env
@@ -303,7 +305,7 @@ jobs:
             FOLDER="development"
           elif [[ "$TAG" == *-rc* ]]; then
             FOLDER="staging"
-          elif [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             FOLDER="production"
           else
             FOLDER=""

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -283,25 +283,96 @@ jobs:
 
   # ----------------- S3 Upload (tag push, post-build, opt-in) -----------------
   s3_upload:
+    name: S3 Upload
     needs: [build]
     if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result == 'success'
+    runs-on: ${{ inputs.runner_type }}
     permissions:
       id-token: write
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        upload: ${{ fromJson(inputs.s3_uploads) }}
-    uses: ./.github/workflows/s3-upload.yml
-    with:
-      runner_type: ${{ inputs.runner_type }}
-      s3_bucket: ${{ matrix.upload.s3_bucket }}
-      file_pattern: ${{ matrix.upload.file_pattern }}
-      s3_prefix: ${{ matrix.upload.s3_prefix }}
-      strip_prefix: ${{ matrix.upload.strip_prefix }}
-      flatten: ${{ toJSON(matrix.upload.flatten) == 'false' && 'false' || 'true' }}
-    secrets:
-      AWS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Determine environment folder from tag
+        id: env
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" == *-beta* ]]; then
+            FOLDER="development"
+          elif [[ "$TAG" == *-rc* ]]; then
+            FOLDER="staging"
+          elif [[ "$TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            FOLDER="production"
+          else
+            FOLDER=""
+          fi
+          echo "folder=${FOLDER}" >> "$GITHUB_OUTPUT"
+          [[ -n "$FOLDER" ]] && echo "📁 Environment: ${FOLDER}" || echo "::warning::Tag '${TAG}' matched no environment — S3 upload skipped."
+
+      - name: Configure AWS credentials
+        if: steps.env.outputs.folder != ''
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Upload files to S3
+        if: steps.env.outputs.folder != ''
+        env:
+          S3_UPLOADS: ${{ inputs.s3_uploads }}
+          FOLDER: ${{ steps.env.outputs.folder }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t ENTRIES < <(printf '%s' "$S3_UPLOADS" | jq -c '.[]')
+          if [[ ${#ENTRIES[@]} -eq 0 ]]; then
+            echo "::warning::s3_uploads is empty — nothing to upload."
+            exit 0
+          fi
+
+          for entry in "${ENTRIES[@]}"; do
+            BUCKET=$(printf '%s' "$entry" | jq -r '.s3_bucket')
+            PATTERN=$(printf '%s' "$entry" | jq -r '.file_pattern')
+            PREFIX=$(printf '%s' "$entry" | jq -r '.s3_prefix // ""')
+            STRIP_PREFIX=$(printf '%s' "$entry" | jq -r '.strip_prefix // ""')
+            FLATTEN=$(printf '%s' "$entry" | jq -r 'if .flatten == false then "false" else "true" end')
+
+            if [[ -z "$BUCKET" || "$BUCKET" == "null" || -z "$PATTERN" || "$PATTERN" == "null" ]]; then
+              echo "::error::Each s3_uploads entry requires s3_bucket and file_pattern. Got: ${entry}"
+              exit 1
+            fi
+
+            if [[ -n "$PREFIX" ]]; then
+              S3_PATH="s3://${BUCKET}/${FOLDER}/${PREFIX}/"
+            else
+              S3_PATH="s3://${BUCKET}/${FOLDER}/"
+            fi
+
+            echo "Uploading '${PATTERN}' -> ${S3_PATH} (flatten=${FLATTEN}, strip_prefix=${STRIP_PREFIX:-<none>})"
+            shopt -s nullglob
+            FILE_COUNT=0
+            for file in $PATTERN; do
+              if [[ "$FLATTEN" == "true" ]]; then
+                aws s3 cp "$file" "${S3_PATH}"
+              elif [[ -n "$STRIP_PREFIX" ]]; then
+                DEST_PATH="${file#"$STRIP_PREFIX"/}"
+                aws s3 cp "$file" "${S3_PATH}${DEST_PATH}"
+              else
+                aws s3 cp "$file" "${S3_PATH}${file}"
+              fi
+              FILE_COUNT=$((FILE_COUNT + 1))
+            done
+            shopt -u nullglob
+
+            if [[ $FILE_COUNT -eq 0 ]]; then
+              echo "::error::No files matched pattern: ${PATTERN}"
+              exit 1
+            fi
+            echo "::notice::Uploaded ${FILE_COUNT} file(s) to ${S3_PATH}"
+          done
+
   # ----------------- Extra Builds (tag push, opt-in) -----------------
   extra_build:
     if: github.ref_type == 'tag' && inputs.extra_builds != ''

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -127,9 +127,9 @@ jobs:
 
 ## S3 migrations upload
 
-Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. Each entry runs as a parallel [s3-upload](./s3-upload.md) matrix leg and is independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional), `strip_prefix` (optional — removes that prefix from the source path so keys land under `s3_prefix` directly), and `flatten` (optional, defaults to `true`; set `false` to preserve the directory structure). The target environment folder is auto-detected from the tag (`-beta.` → development, `-rc.` → staging, `vX.Y.Z` → production).
+Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. All entries are processed sequentially inside a single `s3_upload` job (this avoids a GitHub Actions limitation where a `matrix` over a reusable-workflow `uses:` call is not instantiated in a nested reusable-workflow context), independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional), `strip_prefix` (optional — removes that prefix from the source path so keys land under `s3_prefix` directly), and `flatten` (optional, defaults to `true`; set `false` to preserve the directory structure). The target environment folder is auto-detected from the tag (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production).
 
-All entries share the `AWS_MIGRATIONS_ROLE_ARN` secret (forwarded to `s3-upload.yml`'s `AWS_ROLE_ARN`); map it explicitly in the caller.
+The job assumes the `AWS_MIGRATIONS_ROLE_ARN` secret via OIDC (region `us-east-2`); map it explicitly in the caller.
 ## ApiDog E2E tests
 
 Set `enable_apidog_e2e: true` to run [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) on tag push after a successful `update_gitops`. The job is skipped on branch pushes and when the gitops update did not succeed.
@@ -214,6 +214,6 @@ The single caller job must grant the union of what the internal jobs need: `id-t
 - [release](./release-workflow.md) — semantic-release pipeline this umbrella calls
 - [build](./build-workflow.md) — container build & push this umbrella calls
 - [gitops-update](./gitops-update-workflow.md) — GitOps update this umbrella calls
-- [s3-upload](./s3-upload.md) — optional post-build S3 upload this umbrella calls
+- [s3-upload](./s3-upload.md) — standalone S3 upload reusable workflow (the umbrella performs the equivalent upload inline via `s3_uploads`)
 - [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) — optional post-gitops E2E tests this umbrella calls
 - [go-pr-validation](./go-pr-validation.md) — the matching PR validation umbrella


### PR DESCRIPTION
## Description

The `s3_upload` job in `go-release.yml` used `strategy.matrix` over a reusable-workflow `uses:` call (`s3-upload.yml`). In a 3-level nested reusable-workflow context (caller → `go-release.yml` → `s3-upload.yml` via matrix) GitHub Actions silently fails to instantiate the matrix job: it never appears in the run (not even as skipped) and the overall run is marked **failure**, so the S3 upload never executes.

Observed on `LerianStudio/notifications` [run 27957916809](https://github.com/LerianStudio/notifications/actions/runs/27957916809) (`go-release.yml@v1.36.5`): all 14 jobs success/skipped, `pipeline / s3_upload` **absent**, run **failure**, SQL migrations never uploaded. Notably `extra_build` (same matrix+`uses:` pattern) appeared as *skipped* only because its `if` is false — it never reached matrix evaluation.

This PR replaces the matrix + `uses:` job with a single inline `s3_upload` job that loops the `s3_uploads` JSON and uploads via the AWS CLI directly — no nested reusable-workflow call, no matrix-over-`uses:`.

Files:
- `.github/workflows/go-release.yml` — `s3_upload` is now a normal job: checkout → environment detection from the tag (`-beta`→development, `-rc`→staging, `vX.Y.Z`→production) → AWS OIDC (`aws-actions/configure-aws-credentials`, SHA-pinned) assuming `AWS_MIGRATIONS_ROLE_ARN` in `us-east-2` → a `jq`/`mapfile` loop over the entries running `aws s3 cp` with the same `strip_prefix`/`flatten` semantics as `s3-upload.yml`.
- `docs/go-release-workflow.md` — updated the "S3 migrations upload" section and the Related entry (the umbrella no longer calls `s3-upload.yml`; it performs the equivalent upload inline).

The standalone `s3-upload.yml` reusable workflow is unchanged and still available for direct callers.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None at the caller API — `s3_uploads` (and its `s3_bucket`/`file_pattern`/`s3_prefix`/`strip_prefix`/`flatten` per-entry keys) and `AWS_MIGRATIONS_ROLE_ARN` are unchanged. Behavioural change: uploads now run sequentially within one job rather than as parallel matrix legs; the resulting S3 layout is identical.

## Testing

- [x] YAML syntax validated locally
- [x] `bash -n` on both run steps (environment detection + upload loop) — no syntax errors
- [x] Traced the upload loop against the failing config (`flatten:false`, `strip_prefix:"migrations"`): explicit `flatten:false` honoured, omitted → `true`; per-entry `s3_bucket`/`file_pattern` required-check
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to re-run `notifications` v1.0.0-beta.x against this branch and confirm `s3_upload` runs and the migrations land in S3._

## Related Issues

Closes #474. Follow-up #475 tracks the same matrix+`uses:` pattern still present in the `extra_build` job (latent — no caller exercises it yet).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the release S3 upload process by handling uploads inline during the release workflow.
  * Added clearer tag-to-environment routing (beta → development, rc → staging, version tags → production) and improved error handling when upload instructions are invalid or match no files.
* **Documentation**
  * Updated the Go release workflow guide to describe the new sequential `s3_uploads` behavior, clarify how uploads relate to repository contents, and revise the AWS migrations role instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->