### PR TITLE
feat(release): develop to main

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -150,6 +150,18 @@ on:
         description: 'Languages to analyze with CodeQL (comma-separated, e.g., "go")'
         type: string
         default: ''
+      monorepo_type:
+        description: 'Monorepo layout for the security scan. "type1" = components in separate folders (default). "type2" = backend at repo root + one independent component in a sub-folder.'
+        type: string
+        default: 'type1'
+      frontend_folder:
+        description: 'Sub-folder treated as an independent scan component in type2 repos (e.g. "tools/mock-sta-server"). Ignored when monorepo_type is "type1".'
+        type: string
+        default: 'frontend'
+      trivy_skip_dirs:
+        description: 'Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. "tools/mock-sta-server").'
+        type: string
+        default: ''
 
       # ----------------- Lerian lib version (lerian-lib-version-check.yml) -----------------
       lib_version_go_mod_path:
@@ -272,6 +284,9 @@ jobs:
       filter_paths: ${{ inputs.filter_paths }}
       path_level: ${{ format('{0}', inputs.path_level) }}
       shared_paths: ${{ inputs.shared_paths }}
+      monorepo_type: ${{ inputs.monorepo_type }}
+      frontend_folder: ${{ inputs.frontend_folder }}
+      trivy_skip_dirs: ${{ inputs.trivy_skip_dirs }}
     secrets: inherit
 
   security-gate:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -412,7 +412,7 @@ jobs:
 
   # ----------------- Extra Builds (tag push, opt-in) -----------------
   extra_build:
-    if: github.ref_type == 'tag' && inputs.extra_builds != ''
+    if: github.ref_type == 'tag' && inputs.extra_builds != '' && inputs.extra_builds != '[]'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -112,6 +112,11 @@ on:
         type: string
         required: false
         default: ''
+      trivy_skip_dirs:
+        description: 'Comma-separated directories to skip in the Trivy filesystem scan (appended to the default skip list: .git,node_modules,dist,build,.next,coverage,vendor).'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   actions: read         # Required for CodeQL status reporting
@@ -192,6 +197,7 @@ jobs:
           scan-ref: ${{ matrix.working_dir }}
           app-name: ${{ env.APP_NAME }}
           ignore-file: ${{ inputs.ignore_file }}
+          skip-dirs: ".git,node_modules,dist,build,.next,coverage,vendor${{ inputs.trivy_skip_dirs != '' && format(',{0}', inputs.trivy_skip_dirs) || '' }}"
 
       # ----------------- Docker Build -----------------
       - name: Build Docker Image for Scanning

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -52,6 +52,9 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`); lets monorepos without a root Dockerfile keep `enable_docker_scan: true` | string | `''` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
+| `monorepo_type` | Monorepo layout for the security scan. `"type1"` = components in separate folders (default). `"type2"` = backend at repo root + one independent component in a sub-folder. | string | `'type1'` |
+| `frontend_folder` | Sub-folder treated as an independent scan component in type2 repos (e.g. `"tools/mock-sta-server"`). Ignored when `monorepo_type` is `"type1"`. | string | `'frontend'` |
+| `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. `"tools/mock-sta-server"`). | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
 
 ## Secrets

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -201,6 +201,7 @@ When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for 
 | `enable_prerelease_check` | boolean | `true` | Block dependencies pinned to pre-release versions (`-beta`, `-rc`) |
 | `prerelease_block_branches` | string | `release-candidate,main` | Comma-separated PR target branches where pre-release versions cause a hard failure. On other branches, findings are reported as warnings only |
 | `ignore_file` | string | `''` | Path to Trivy ignore file (e.g., `.trivyignore.yaml`) for path-scoped suppression of secrets and vulnerabilities. Passed through to `trivy-fs-scan` via `--ignorefile`. Supports Trivy's structured YAML format with `paths:` constraints |
+| `trivy_skip_dirs` | string | `''` | Comma-separated directories to skip in the Trivy filesystem scan (appended to the default skip list: `.git`, `node_modules`, `dist`, `build`, `.next`, `coverage`, `vendor`). Useful for excluding sub-modules from the root scan (e.g. `tools/mock-sta-server`) |
 
 ## Secrets
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

<!-- Summarize what this PR does and why. List which workflow(s) are affected and what behavior changes. -->

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

<!-- If applicable, describe exactly what breaks and how callers should migrate. Remove this section if not applicable. -->

None.

## Testing

<!-- Shared workflows can't be unit-tested locally. Describe how you validated the change. -->

- [x] YAML syntax validated locally
- [x] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- Link to the Actions run that validated this change -->

## Related Issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more configuration options for PR validation security scans, including monorepo layout settings and extra scan exclusions.
  * Security scans can now skip additional directories during filesystem analysis.
* **Bug Fixes**
  * Improved release workflow conditions so extra build steps only run when actual build entries are provided.
* **Documentation**
  * Updated workflow docs to reflect the new configuration options and scan skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->