### PR TITLE
fix(go-release): fail on invalid s3_uploads JSON and sync runner_type docs

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -371,8 +371,8 @@ jobs:
               --output text
           }
 
-          if ! PARSED_ENTRIES=$(printf '%s' "$S3_UPLOADS" | jq -c '.[]'); then
-            echo "::error::s3_uploads is not valid JSON."
+          if ! PARSED_ENTRIES=$(printf '%s' "$S3_UPLOADS" | jq -c 'if type == "array" then .[] else error("s3_uploads must be a JSON array") end'); then
+            echo "::error::s3_uploads must be a valid JSON array."
             exit 1
           fi
           mapfile -t ENTRIES < <(printf '%s' "$PARSED_ENTRIES")

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -371,7 +371,11 @@ jobs:
               --output text
           }
 
-          mapfile -t ENTRIES < <(printf '%s' "$S3_UPLOADS" | jq -c '.[]')
+          if ! PARSED_ENTRIES=$(printf '%s' "$S3_UPLOADS" | jq -c '.[]'); then
+            echo "::error::s3_uploads is not valid JSON."
+            exit 1
+          fi
+          mapfile -t ENTRIES < <(printf '%s' "$PARSED_ENTRIES")
           if [[ ${#ENTRIES[@]} -eq 0 ]]; then
             echo "::warning::s3_uploads is empty — nothing to upload."
             exit 0

--- a/docs/api-dog-e2e-tests-workflow.md
+++ b/docs/api-dog-e2e-tests-workflow.md
@@ -23,7 +23,7 @@ api-tests:
     test_iterations: "1"
     output_formats: "html,cli"
     node_version: "20"
-    runner_type: "firmino-lxc-runners"
+    runner_type: "eveo-lxc-runners"
     secrets: inherit
 ```
 
@@ -77,7 +77,7 @@ jobs:
 | `node_version` | string | `20` | Node.js version to use |
 | `test_iterations` | string | `1` | Number of test iterations |
 | `output_formats` | string | `html,cli` | Report formats (comma-separated: html, cli, json) |
-| `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `runner_type` | string | `eveo-lxc-runners` | GitHub runner type |
 | `auto_detect_environment` | boolean | `false` | Enable automatic environment detection from tag |
 | `apidog_cli_version` | string | `latest` | Apidog CLI version to install (npm dist-tag or version, e.g. `latest`, `0.5.2`). Pin to a specific version to avoid non-deterministic CI behavior. |
 
@@ -190,7 +190,7 @@ with:
 
 ```yaml
 with:
-  runner_type: "firmino-lxc-runners"
+  runner_type: "eveo-lxc-runners"
 ```
 
 Faster execution and better resource control.
@@ -322,7 +322,7 @@ jobs:
       auto_detect_environment: true
       test_iterations: "3"
       output_formats: "html,cli,json"
-      runner_type: "firmino-lxc-runners"
+      runner_type: "eveo-lxc-runners"
     secrets: inherit
 ```
 

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -52,7 +52,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `gitops_repository` | GitOps repository to update (org/repo) | string | `LerianStudio/midaz-firmino-gitops` |
 | `gitops_artifact_pattern` | Pattern to download GitOps artifacts. Empty → `gitops-tags-<repo-name>*` | string | `''` |
 | `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
-| `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `firmino-lxc-runners` |
+| `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `eveo-lxc-runners` |
 | `enable_argocd_sync` | Trigger ArgoCD sync after updating the GitOps repo | boolean | `true` |
 | `commit_message_prefix` | Prefix for the GitOps commit message. Empty → `app_name_prefix`, then repo name | string | `''` |
 | `deploy_in_firmino` | Force-off override for Firmino; set `false` to suppress deployment even when the manifest includes the app | boolean | `true` |
@@ -62,7 +62,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `s3_uploads` | JSON array of S3 upload entries run after build on tag push (see [S3 migrations upload](#s3-migrations-upload)) | string | `''` |
 | `enable_apidog_e2e` | Run the ApiDog E2E test job on tag push after a successful gitops-update | boolean | `false` |
-| `apidog_runner_type` | Runner for the ApiDog E2E test job (needs reach to the deployed environment) | string | `firmino-lxc-runners` |
+| `apidog_runner_type` | Runner for the ApiDog E2E test job (needs reach to the deployed environment) | string | `eveo-lxc-runners` |
 | `apidog_auto_detect_environment` | Auto-detect the ApiDog environment from the tag (beta → dev, rc → stg); when `false`, uses `APIDOG_ENVIRONMENT_ID` | boolean | `true` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |


### PR DESCRIPTION
## Description

Addresses three findings CodeRabbit raised on the `develop → main` release PR (#483). They already live on `develop`, so they're fixed here on a branch off `develop` (the release PR picks them up).

1. **`s3_upload`: fail on invalid `s3_uploads` JSON (fail-open bug).** `mapfile -t ENTRIES < <(… jq …)` runs `jq` inside a process substitution, so its non-zero exit is invisible to `set -euo pipefail`. With malformed `S3_UPLOADS`, `jq` errored, `mapfile` still produced zero entries, and the job logged "nothing to upload" and exited **0** — silently skipping migration uploads on a tag release. Now the parse is captured and a parse failure errors out explicitly:
   ```bash
   if ! PARSED_ENTRIES=$(printf '%s' "$S3_UPLOADS" | jq -c '.[]'); then
     echo "::error::s3_uploads is not valid JSON."; exit 1
   fi
   mapfile -t ENTRIES < <(printf '%s' "$PARSED_ENTRIES")
   ```
   A valid empty array still no-ops (exit 0) as before.

2. **Docs drift: `go-release` runner defaults.** `gitops_runner_type` and `apidog_runner_type` now default to `eveo-lxc-runners` in the workflow, but `docs/go-release-workflow.md` still listed `firmino-lxc-runners` (rows for both inputs). Synced.

3. **Docs drift: api-dog runner default.** `api-dog-e2e-tests.yml` `runner_type` now defaults to `eveo-lxc-runners`; `docs/api-dog-e2e-tests-workflow.md` still showed `firmino-lxc-runners` in the inputs table and examples. Synced (4 occurrences).

Files: `.github/workflows/go-release.yml`, `docs/go-release-workflow.md`, `docs/api-dog-e2e-tests-workflow.md`.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The JSON-validation change only converts a previously-silent failure (invalid JSON) into an explicit error; valid configs (including an empty array) behave as before. The doc edits are documentation-only.

## Testing

- [x] YAML syntax validated locally
- [x] `bash -n` on the rewritten `s3_upload` step — no syntax errors
- [x] Traced the parse logic: invalid JSON → `jq` non-zero → explicit error + exit 1; valid `[]` → no entries → "nothing to upload" exit 0; populated array → entries parsed
- [x] Confirmed no remaining `firmino-lxc-runners` references in the two docs
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — covered by the existing s3_upload validation on a caller release._

## Related Issues

Addresses CodeRabbit review findings on #483 (develop → main). No standalone issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 upload parsing by validating that the `s3_uploads` input is a proper JSON array, with clear failure messaging on invalid formats.

* **Documentation**
  * Updated workflow documentation to use the current default runner type (`eveo-lxc-runners`) across API Dog E2E and Go release pipeline guides, including environment setup and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->