### PR TITLE
fix(gptchangelog): use --force on git fetch --tags to handle floating major tags

### DIFF
--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -77,7 +77,7 @@ runs:
           echo "📌 Triggered by tag push: $TAG_NAME"
         else
           echo "📌 Triggered by branch/workflow_run, finding latest stable tags..."
-          git fetch --tags
+          git fetch --tags --force
 
           LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
           echo "📌 Recent tags: $LATEST_TAGS"
@@ -144,7 +144,7 @@ runs:
           exit 0
         fi
 
-        git fetch --tags
+        git fetch --tags --force
 
         if [ -z "$FILTER_PATHS" ]; then
           APP_NAME="${GITHUB_REPOSITORY##*/}"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `Generate Changelog` job failed with:

\`\`\`
! [rejected] v1 -> v1 (would clobber existing tag)
Process completed with exit code 1.
\`\`\`

**Root cause:** `git fetch --tags` (without `--force`) refuses to overwrite an existing local tag that points to a different commit. This happens with floating major tags like `v1`, which are updated on every release to point to the latest commit. When the runner's local git state already has `v1` pointing to an older commit, the fetch is rejected.

The `Generate changelog for all apps` step already used `git fetch --tags --force` correctly. The two other `git fetch --tags` calls in `Check if tag is stable release on main` (line 80) and `Set changelog matrix` (line 147) were missing `--force`.

**Fix:** add `--force` to all three `git fetch --tags` calls in `src/changelog/gptchangelog/action.yml`.

**Evidence:** https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/28141647202/job/83340172970

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `--force` only affects floating tags that have moved; immutable tags (e.g., `v1.38.0`) are fetched identically.

## Testing

- [x] YAML syntax validated locally
- [x] Confirmed all three `git fetch --tags` calls now include `--force`
- [x] Checked that unrelated workflows are not affected

**Failing run:** https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/28141647202/job/83340172970