### PR TITLE
feat(go-pr-validation): expose monorepo security params to security scan

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -150,6 +150,18 @@ on:
         description: 'Languages to analyze with CodeQL (comma-separated, e.g., "go")'
         type: string
         default: ''
+      monorepo_type:
+        description: 'Monorepo layout for the security scan. "type1" = components in separate folders (default). "type2" = backend at repo root + one independent component in a sub-folder.'
+        type: string
+        default: 'type1'
+      frontend_folder:
+        description: 'Sub-folder treated as an independent scan component in type2 repos (e.g. "tools/mock-sta-server"). Ignored when monorepo_type is "type1".'
+        type: string
+        default: 'frontend'
+      trivy_skip_dirs:
+        description: 'Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. "tools/mock-sta-server").'
+        type: string
+        default: ''
 
       # ----------------- Lerian lib version (lerian-lib-version-check.yml) -----------------
       lib_version_go_mod_path:
@@ -272,6 +284,9 @@ jobs:
       filter_paths: ${{ inputs.filter_paths }}
       path_level: ${{ format('{0}', inputs.path_level) }}
       shared_paths: ${{ inputs.shared_paths }}
+      monorepo_type: ${{ inputs.monorepo_type }}
+      frontend_folder: ${{ inputs.frontend_folder }}
+      trivy_skip_dirs: ${{ inputs.trivy_skip_dirs }}
     secrets: inherit
 
   security-gate:

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -112,6 +112,11 @@ on:
         type: string
         required: false
         default: ''
+      trivy_skip_dirs:
+        description: 'Comma-separated directories to skip in the Trivy filesystem scan (appended to the default skip list: .git,node_modules,dist,build,.next,coverage,vendor).'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   actions: read         # Required for CodeQL status reporting
@@ -192,6 +197,7 @@ jobs:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
           ignore-file: ${{ inputs.ignore_file }}
+          skip-dirs: ".git,node_modules,dist,build,.next,coverage,vendor${{ inputs.trivy_skip_dirs != '' && format(',{0}', inputs.trivy_skip_dirs) || '' }}"
 
       # ----------------- Docker Build -----------------
       - name: Build Docker Image for Scanning

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -52,6 +52,9 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`); lets monorepos without a root Dockerfile keep `enable_docker_scan: true` | string | `''` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
+| `monorepo_type` | Monorepo layout for the security scan. `"type1"` = components in separate folders (default). `"type2"` = backend at repo root + one independent component in a sub-folder. | string | `'type1'` |
+| `frontend_folder` | Sub-folder treated as an independent scan component in type2 repos (e.g. `"tools/mock-sta-server"`). Ignored when `monorepo_type` is `"type1"`. | string | `'frontend'` |
+| `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. `"tools/mock-sta-server"`). | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
 
 ## Secrets

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -201,6 +201,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
 | `prerelease_block_branches` | string | `release-candidate,main` | Comma-separated PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only |
 | `ignore_file` | string | `''` | Path to Trivy ignore file (e.g., `.trivyignore.yaml`) for path-scoped suppression of secrets and vulnerabilities. Passed through to `trivy-fs-scan` via `--ignorefile`. Supports Trivy's structured YAML format with `paths:` constraints |
+| `trivy_skip_dirs` | string | `''` | Comma-separated directories to skip in the Trivy filesystem scan (appended to the default skip list: `.git`, `node_modules`, `dist`, `build`, `.next`, `coverage`, `vendor`). Useful for excluding sub-modules from the root scan (e.g. `tools/mock-sta-server`) |
 
 ## Secrets
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`pr-security-scan.yml` already supports monorepo component scanning via `monorepo_type`, `frontend_folder`, and `app_name_overrides`, but `go-pr-validation.yml` — the main entry-point used by most Go repos — did not expose these inputs or forward them to the internal `pr-security-scan.yml` call. Repos using `go-pr-validation.yml` had no way to configure per-component Trivy scans without either calling `pr-security-scan.yml` directly (breaking check names) or accepting CVE attribution across sub-modules.

This PR exposes three new inputs in `go-pr-validation.yml` and forwards them to `pr-security-scan.yml`:

- **`monorepo_type`** (`string`, default `'type1'`) — security scan layout: `type1` (components in separate folders) or `type2` (backend at root + one sub-folder component).
- **`frontend_folder`** (`string`, default `'frontend'`) — the sub-folder treated as an independent scan component in `type2` repos.
- **`trivy_skip_dirs`** (`string`, default `''`) — comma-separated dirs appended to the built-in Trivy skip list (`.git,node_modules,dist,build,.next,coverage,vendor`), useful for excluding sub-modules like `tools/mock-sta-server` from the root component scan.

`trivy_skip_dirs` is also added as a new input to `pr-security-scan.yml` and wired into the `trivy-fs-scan` composite call.

All three inputs default to values that preserve the current behavior — no existing caller is affected.

**Example usage for a repo with a `tools/mock-sta-server` sub-module:**
```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-validation.yml@vX.Y.Z
with:
  monorepo_type: type2
  frontend_folder: tools/mock-sta-server
  trivy_skip_dirs: "tools/mock-sta-server"
  # ... rest of params unchanged
```

This produces two independent scan components:
- **root component** → `trivy fs .` skipping `tools/mock-sta-server`
- **mock-sta-server component** → `trivy fs tools/mock-sta-server`

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [x] Verified all existing inputs still work with default values

**Caller repo / workflow run:** validated via issue #492 analysis; defaults preserve current behavior for all existing callers.

## Related Issues

Closes #492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended reusable validation and security-scan workflows with new configurable security inputs: monorepo layout selection, frontend folder, and `trivy_skip_dirs`.
  * Security scans can now skip additional directories in filesystem analysis via the customizable `trivy_skip_dirs` list.
* **Documentation**
  * Updated workflow documentation to describe the new inputs and their defaults for security scanning configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->