### PR TITLE
fix(gitops-update): add argocd_sync_timeout input with 480s default

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -92,6 +92,10 @@ on:
         description: 'Template for the ArgoCD application name. Supports placeholders {server}, {app}, {env}. Default {server}-{app}-{env} preserves current behavior. For kustomize layouts without env split, use e.g. {server}-{app}.'
         type: string
         default: '{server}-{app}-{env}'
+      argocd_sync_timeout:
+        description: 'Timeout in seconds for argocd app wait after sync. Increase for larger applications or clusters under load.'
+        type: number
+        default: 480
 
 jobs:
   update_gitops:
@@ -892,6 +896,7 @@ jobs:
           ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
           APP_NAME: ${{ steps.resolve_argocd_app.outputs.name }}
           ARGOCD_PRUNE: ${{ inputs.argocd_prune }}
+          ARGOCD_SYNC_TIMEOUT: ${{ inputs.argocd_sync_timeout }}
         run: |
           set -uo pipefail
 
@@ -925,7 +930,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::argocd app wait $APP_NAME"
-          if ! argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --timeout 180; then
+          if ! argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --timeout "$ARGOCD_SYNC_TIMEOUT"; then
             echo "::endgroup::"
             echo "::error::Timeout waiting for sync completion of $APP_NAME"
             exit 1


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `argocd app wait` step in `gitops-update.yml` had a hardcoded `--timeout 180` (3 minutes). For larger applications or clusters under load, the sync can take longer and the job fails with a timeout error even though the sync would have completed with more time.

This PR adds a new `argocd_sync_timeout` input (default `480` — 8 minutes) and passes it via `env:` to avoid inline expression injection.

Changes:
- New `argocd_sync_timeout: number` input (default `480`) in the `workflow_call` block
- `ARGOCD_SYNC_TIMEOUT: ${{ inputs.argocd_sync_timeout }}` added to the `env:` of the Sync ArgoCD application step
- `--timeout 180` → `--timeout "$ARGOCD_SYNC_TIMEOUT"` in the `argocd app wait` call

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The default timeout increases from 180 s to 480 s — a silent improvement for all existing callers. Callers that need a shorter timeout can explicitly set `argocd_sync_timeout: 180`.

## Testing

- [x] YAML syntax validated locally
- [x] Verified `ARGOCD_SYNC_TIMEOUT` is available in the run script scope via `env:`
- [x] Confirmed `--timeout "$ARGOCD_SYNC_TIMEOUT"` is correct shell quoting
- [x] Checked that unrelated workflows are not affected

## Related Issues

Closes #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a configurable timeout for GitOps sync waits, allowing sync operations to wait longer before timing out by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->