### PR TITLE
fix(go-release): support per-entry aws_role_arn in s3_uploads

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -325,8 +325,51 @@ jobs:
         env:
           S3_UPLOADS: ${{ inputs.s3_uploads }}
           FOLDER: ${{ steps.env.outputs.folder }}
+          AWS_REGION: us-east-2
         run: |
           set -euo pipefail
+
+          upload_entry() {
+            local BUCKET="$1" PATTERN="$2" PREFIX="$3" STRIP_PREFIX="$4" FLATTEN="$5"
+            local S3_PATH file DEST_PATH FILE_COUNT=0
+            if [[ -n "$PREFIX" ]]; then
+              S3_PATH="s3://${BUCKET}/${FOLDER}/${PREFIX}/"
+            else
+              S3_PATH="s3://${BUCKET}/${FOLDER}/"
+            fi
+            echo "Uploading '${PATTERN}' -> ${S3_PATH} (flatten=${FLATTEN}, strip_prefix=${STRIP_PREFIX:-<none>})"
+            shopt -s nullglob
+            for file in $PATTERN; do
+              if [[ "$FLATTEN" == "true" ]]; then
+                aws s3 cp "$file" "${S3_PATH}"
+              elif [[ -n "$STRIP_PREFIX" ]]; then
+                DEST_PATH="${file#"$STRIP_PREFIX"/}"
+                aws s3 cp "$file" "${S3_PATH}${DEST_PATH}"
+              else
+                aws s3 cp "$file" "${S3_PATH}${file}"
+              fi
+              FILE_COUNT=$((FILE_COUNT + 1))
+            done
+            shopt -u nullglob
+            if [[ $FILE_COUNT -eq 0 ]]; then
+              echo "::error::No files matched pattern: ${PATTERN}"
+              return 1
+            fi
+            echo "::notice::Uploaded ${FILE_COUNT} file(s) to ${S3_PATH}"
+          }
+
+          assume_role() {
+            local role_arn="$1" token
+            token=$(curl -sS -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | jq -r '.value')
+            aws sts assume-role-with-web-identity \
+              --role-arn "$role_arn" \
+              --role-session-name go-release-s3-upload \
+              --web-identity-token "$token" \
+              --duration-seconds 3600 \
+              --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+              --output text
+          }
 
           mapfile -t ENTRIES < <(printf '%s' "$S3_UPLOADS" | jq -c '.[]')
           if [[ ${#ENTRIES[@]} -eq 0 ]]; then
@@ -340,39 +383,31 @@ jobs:
             PREFIX=$(printf '%s' "$entry" | jq -r '.s3_prefix // ""')
             STRIP_PREFIX=$(printf '%s' "$entry" | jq -r '.strip_prefix // ""')
             FLATTEN=$(printf '%s' "$entry" | jq -r 'if .flatten == false then "false" else "true" end')
+            ROLE_ARN=$(printf '%s' "$entry" | jq -r '.aws_role_arn // ""')
 
             if [[ -z "$BUCKET" || "$BUCKET" == "null" || -z "$PATTERN" || "$PATTERN" == "null" ]]; then
               echo "::error::Each s3_uploads entry requires s3_bucket and file_pattern. Got: ${entry}"
               exit 1
             fi
 
-            if [[ -n "$PREFIX" ]]; then
-              S3_PATH="s3://${BUCKET}/${FOLDER}/${PREFIX}/"
+            if [[ -n "$ROLE_ARN" && "$ROLE_ARN" != "null" ]]; then
+              (
+                set -euo pipefail
+                CREDS=$(assume_role "$ROLE_ARN")
+                AK=$(printf '%s' "$CREDS" | cut -f1)
+                SK=$(printf '%s' "$CREDS" | cut -f2)
+                ST=$(printf '%s' "$CREDS" | cut -f3)
+                if [[ -z "$AK" || -z "$SK" || -z "$ST" ]]; then
+                  echo "::error::Failed to assume role for s3 upload: ${ROLE_ARN}"
+                  exit 1
+                fi
+                echo "::add-mask::$AK"; echo "::add-mask::$SK"; echo "::add-mask::$ST"
+                export AWS_ACCESS_KEY_ID="$AK" AWS_SECRET_ACCESS_KEY="$SK" AWS_SESSION_TOKEN="$ST"
+                upload_entry "$BUCKET" "$PATTERN" "$PREFIX" "$STRIP_PREFIX" "$FLATTEN"
+              )
             else
-              S3_PATH="s3://${BUCKET}/${FOLDER}/"
+              upload_entry "$BUCKET" "$PATTERN" "$PREFIX" "$STRIP_PREFIX" "$FLATTEN"
             fi
-
-            echo "Uploading '${PATTERN}' -> ${S3_PATH} (flatten=${FLATTEN}, strip_prefix=${STRIP_PREFIX:-<none>})"
-            shopt -s nullglob
-            FILE_COUNT=0
-            for file in $PATTERN; do
-              if [[ "$FLATTEN" == "true" ]]; then
-                aws s3 cp "$file" "${S3_PATH}"
-              elif [[ -n "$STRIP_PREFIX" ]]; then
-                DEST_PATH="${file#"$STRIP_PREFIX"/}"
-                aws s3 cp "$file" "${S3_PATH}${DEST_PATH}"
-              else
-                aws s3 cp "$file" "${S3_PATH}${file}"
-              fi
-              FILE_COUNT=$((FILE_COUNT + 1))
-            done
-            shopt -u nullglob
-
-            if [[ $FILE_COUNT -eq 0 ]]; then
-              echo "::error::No files matched pattern: ${PATTERN}"
-              exit 1
-            fi
-            echo "::notice::Uploaded ${FILE_COUNT} file(s) to ${S3_PATH}"
           done
 
   # ----------------- Extra Builds (tag push, opt-in) -----------------

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -127,9 +127,24 @@ jobs:
 
 ## S3 migrations upload
 
-Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. All entries are processed sequentially inside a single `s3_upload` job (this avoids a GitHub Actions limitation where a `matrix` over a reusable-workflow `uses:` call is not instantiated in a nested reusable-workflow context), independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional), `strip_prefix` (optional — removes that prefix from the source path so keys land under `s3_prefix` directly), and `flatten` (optional, defaults to `true`; set `false` to preserve the directory structure). The target environment folder is auto-detected from the tag (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production).
+Set `s3_uploads` to a JSON array to upload files (e.g. SQL migrations) to S3 on tag push, after `build` succeeds. All entries are processed sequentially inside a single `s3_upload` job (this avoids a GitHub Actions limitation where a `matrix` over a reusable-workflow `uses:` call is not instantiated in a nested reusable-workflow context), independent of the gitops update (it reads repo files, not build artifacts). Per-entry keys: `s3_bucket` (required), `file_pattern` (required), `s3_prefix` (optional), `strip_prefix` (optional — removes that prefix from the source path so keys land under `s3_prefix` directly), `flatten` (optional, defaults to `true`; set `false` to preserve the directory structure), and `aws_role_arn` (optional — see per-entry role below). The target environment folder is auto-detected from the tag (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production).
 
-The job assumes the `AWS_MIGRATIONS_ROLE_ARN` secret via OIDC (region `us-east-2`); map it explicitly in the caller.
+By default the job assumes the `AWS_MIGRATIONS_ROLE_ARN` secret via OIDC (region `us-east-2`); map it explicitly in the caller.
+
+### Per-entry IAM role
+
+To upload to buckets that require different IAM roles, set `aws_role_arn` on an entry to the **role ARN value** — resolve the secret in the caller and inline it into the JSON (GitHub Actions cannot look up a secret by a dynamic name). Entries with `aws_role_arn` assume that role via OIDC for their upload; entries without it use the default `AWS_MIGRATIONS_ROLE_ARN`. Each role referenced this way must have an OIDC trust policy that allows the **caller** repository (same prerequisite as the default role).
+
+```yaml
+secrets:
+  AWS_MIGRATIONS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
+with:
+  s3_uploads: |
+    [
+      { "s3_bucket": "lerian-migration-files", "file_pattern": "migrations/*.sql", "s3_prefix": "myapp/postgresql" },
+      { "s3_bucket": "lerian-casdoor-init-data", "file_pattern": "init/casdoor/*.json", "aws_role_arn": "${{ secrets.AWS_INIT_DATA_ROLE_ARN }}" }
+    ]
+```
 ## ApiDog E2E tests
 
 Set `enable_apidog_e2e: true` to run [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) on tag push after a successful `update_gitops`. The job is skipped on branch pushes and when the gitops update did not succeed.


### PR DESCRIPTION
## Description

The inline `s3_upload` job in `go-release.yml` assumed a single role (`AWS_MIGRATIONS_ROLE_ARN`) for all `s3_uploads` entries, so repos uploading to buckets that require different IAM roles (e.g. `plugin-access-manager`: `lerian-migration-files` via `AWS_MIGRATIONS_ROLE_ARN` and `lerian-casdoor-init-data` via `AWS_INIT_DATA_ROLE_ARN`) could not be fully consolidated.

This PR adds an optional per-entry `aws_role_arn`. Entries that set it assume that role (via OIDC) for their upload; entries without it use the default `AWS_MIGRATIONS_ROLE_ARN`.

### Why `aws_role_arn` (value) and not `aws_role_secret` (name)

The original proposal was a per-entry secret **name**. GitHub Actions cannot resolve a secret by a dynamic name (`${{ secrets[expr] }}` is unsupported — secret names must be literal), so a name-based field is not implementable. Instead the caller resolves its own secret and inlines the **ARN value** into the JSON:

```yaml
secrets:
  AWS_MIGRATIONS_ROLE_ARN: ${{ secrets.AWS_MIGRATIONS_ROLE_ARN }}
with:
  s3_uploads: |
    [
      { "s3_bucket": "lerian-migration-files",  "file_pattern": "migrations/*.sql",       "s3_prefix": "myapp/postgresql" },
      { "s3_bucket": "lerian-casdoor-init-data", "file_pattern": "init/casdoor/*.json",   "aws_role_arn": "${{ secrets.AWS_INIT_DATA_ROLE_ARN }}" }
    ]
```

### Implementation

- The job-level `configure-aws-credentials` (default `AWS_MIGRATIONS_ROLE_ARN`) is **unchanged** — entries without `aws_role_arn` run exactly as before.
- The upload loop is factored into an `upload_entry()` helper. Entries with `aws_role_arn` run in an **isolated subshell** that fetches the GitHub OIDC token and calls `aws sts assume-role-with-web-identity`, masks the temporary credentials (`::add-mask::`), exports them, and uploads — so per-entry credentials never leak into other iterations.
- `AWS_REGION: us-east-2` is set on the step (STS needs a region).

Files: `.github/workflows/go-release.yml` (the `s3_upload` job), `docs/go-release-workflow.md` (per-entry key + "Per-entry IAM role" section).

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `aws_role_arn` is optional; entries without it use the default `AWS_MIGRATIONS_ROLE_ARN` exactly as today.

## Prerequisite (AWS, not a code change)

Each role referenced via `aws_role_arn` must have an OIDC trust policy that allows the **caller** repository — the same prerequisite the default `AWS_MIGRATIONS_ROLE_ARN` role already satisfies. This is IAM configuration on the AWS side, not part of this PR.

## Testing

- [x] YAML syntax validated locally
- [x] `bash -n` on the rewritten upload step — no syntax errors
- [x] Traced both paths: entry without `aws_role_arn` (ambient default creds) and with `aws_role_arn` (OIDC assume-role in an isolated subshell, creds masked)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Confirmed existing single-role `s3_uploads` configs are unaffected
- [x] Confirmed no secrets or tokens are printed in logs (temp credentials masked via `::add-mask::`)
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — to validate on `plugin-access-manager` uploading to both buckets with distinct roles._

## Related Issues

Closes #480
