### PR TITLE
fix(lerian-lib-version): add TTL support to .lerianstudiolibignore

### DIFF
--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -45,6 +45,9 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 | `.lerianstudiolibignore` does not exist                  | `::warning` — proceed normally                             |
 | A lib is matched by an ignore-skip rule                  | Skipped, marked _skipped_ in the report                    |
 | A lib is matched by an ignore-pin rule (`lib@vX.Y.Z`)    | Compared against the pin instead of latest, marked _pinned_ |
+| A lib has an active TTL (`lib\|ttl:YYYY-MM-DD`)          | Rule honored; expiry date shown in the report column        |
+| A lib's TTL has expired (today ≥ TTL date)               | `::warning` — rule ignored, version check enforced         |
+| TTL date format is invalid                               | `::warning` — treated as expired, version check enforced   |
 | Latest stable release cannot be resolved (API error)     | `::warning` — marked _unknown_, does not fail              |
 
 ## `.lerianstudiolibignore` format
@@ -60,9 +63,25 @@ lib-commons/v5@v5.3.0
 
 # Skip an unversioned module path (v0/v1 modules)
 lib-foo
+
+# Skip with TTL — defer until 2025-09-30, then enforce again automatically
+lib-auth/v2|ttl:2025-09-30
+
+# Pin with TTL — pin is active until 2025-09-30, then latest is enforced
+lib-commons/v5@v5.3.0|ttl:2025-09-30
 ```
 
 Use the **short module path** (strip `github.com/LerianStudio/`).
+
+### TTL (time-to-live)
+
+Append `|ttl:YYYY-MM-DD` to any rule to set an expiry date:
+
+- **Before the TTL date** — the ignore or pin rule is honored as usual. The report shows the expiry date in the status column.
+- **On or after the TTL date** — the rule is treated as if it does not exist. A `::warning` is emitted and the version check is enforced normally.
+- **Invalid format** — treated as expired (safe default). A `::warning` is emitted.
+
+This gives teams a built-in reminder mechanism: acknowledge a deferred bump with a concrete deadline, and CI re-enforces it automatically once the deadline passes.
 
 ## Usage as composite step
 

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -155,7 +155,7 @@ runs:
 
             # Validate TTL date format and check expiry
             if [[ -n "${ttl}" ]]; then
-              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || ! date -d "${ttl}" +%Y-%m-%d > /dev/null 2>&1; then
                 echo "::warning title=Invalid TTL format::Ignore rule for '${line}' has invalid TTL '${ttl}' (expected YYYY-MM-DD). Treating as expired."
                 continue
               fi

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -159,12 +159,28 @@ runs:
               if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
                 _ttl_ok=false
               else
-                # Portable calendar range check (no GNU date required).
+                # Portable full calendar check (no GNU date required).
                 # Pre-expand with $(( 10#... )) to avoid SC2309 in [[ -lt/-gt ]].
-                _ttl_mi=$(( 10#${ttl:5:2} )); _ttl_di=$(( 10#${ttl:8:2} ))
-                if [[ "${_ttl_mi}" -lt 1 || "${_ttl_mi}" -gt 12 || \
-                      "${_ttl_di}" -lt 1 || "${_ttl_di}" -gt 31 ]]; then
+                _ttl_yi=$(( 10#${ttl:0:4} ))
+                _ttl_mi=$(( 10#${ttl:5:2} ))
+                _ttl_di=$(( 10#${ttl:8:2} ))
+                if [[ "${_ttl_mi}" -lt 1 || "${_ttl_mi}" -gt 12 ]]; then
                   _ttl_ok=false
+                else
+                  case "${_ttl_mi}" in
+                    1|3|5|7|8|10|12) _ttl_max_day=31 ;;
+                    4|6|9|11)        _ttl_max_day=30 ;;
+                    2)
+                      if (( (_ttl_yi % 400 == 0) || (_ttl_yi % 4 == 0 && _ttl_yi % 100 != 0) )); then
+                        _ttl_max_day=29
+                      else
+                        _ttl_max_day=28
+                      fi
+                      ;;
+                  esac
+                  if [[ "${_ttl_di}" -lt 1 || "${_ttl_di}" -gt "${_ttl_max_day}" ]]; then
+                    _ttl_ok=false
+                  fi
                 fi
               fi
               if [[ "${_ttl_ok}" != "true" ]]; then

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -155,11 +155,19 @@ runs:
 
             # Validate TTL date format and check expiry
             if [[ -n "${ttl}" ]]; then
-              # Portable calendar range check (no GNU date required)
-              _ttl_m="${ttl:5:2}"; _ttl_d="${ttl:8:2}"
-              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || \
-                 [[ 10#${_ttl_m} -lt 1 || 10#${_ttl_m} -gt 12 ]] || \
-                 [[ 10#${_ttl_d} -lt 1 || 10#${_ttl_d} -gt 31 ]]; then
+              _ttl_ok=true
+              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                _ttl_ok=false
+              else
+                # Portable calendar range check (no GNU date required).
+                # Pre-expand with $(( 10#... )) to avoid SC2309 in [[ -lt/-gt ]].
+                _ttl_mi=$(( 10#${ttl:5:2} )); _ttl_di=$(( 10#${ttl:8:2} ))
+                if [[ "${_ttl_mi}" -lt 1 || "${_ttl_mi}" -gt 12 || \
+                      "${_ttl_di}" -lt 1 || "${_ttl_di}" -gt 31 ]]; then
+                  _ttl_ok=false
+                fi
+              fi
+              if [[ "${_ttl_ok}" != "true" ]]; then
                 echo "::warning title=Invalid TTL format::Ignore rule for '${line}' has invalid TTL '${ttl}' (expected YYYY-MM-DD). Treating as expired."
                 continue
               fi

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -128,10 +128,15 @@ runs:
         # ---------- 2. Load ignore file (optional) ----------
         # Format:
         #   # comment
-        #   lib-name/vN                  -> skip entirely
-        #   lib-name/vN@vX.Y.Z           -> pin: only fail if current < pinned target
+        #   lib-name/vN                          -> skip entirely (permanent)
+        #   lib-name/vN@vX.Y.Z                   -> pin: only fail if current < pinned target
+        #   lib-name/vN|ttl:YYYY-MM-DD           -> skip until TTL date (expires on/after that date)
+        #   lib-name/vN@vX.Y.Z|ttl:YYYY-MM-DD   -> pin until TTL date
         declare -A IGNORE_SKIP=()       # key: module path  -> "1"
         declare -A IGNORE_PIN=()        # key: module path  -> pinned version (vX.Y.Z)
+        declare -A IGNORE_TTL=()        # key: module path  -> TTL date (YYYY-MM-DD)
+
+        TODAY=$(date -u +%Y-%m-%d)
 
         if [[ -f "${IGNORE_FILE}" ]]; then
           log "Loading ignore rules from ${IGNORE_FILE}"
@@ -140,14 +145,36 @@ runs:
             line="${line#"${line%%[![:space:]]*}"}"
             line="${line%"${line##*[![:space:]]}"}"
             [[ -z "${line}" ]] && continue
+
+            # Extract optional TTL suffix: lib-name/vN[|ttl:YYYY-MM-DD]
+            ttl=""
+            if [[ "${line}" == *"|ttl:"* ]]; then
+              ttl="${line##*|ttl:}"
+              line="${line%%|ttl:*}"
+            fi
+
+            # Validate TTL date format and check expiry
+            if [[ -n "${ttl}" ]]; then
+              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                echo "::warning title=Invalid TTL format::Ignore rule for '${line}' has invalid TTL '${ttl}' (expected YYYY-MM-DD). Treating as expired."
+                continue
+              fi
+              if ! [[ "${TODAY}" < "${ttl}" ]]; then
+                echo "::warning title=Expired ignore rule::Ignore rule for '${line}' (ttl: ${ttl}) has expired as of ${TODAY}. Version check enforced."
+                continue
+              fi
+            fi
+
             if [[ "${line}" == *"@"* ]]; then
               mod="${line%@*}"
               pin="${line##*@}"
               IGNORE_PIN["${mod}"]="${pin}"
-              debug "ignore-pin: ${mod} -> ${pin}"
+              [[ -n "${ttl}" ]] && IGNORE_TTL["${mod}"]="${ttl}"
+              debug "ignore-pin: ${mod} -> ${pin}${ttl:+ (ttl: ${ttl})}"
             else
               IGNORE_SKIP["${line}"]="1"
-              debug "ignore-skip: ${line}"
+              [[ -n "${ttl}" ]] && IGNORE_TTL["${line}"]="${ttl}"
+              debug "ignore-skip: ${line}${ttl:+ (ttl: ${ttl})}"
             fi
           done < "${IGNORE_FILE}"
         else
@@ -282,7 +309,9 @@ runs:
           # Ignore rules
           if [[ -n "${IGNORE_SKIP[${short_path}]:-}" ]]; then
             SKIPPED=$((SKIPPED+1))
-            printf '| `%s` | `%s` | _skipped_ | Skipped (ignore file) |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
+            ttl_suffix=""
+            [[ -n "${IGNORE_TTL[${short_path}]:-}" ]] && ttl_suffix=", expires ${IGNORE_TTL[${short_path}]}"
+            printf '| `%s` | `%s` | _skipped_ | Skipped (ignore file%s) |\n' "${short_path}" "${current}" "${ttl_suffix}" >> "${ROWS_FILE}"
             continue
           fi
 
@@ -295,6 +324,7 @@ runs:
             target="${IGNORE_PIN[${short_path}]}"
             latest="${target}"
             marker_suffix=" (pinned)"
+            [[ -n "${IGNORE_TTL[${short_path}]:-}" ]] && marker_suffix=" (pinned, expires ${IGNORE_TTL[${short_path}]})"
           else
             latest=$(resolve_latest "${repo}" "${major_filter}")
 

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -155,7 +155,11 @@ runs:
 
             # Validate TTL date format and check expiry
             if [[ -n "${ttl}" ]]; then
-              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || ! date -d "${ttl}" +%Y-%m-%d > /dev/null 2>&1; then
+              # Portable calendar range check (no GNU date required)
+              _ttl_m="${ttl:5:2}"; _ttl_d="${ttl:8:2}"
+              if ! [[ "${ttl}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || \
+                 [[ 10#${_ttl_m} -lt 1 || 10#${_ttl_m} -gt 12 ]] || \
+                 [[ 10#${_ttl_d} -lt 1 || 10#${_ttl_d} -gt 31 ]]; then
                 echo "::warning title=Invalid TTL format::Ignore rule for '${line}' has invalid TTL '${ttl}' (expected YYYY-MM-DD). Treating as expired."
                 continue
               fi


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Ignore entries in `.lerianstudiolibignore` were permanent — once added, they stayed until manually removed, making it easy to forget about deferred bumps indefinitely.

This PR adds an optional `|ttl:YYYY-MM-DD` suffix to any ignore or pin rule. When present:

- **Before the TTL date** — the rule is honored as usual; the expiry date is shown in the report's status column.
- **On or after the TTL date** — the rule is silently dropped and the version check is enforced normally; a `::warning` is emitted so the team is notified.
- **Invalid date format** — treated as expired (safe default) with a `::warning`.

**Format:**
```
# Skip with TTL — CI enforces again after 2025-09-30
lib-auth/v2|ttl:2025-09-30

# Pin with TTL
lib-commons/v5@v5.3.0|ttl:2025-09-30
```

**Backward compatible:** entries without `|ttl:` work exactly as before.

Files changed:
- `src/validate/lerian-lib-version/action.yml` — TTL parsing in the ignore-file loader; `IGNORE_TTL` associative array; expiry date shown in skip/pin report columns
- `src/validate/lerian-lib-version/README.md` — TTL format documented in the ignore file section and behavior matrix

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Existing `.lerianstudiolibignore` files without `|ttl:` entries are unaffected.

## Testing

- [x] YAML syntax validated locally
- [x] `bash -n` on the modified step — no syntax errors
- [x] Traced TTL parsing: valid future TTL → rule honored; expired TTL → warning + rule skipped; invalid format → warning + rule skipped
- [x] Verified `TODAY < ttl` string comparison is correct for ISO 8601 dates
- [x] Confirmed backward compatibility: existing entries without `|ttl:` parse identically
- [x] Checked that unrelated workflows are not affected

## Related Issues

Closes #466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for time-limited ignore and pin rules using a `|ttl:YYYY-MM-DD` suffix.
  * When TTLs are expired (or invalid), warnings are emitted and version checks are enforced again.
  * Generated reports now show expiry (`expires <date>`) for the matched skip and pinned entries.
* **Documentation**
  * Updated the ignore-file guide with TTL syntax, examples, and clear behavior for honored, expired, and invalid TTL dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->