### PR TITLE
fix(gptchangelog): retry OpenRouter API call with exponential backoff

### DIFF
--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -320,18 +320,44 @@ runs:
               max_tokens: 1000
             }')
 
-          HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 60 --connect-timeout 10 -o /tmp/api_response.json \
-            https://openrouter.ai/api/v1/chat/completions \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
-            -H "HTTP-Referer: https://github.com/${GITHUB_REPOSITORY}" \
-            -H "X-Title: GPT Changelog" \
-            -d "$REQUEST_BODY")
+          MAX_ATTEMPTS=3
+          BACKOFF=(10 30)
+          HTTP_CODE="000"
+          for _attempt in 1 2 3; do
+            HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 60 --connect-timeout 10 \
+              -o /tmp/api_response.json \
+              https://openrouter.ai/api/v1/chat/completions \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+              -H "HTTP-Referer: https://github.com/${GITHUB_REPOSITORY}" \
+              -H "X-Title: GPT Changelog" \
+              -d "$REQUEST_BODY") || HTTP_CODE="000"
 
-          if [ "$HTTP_CODE" -ge 400 ]; then
-            echo "⚠️ API returned HTTP $HTTP_CODE for $APP_NAME - skipping"
-            cat /tmp/api_response.json 2>/dev/null || true
-            rm -f /tmp/api_response.json
+            if [[ "$HTTP_CODE" =~ ^[0-9]+$ ]] && [ "$HTTP_CODE" -lt 400 ]; then
+              break
+            fi
+
+            # Permanent client errors (4xx except 429) — no point retrying
+            if [[ "$HTTP_CODE" =~ ^4 ]] && [ "$HTTP_CODE" != "429" ]; then
+              echo "⚠️ Permanent API error HTTP $HTTP_CODE for $APP_NAME — skipping"
+              cat /tmp/api_response.json 2>/dev/null || true
+              break
+            fi
+
+            if [ "$_attempt" -lt "$MAX_ATTEMPTS" ]; then
+              WAIT=${BACKOFF[$((_attempt - 1))]}
+              echo "⚠️ Attempt $_attempt/$MAX_ATTEMPTS failed (HTTP $HTTP_CODE) — retrying in ${WAIT}s"
+              cat /tmp/api_response.json 2>/dev/null || true
+              sleep "$WAIT"
+            else
+              echo "⚠️ All $MAX_ATTEMPTS attempts failed for $APP_NAME (last HTTP $HTTP_CODE) — skipping"
+              cat /tmp/api_response.json 2>/dev/null || true
+            fi
+          done
+
+          rm -f /tmp/api_response.json
+
+          if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]] || [ "$HTTP_CODE" -ge 400 ]; then
             continue
           fi
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The OpenRouter API call in `src/changelog/gptchangelog/action.yml` was made as a single attempt with no retry. When the request failed due to transient network issues or rate limits, `curl` would exit non-zero, causing the variable assignment `HTTP_CODE=$(curl ...)` to also fail. With `set -euo pipefail` active, this terminated the entire step with exit 1 — failing the changelog job even though the error was transient.

**Root cause:** Network-level failures from `curl` produce a non-numeric value in `HTTP_CODE`, making the subsequent `[ "$HTTP_CODE" -ge 400 ]` comparison fail with "integer expression expected", which `pipefail` escalates to a step failure.

**Fix:** Replace the single `curl` call with a retry loop (3 attempts, exponential backoff: 10 s → 30 s):
- `|| HTTP_CODE="000"` captures curl network failures without triggering `pipefail`
- Permanent 4xx errors (except 429) break immediately — no point retrying auth/not-found errors
- 429 (rate limit) and 5xx (server errors) and network failures are retried
- After all retries, the app is skipped with a warning (`continue`) — one app's changelog failure does not abort the whole job

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The behavior is identical on success. On failure, the step is now more resilient — transient errors are retried before skipping the app.

## Testing

- [x] YAML syntax validated locally
- [x] `bash -n` on the modified step — no syntax errors
- [x] Traced the retry loop: network failure → `HTTP_CODE="000"` → retries → skip after 3 attempts
- [x] Permanent 4xx path: sets `HTTP_CODE` from curl, breaks immediately, `continue`s to next app
- [ ] Triggered a real workflow run on a caller repository using `@this-branch`
- [x] Confirmed no secrets or tokens are printed in logs

## Related Issues

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog generation reliability by retrying failed API requests instead of failing immediately.
  * Added smarter handling for temporary errors and rate limits, reducing skipped app changelog entries.
  * Non-retryable client errors now stop quickly with clearer logging, while successful requests proceed without delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->