### PR TITLE
chore(runners): default to eveo-lxc-runners instead of firmino-lxc-runners

### DIFF
--- a/.github/workflows/api-dog-e2e-tests.yml
+++ b/.github/workflows/api-dog-e2e-tests.yml
@@ -21,7 +21,7 @@ on:
       runner_type:
         description: 'GitHub runner type to use'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'eveo-lxc-runners'
       auto_detect_environment:
         description: 'Enable automatic environment detection from tag (beta/rc)'
         type: boolean

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -126,9 +126,9 @@ on:
         type: string
         default: ''
       gitops_runner_type:
-        description: 'Runner for the gitops-update (deploy) job. Deploy needs cluster access, so this defaults to firmino-lxc-runners rather than the build runner.'
+        description: 'Runner for the gitops-update (deploy) job. Deploy needs cluster access, so this defaults to eveo-lxc-runners rather than the build runner.'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'eveo-lxc-runners'
       enable_argocd_sync:
         description: 'Trigger ArgoCD sync after updating the GitOps repository'
         type: boolean
@@ -169,9 +169,9 @@ on:
         type: boolean
         default: false
       apidog_runner_type:
-        description: 'Runner for the ApiDog E2E test job. Needs reach to the deployed environment, so it defaults to firmino-lxc-runners rather than the build runner.'
+        description: 'Runner for the ApiDog E2E test job. Needs reach to the deployed environment, so it defaults to eveo-lxc-runners rather than the build runner.'
         type: string
-        default: 'firmino-lxc-runners'
+        default: 'eveo-lxc-runners'
       apidog_auto_detect_environment:
         description: 'Auto-detect the ApiDog environment from the tag (beta -> dev, rc -> stg). When false, the manual APIDOG_ENVIRONMENT_ID secret is used.'
         type: boolean


### PR DESCRIPTION
## Summary
Switch the default runner pool for cluster-access jobs from `firmino-lxc-runners` to `eveo-lxc-runners`.

## Why
`firmino` is being decommissioned and `benedita` (running on `eveo`) is the new primary cluster. Jobs that need cluster reachability — gitops deploy + ApiDog E2E tests — should default to runners that can reach the new cluster.

## Scope
Renames the **default value** of three reusable-workflow inputs. All inputs remain configurable, so any caller that still wants the firmino pool can pass it explicitly.

| File | Input | Old default | New default |
|---|---|---|---|
| `.github/workflows/go-release.yml` | `gitops_runner_type` | `firmino-lxc-runners` | `eveo-lxc-runners` |
| `.github/workflows/go-release.yml` | `apidog_runner_type` | `firmino-lxc-runners` | `eveo-lxc-runners` |
| `.github/workflows/api-dog-e2e-tests.yml` | `runner_type` | `firmino-lxc-runners` | `eveo-lxc-runners` |

Description strings updated to match the new default.

## Out of scope
- `deploy_in_firmino` input name and cluster-name references in `config/deployment-matrix.yml` — left untouched to avoid breaking downstream workflows that pass `deploy_in_firmino: true`. Can be cleaned up in a follow-up once firmino is fully gone.
- `gitops-update.yml` `runner_type` already defaults to `blacksmith-4vcpu-ubuntu-2404` and is unaffected.

## Validation
- Diff is 5 lines across 2 files
- No `firmino-lxc-runners` references remain (verified via grep)
- Reusable-workflow inputs remain backward-compatible (callers can still override)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default infrastructure runner configuration for CI/CD workflows.

---

**Note:** This is an internal infrastructure update with no direct user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->