### PR TITLE
fix(lerian-lib-version): clear stale IGNORE_TTL on duplicate ignore rule

### DIFF
--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -197,10 +197,12 @@ runs:
               mod="${line%@*}"
               pin="${line##*@}"
               IGNORE_PIN["${mod}"]="${pin}"
+              unset "IGNORE_TTL[${mod}]"
               [[ -n "${ttl}" ]] && IGNORE_TTL["${mod}"]="${ttl}"
               debug "ignore-pin: ${mod} -> ${pin}${ttl:+ (ttl: ${ttl})}"
             else
               IGNORE_SKIP["${line}"]="1"
+              unset "IGNORE_TTL[${line}]"
               [[ -n "${ttl}" ]] && IGNORE_TTL["${line}"]="${ttl}"
               debug "ignore-skip: ${line}${ttl:+ (ttl: ${ttl})}"
             fi


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

If the same module path appears more than once in `.lerianstudiolibignore`, a TTL from an earlier rule could persist in `IGNORE_TTL` and incorrectly annotate the final (duplicate) rule as expiring.

**Example:**
\`\`\`
lib-auth/v2|ttl:2025-09-30   # first rule — sets TTL
lib-auth/v2                  # second rule — overwrites IGNORE_SKIP but leaves stale TTL!
\`\`\`

After processing the second rule without this fix, `IGNORE_TTL["lib-auth/v2"]` still holds `2025-09-30`, so the report incorrectly shows `Skipped (ignore file, expires 2025-09-30)` even though the second rule is permanent.

**Fix:** add `unset "IGNORE_TTL[${key}]"` before each conditional TTL assignment in both the pin and skip branches so the final rule state always reflects the most recent entry.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Only affects repos that have duplicate module entries in `.lerianstudiolibignore`, which is unusual.

## Testing

- [x] YAML syntax validated locally
- [x] Traced the duplicate-rule scenario: second entry without TTL now correctly clears stale expiry metadata
- [x] Confirmed existing single-entry behavior is unchanged

## Related Issues

Identified via CodeRabbit review on PR #506.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ignore rules with version pins and plain skips, making library validation behave more consistently.
  * Fixed TTL clearing so previously applied ignore timing no longer carries over incorrectly between different rule types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->