### PR TITLE
fix(gptchangelog): delete api_response.json after jq read, not before

### DIFF
--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -355,9 +355,8 @@ runs:
             fi
           done
 
-          rm -f /tmp/api_response.json
-
           if ! [[ "$HTTP_CODE" =~ ^[0-9]+$ ]] || [ "$HTTP_CODE" -ge 400 ]; then
+            rm -f /tmp/api_response.json
             continue
           fi
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

PR #503 introduced a regression: `rm -f /tmp/api_response.json` was placed **after** the retry loop but **before** `jq` reads the file, causing the changelog generation to fail with:

\`\`\`
jq: error: Could not open file /tmp/api_response.json: No such file or directory
Process completed with exit code 2.
\`\`\`

**Root cause:** In the retry loop refactor, the unconditional `rm -f` was extracted outside the loop and placed between the loop-end and the success path, deleting the response file that `jq` needs to parse the API content.

**Fix:** Move `rm -f /tmp/api_response.json` to only execute in the failure path (`continue`) and keep the existing `rm -f` on line 365 for the success path (after `jq` has read the content).

**Evidence:** https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/28142460333/job/83342700162

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Restores the correct behavior from before PR #503.

## Testing

- [x] YAML syntax validated locally
- [x] Traced the execution path: on success `jq` reads the file, then `rm -f` deletes it; on failure `rm -f` runs before `continue`
- [x] Confirmed the cleanup step at the end of the composite also removes it as a safety net

## Related Issues

Regression introduced in PR #503.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changelog generation so response data is retained when the request succeeds, preventing missing output in successful runs.
  * Improved cleanup behavior so temporary data is only removed when an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->