### PR TITLE
fix(gitops-update): rename lerian-notification to notifications in deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -69,7 +69,7 @@ apps:
     - reporter
     - tracer
     - product-console
-    - lerian-notification
+    - notifications
 
     # Plugins
     - plugin-access-manager       # caller repo may push as plugin-identity / plugin-auth / casdoor
@@ -164,7 +164,7 @@ clusters:
       - gestao-acessos-console
       - lerian-map
       - tenant-manager
-      - lerian-notification
+      - notifications
       - rosiehr
       - go-boilerplate-ddd
       - severino-bot


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `lerian-notification` repository was renamed to `notifications`. The deployment matrix still referenced the old name, causing the gitops-update workflow to warn `App 'notifications' is not registered in any cluster` on every tag push.

Renames the entry in `apps.registry` and in the `benedita` cluster apps list from `lerian-notification` to `notifications`, matching the app name used by the caller (`app_name_prefix: "notifications"`) and the helmfile path (`environments/benedita/helmfile/applications/.../notifications/`).

## Type of Change

- [x] `fix`: Bug fix

## Breaking Changes

None. Callers using the old `lerian-notification` app name will no longer match any cluster (but the repository was already renamed, so no active caller uses the old name).

## Testing

- [x] Deployment matrix lint passes (0 errors, 0 warnings)
- [x] Validated against lerian-internal-gitops: `environments/benedita/helmfile/applications/stg-mt/notifications/` exists

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include the `notifications` app and remove the old `lerian-notification` entry for the affected cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->