### PR TITLE
fix(go-pr-analysis): prevent code injection via coverage_threshold interpolation

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -645,14 +645,19 @@ jobs:
       - name: Post coverage comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+          THRESHOLD: ${{ inputs.coverage_threshold }}
+          APP_NAME: ${{ matrix.app.name }}
+          WORKING_DIR: ${{ matrix.app.working_dir }}
         with:
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           script: |
             const fs = require('fs');
-            const coverage = '${{ steps.coverage.outputs.coverage }}';
-            const threshold = '${{ inputs.coverage_threshold }}';
-            const appName = '${{ matrix.app.name }}';
-            const workingDir = '${{ matrix.app.working_dir }}';
+            const coverage = process.env.COVERAGE;
+            const threshold = process.env.THRESHOLD;
+            const appName = process.env.APP_NAME;
+            const workingDir = process.env.WORKING_DIR;
             const passFail = parseFloat(coverage) >= parseFloat(threshold) ? '✅ PASS' : '⚠️ BELOW THRESHOLD';
 
             let coverageReport = '';
@@ -712,9 +717,10 @@ jobs:
 
       - name: Check coverage threshold
         if: inputs.fail_on_coverage_threshold
+        env:
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+          THRESHOLD: ${{ inputs.coverage_threshold }}
         run: |
-          COVERAGE=${{ steps.coverage.outputs.coverage }}
-          THRESHOLD=${{ inputs.coverage_threshold }}
           if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
             echo "::error::Coverage $COVERAGE% is below threshold $THRESHOLD%"
             exit 1


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

CodeQL (Actions analysis) flagged two medium-severity code injection vectors in `go-pr-analysis.yml` where the `coverage_threshold` workflow input was interpolated directly into executable contexts without sanitization.

**Fix 1 — JavaScript injection (`actions/github-script` step):**
`coverage_threshold`, `coverage`, `app.name`, and `app.working_dir` were all interpolated inline inside the JS string (`'${{ ... }}'`). A caller passing a crafted string as `coverage_threshold` could execute arbitrary Node.js code. All four values are now passed via the step's `env:` block and read from `process.env.*`.

**Fix 2 — Shell injection (`run` step):**
`COVERAGE` and `THRESHOLD` were assigned via bare `${{ ... }}` interpolation before shell parsing. Both are now declared in the step's `env:` block, which ensures GitHub substitutes the value into the environment rather than into the shell command string.

No behavior change — the logic is identical; only the injection surface is eliminated.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The `coverage_threshold` input API is unchanged. Callers do not need to update their configuration.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — CodeQL re-scan on this PR will confirm the alerts are resolved._

## Related Issues

Closes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of coverage reporting in the CI workflow by standardizing how coverage values are passed between steps.
  * Updated the coverage threshold check to use clearer environment-based inputs, helping keep the workflow easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->