### PR TITLE
feat(go-release): expose force_full_matrix passthrough to build job

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -107,6 +107,10 @@ on:
         description: 'JSON array of additional build groups, each forwarded to build.yml with its own config (filter_paths, path_level, normalize_to_filter, app_name_overrides, build_context_from_working_dir, helm_*). Runs alongside the primary build on tag push; all groups feed the single gitops-update. Empty = one build only (default).'
         type: string
         default: ''
+      force_full_matrix:
+        description: 'When true, build all filter_paths components on every run regardless of what changed. Use for repos where components must always share the same image tag (e.g., auth + identity always released together).'
+        type: boolean
+        default: false
 
       # ----------------- GitOps Update (gitops-update.yml) -----------------
       enable_gitops_update:
@@ -275,6 +279,7 @@ jobs:
       helm_values_key_mappings: ${{ inputs.helm_values_key_mappings }}
       shared_paths: ${{ inputs.shared_paths }}
       filter_paths: ${{ inputs.filter_paths }}
+      force_full_matrix: ${{ inputs.force_full_matrix }}
     secrets: inherit
 
   # ----------------- S3 Upload (tag push, post-build, opt-in) -----------------


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Exposes the existing `force_full_matrix` input from `build.yml` as a passthrough in `go-release.yml`, so callers can use it directly.

**Why:** `force_full_matrix` already exists in `build.yml` — when `true`, it builds all `filter_paths` components on every run regardless of what changed. This is useful for repos like `plugin-access-manager` where `auth` and `identity` must always share the same image tag (releasing one without the other causes version mismatches in environments).

Without this passthrough, callers had to use a `shared_paths` workaround to force both components to build together.

**Usage:**
```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-release.yml@vX.Y.Z
with:
  force_full_matrix: true
  filter_paths: |
    components/auth
    components/identity
```

## Type of Change

- [x] `feat`: New feature or capability

## Breaking Changes

None. `force_full_matrix` defaults to `false`, preserving existing behavior for all callers.

## Testing

- [x] `force_full_matrix: false` (default) — behavior unchanged for all existing callers
- [x] `force_full_matrix: true` — all `filter_paths` components build on every run

## Related Issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to force a full build matrix during release runs.
  * When enabled, all components are built every time, helping keep related outputs on the same image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->