### PR TITLE
fix(go-release): guard extra_build against empty JSON array

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -412,7 +412,7 @@ jobs:
 
   # ----------------- Extra Builds (tag push, opt-in) -----------------
   extra_build:
-    if: github.ref_type == 'tag' && inputs.extra_builds != ''
+    if: github.ref_type == 'tag' && inputs.extra_builds != '' && inputs.extra_builds != '[]'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When a caller passes `extra_builds: '[]'` (empty JSON array as a string), the `extra_build` job's guard `inputs.extra_builds != ''` evaluates to **true** because `'[]'` is not an empty string. GitHub Actions then attempts to run the job with an empty matrix, which **fails** the job. Since `update_gitops` has `needs: [build, extra_build]` and checks `needs.extra_build.result != 'failure'`, the gitops update is skipped even though the primary `build` succeeded with artifacts.

This happens when callers compute `extra_builds` dynamically (e.g., based on changed files) and produce `'[]'` when no extra components changed.

**Fix:** add `&& inputs.extra_builds != '[]'` to the `extra_build` job's `if:` condition. This causes the job to be correctly **skipped** (instead of **failed**) when the array is empty, which lets the existing `update_gitops` condition resolve correctly via `needs.build.result == 'success' && needs.build.outputs.has_builds == 'true'`.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values

**Caller repo / workflow run:** reproduced via issue #486 report (tag push with `extra_builds: '[]'` → `update_gitops` skipped)

## Related Issues

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow gating so extra build jobs no longer run when no extra builds are configured.
  * This helps avoid unnecessary release processing and keeps automated releases cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->