### PR TITLE
feat(build): add force_full_matrix opt-in for tightly-coupled components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,10 @@ on:
         description: 'Normalize changed paths to their filter path (e.g., components/app/cmd -> components/app). Recommended for monorepos to avoid duplicate builds.'
         type: boolean
         default: true
+      force_full_matrix:
+        description: 'When true, build all filter_paths components on every run regardless of what changed. Use for repos where components must always share the same image tag (e.g., auth + identity always released together).'
+        type: boolean
+        default: false
       force_multiplatform:
         description: 'Force multi-platform build (amd64+arm64) even for beta/rc tags'
         type: boolean
@@ -182,7 +186,7 @@ jobs:
           app-name-prefix: ${{ inputs.app_name_prefix }}
           app-name-overrides: ${{ inputs.app_name_overrides }}
           normalize-to-filter: ${{ inputs.normalize_to_filter }}
-          force-full-matrix: ${{ github.ref_type == 'tag' }}
+          force-full-matrix: ${{ inputs.force_full_matrix }}
 
       - name: Set matrix
         id: set-matrix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
           app-name-prefix: ${{ inputs.app_name_prefix }}
           app-name-overrides: ${{ inputs.app_name_overrides }}
           normalize-to-filter: ${{ inputs.normalize_to_filter }}
+          force-full-matrix: ${{ github.ref_type == 'tag' }}
 
       - name: Set matrix
         id: set-matrix

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -433,7 +433,7 @@ jobs:
       filter_paths: ${{ matrix.group.filter_paths }}
       shared_paths: ${{ matrix.group.shared_paths || inputs.shared_paths }}
       path_level: ${{ matrix.group.path_level || inputs.path_level }}
-      normalize_to_filter: ${{ toJSON(matrix.group.normalize_to_filter) != 'false' }}
+      normalize_to_filter: ${{ toJSON(matrix.group.normalize_to_filter) == 'false' && 'false' || 'true' }}
       app_name: ${{ matrix.group.app_name }}
       app_name_prefix: ${{ matrix.group.app_name_prefix }}
       app_name_overrides: ${{ matrix.group.app_name_overrides }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -433,7 +433,7 @@ jobs:
       filter_paths: ${{ matrix.group.filter_paths }}
       shared_paths: ${{ matrix.group.shared_paths || inputs.shared_paths }}
       path_level: ${{ matrix.group.path_level || inputs.path_level }}
-      normalize_to_filter: ${{ toJSON(matrix.group.normalize_to_filter) == 'false' && 'false' || 'true' }}
+      normalize_to_filter: ${{ toJSON(matrix.group.normalize_to_filter) != 'false' }}
       app_name: ${{ matrix.group.app_name }}
       app_name_prefix: ${{ matrix.group.app_name_prefix }}
       app_name_overrides: ${{ matrix.group.app_name_overrides }}

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -4,7 +4,7 @@ Reusable workflow for building and pushing Docker images to container registries
 
 ## Features
 
-- **Monorepo support**: Automatic detection of changed components via filter_paths
+- **Monorepo support**: Automatic detection of changed components via filter_paths; on tag pushes all components are always built regardless of what changed
 - **Multi-registry**: Push to DockerHub and/or GitHub Container Registry (GHCR)
 - **Smart platform builds**: Beta/RC tags build amd64 only (unless `force_multiplatform` is enabled), release tags build amd64+arm64
 - **Semantic versioning**: Automatic tag extraction and Docker metadata

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -4,7 +4,7 @@ Reusable workflow for building and pushing Docker images to container registries
 
 ## Features
 
-- **Monorepo support**: Automatic detection of changed components via filter_paths; on tag pushes all components are always built regardless of what changed
+- **Monorepo support**: Automatic detection of changed components via filter_paths; opt-in `force_full_matrix` to always build all components together (useful for tightly-coupled services)
 - **Multi-registry**: Push to DockerHub and/or GitHub Container Registry (GHCR)
 - **Smart platform builds**: Beta/RC tags build amd64 only (unless `force_multiplatform` is enabled), release tags build amd64+arm64
 - **Semantic versioning**: Automatic tag extraction and Docker metadata

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -107,6 +107,7 @@ jobs:
 | `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
 | `build_context` | string | `.` | Docker build context |
 | `enable_gitops_artifacts` | boolean | `false` | Upload artifacts for gitops-update workflow |
+| `force_full_matrix` | boolean | `false` | When `true`, build all `filter_paths` components on every run regardless of what changed. Use for tightly-coupled services that must always share the same image tag (e.g., auth + identity always released together) |
 | `force_multiplatform` | boolean | `false` | Force multi-platform build (amd64+arm64) even for beta/rc tags |
 | `enable_cosign_sign` | boolean | `true` | Sign images with cosign keyless (OIDC) signing. Requires `id-token: write` in caller |
 | `cosign_max_attempts` | string | `3` | Max cosign signing attempts per image. Increase to absorb transient OIDC/Fulcio rate limits |

--- a/src/config/changed-paths/README.md
+++ b/src/config/changed-paths/README.md
@@ -38,6 +38,7 @@ Composite action that detects changed files between commits and outputs a matrix
 | `fallback-app-name` | When `filter-paths` is empty, return single-item matrix with this name | No | `''` |
 | `consolidate-to-root` | Consolidate all entries (except `consolidate-keep-dirs`) to root | No | `false` |
 | `consolidate-keep-dirs` | Newline-separated dirs to keep as-is during consolidation | No | `''` |
+| `force-full-matrix` | When `true`, skip change detection and return all `filter-paths` entries. Use on tag pushes where all components must be built regardless of what changed. | No | `false` |
 
 ## Outputs
 

--- a/src/config/changed-paths/README.md
+++ b/src/config/changed-paths/README.md
@@ -38,7 +38,7 @@ Composite action that detects changed files between commits and outputs a matrix
 | `fallback-app-name` | When `filter-paths` is empty, return single-item matrix with this name | No | `''` |
 | `consolidate-to-root` | Consolidate all entries (except `consolidate-keep-dirs`) to root | No | `false` |
 | `consolidate-keep-dirs` | Newline-separated dirs to keep as-is during consolidation | No | `''` |
-| `force-full-matrix` | When `true`, skip change detection and return all `filter-paths` entries. Use on tag pushes where all components must be built regardless of what changed. | No | `false` |
+| `force-full-matrix` | When `true`, skip change detection and return all `filter-paths` entries. Use for tightly-coupled components that must always share the same image tag (e.g., auth + identity always released together). | No | `false` |
 
 ## Outputs
 

--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: ''
   force-full-matrix:
-    description: 'When true, skip change detection and return all filter-paths entries as the build matrix. Intended for tag pushes where all components must be built regardless of what changed.'
+    description: 'When true, skip change detection and return all filter-paths entries as the build matrix. Use for tightly-coupled components that must always share the same image tag (e.g., auth + identity always released together).'
     required: false
     default: 'false'
 

--- a/src/config/changed-paths/action.yml
+++ b/src/config/changed-paths/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Newline-separated list of working_dirs to keep as-is during consolidation (e.g., "frontend"). Only used when consolidate_to_root is true.'
     required: false
     default: ''
+  force-full-matrix:
+    description: 'When true, skip change detection and return all filter-paths entries as the build matrix. Intended for tag pushes where all components must be built regardless of what changed.'
+    required: false
+    default: 'false'
 
 outputs:
   matrix:
@@ -140,6 +144,7 @@ runs:
         FALLBACK_APP_NAME: ${{ inputs.fallback-app-name }}
         CONSOLIDATE_TO_ROOT: ${{ inputs.consolidate-to-root }}
         CONSOLIDATE_KEEP_DIRS: ${{ inputs.consolidate-keep-dirs }}
+        FORCE_FULL_MATRIX: ${{ inputs.force-full-matrix }}
       run: |
         # Read the file list from the temp file (see "Get changed files"). Command
         # substitution strips the trailing newline, so an empty diff yields empty FILES
@@ -166,17 +171,23 @@ runs:
           done <<< "$APP_NAME_OVERRIDES"
         fi
 
-        if [[ -z "$FILES" ]]; then
+        DIRS_FROM_SHARED=false
+
+        # Force full matrix: skip diff detection and build all filter_paths components
+        if [[ "$FORCE_FULL_MATRIX" == "true" && -n "$FILTER_PATHS" && "$FILTER_PATHS" != "[]" ]]; then
+          echo "Force full matrix: building all filter_paths components"
+          DIRS_FROM_SHARED=true
+        fi
+
+        if [[ "$DIRS_FROM_SHARED" != "true" && -z "$FILES" ]]; then
           echo "No files changed."
           printf "matrix=[]\n" >> "$GITHUB_OUTPUT"
           printf "has_changes=false\n" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        DIRS_FROM_SHARED=false
-
         # Check shared_paths: if any changed file matches, include ALL filter_paths entries
-        if [[ -n "$SHARED_PATHS" ]] && [[ "$SHARED_PATHS" != "[]" ]] && [[ -n "$FILTER_PATHS" ]] && [[ "$FILTER_PATHS" != "[]" ]]; then
+        if [[ "$DIRS_FROM_SHARED" != "true" ]] && [[ -n "$SHARED_PATHS" ]] && [[ "$SHARED_PATHS" != "[]" ]] && [[ -n "$FILTER_PATHS" ]] && [[ "$FILTER_PATHS" != "[]" ]]; then
           if [[ "$SHARED_PATHS" == "["* ]]; then
             SHARED_LIST=$(echo "$SHARED_PATHS" | jq -er '.[]' 2>/dev/null)
             if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Monorepo builds with \`filter_paths\` only build components whose paths changed — the correct default. However, some repos have tightly-coupled components that must always carry the same image tag. For example, \`plugin-auth\` and \`plugin-identity\` in \`plugin-access-manager\` are deployed together in all environments, so mixing \`v3.1.0-beta.27\` (identity) with \`v3.1.0-beta.26\` (auth) creates operational friction.

This PR adds an opt-in \`force_full_matrix\` boolean input to \`build.yml\` (default \`false\`). When enabled, all \`filter_paths\` components are always built on every run regardless of what changed — ensuring tightly-coupled services always share the same image tag.

The feature is implemented via a new \`force-full-matrix\` input on the \`changed-paths\` composite action, which short-circuits diff detection and returns all \`filter-paths\` entries directly, reusing the existing \`DIRS_FROM_SHARED=true\` logic path.

**Usage — \`plugin-access-manager\` example:**
\`\`\`yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1
with:
  force_full_matrix: true   # always build plugin-auth + plugin-identity together
  filter_paths: |
    components/auth
    components/identity
\`\`\`

Files changed:
- \`src/config/changed-paths/action.yml\` — new \`force-full-matrix\` input; skips empty-diff short-circuit and shared_paths check when set
- \`.github/workflows/build.yml\` — new \`force_full_matrix\` input (default \`false\`), forwarded to \`changed-paths\`
- \`src/config/changed-paths/README.md\` — documents the new input
- \`docs/build-workflow.md\` — mentions the new opt-in feature

## Type of Change

- [x] \`feat\`: New workflow or new input/output/step in an existing workflow
- [ ] \`fix\`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] \`perf\`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] \`refactor\`: Internal restructuring with no behavior change
- [ ] \`docs\`: Documentation only (README, docs/, inline comments)
- [ ] \`ci\`: Changes to self-CI (workflows under \`.github/workflows/\` that run on this repo)
- [ ] \`chore\`: Dependency bumps, config updates, maintenance
- [ ] \`test\`: Adding or updating tests
- [ ] \`BREAKING CHANGE\`: Callers must update their configuration after this PR

## Breaking Changes

None. The new input defaults to \`false\`, preserving the existing smart change-detection behavior for all current callers.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using \`@this-branch\` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _Pending — validate on \`plugin-access-manager\` with \`force_full_matrix: true\` to confirm auth + identity always build together._

## Related Issues

Closes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `force_full_matrix` option to build using the full component matrix rather than relying on changed-path detection.
  * When enabled, the build matrix includes all components matched by the configured `filter_paths`, ensuring consistent grouping on tags.

* **Documentation**
  * Updated the build workflow documentation to describe the default changed-paths behavior and how `force_full_matrix` overrides it.
  * Expanded changed-paths action documentation to explain the new `force-full-matrix` input and its effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->