### PR TITLE
fix(gptchangelog): attribute contributors inline per bullet instead of trailing list

### DIFF
--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -265,13 +265,15 @@ runs:
             VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
           fi
 
+          # Collect SHA, short-hash, and subject in one git log pass (unit-separator delimited)
+          # to avoid a redundant git log -1 subprocess per commit.
           if [ "$WORKING_DIR" != "." ]; then
-            SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' -- "$WORKING_DIR" 2>/dev/null)
+            GIT_LOG_DATA=$(git log "$SINCE".."$LAST_TAG" --format='%H%x1f%h%x1f%s' -- "$WORKING_DIR" 2>/dev/null || true)
           else
-            SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' 2>/dev/null)
+            GIT_LOG_DATA=$(git log "$SINCE".."$LAST_TAG" --format='%H%x1f%h%x1f%s' 2>/dev/null || true)
           fi
 
-          COMMIT_COUNT=$(echo "$SHAS" | grep -c . || true)
+          COMMIT_COUNT=$(echo "$GIT_LOG_DATA" | grep -c . || true)
           echo "📊 Found $COMMIT_COUNT commits for $APP_NAME"
 
           if [ "$COMMIT_COUNT" -eq 0 ]; then
@@ -282,16 +284,16 @@ runs:
           # Build annotated commit list: "short-hash subject [@author]"
           # Each commit carries its author handle so GPT can attribute inline.
           COMMITS_ANNOTATED=""
-          for SHA in $SHAS; do
-            COMMIT_LINE=$(git log -1 --format='%h %s' "$SHA" 2>/dev/null || true)
+          while IFS=$'\x1f' read -r SHA SHORT_HASH SUBJECT; do
+            [[ -z "$SHA" ]] && continue
             LOGIN=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" \
               --jq '.author.login // empty' 2>/dev/null || true)
             if [[ -n "$LOGIN" && "$LOGIN" != *"[bot]" ]]; then
-              COMMITS_ANNOTATED+="${COMMIT_LINE} [@${LOGIN}]"$'\n'
+              COMMITS_ANNOTATED+="${SHORT_HASH} ${SUBJECT} [@${LOGIN}]"$'\n'
             else
-              COMMITS_ANNOTATED+="${COMMIT_LINE}"$'\n'
+              COMMITS_ANNOTATED+="${SHORT_HASH} ${SUBJECT}"$'\n'
             fi
-          done
+          done <<< "$GIT_LOG_DATA"
           echo "📝 Annotated commits:"$'\n'"${COMMITS_ANNOTATED}"
 
           PROMPT="Generate a changelog for ${APP_NAME} ONLY. Each commit below includes the author handle in brackets. Commits: ${COMMITS_ANNOTATED} --- STRICT RULES: 1) NEVER mention other components - only ${APP_NAME}. 2) Use bullet points. 3) Group by Features, Fixes, Improvements (skip empty sections). 4) No markdown headers. 5) Max 5 bullet points. 6) For each bullet point add the GitHub handle(s) of the author(s) in parentheses at the end, e.g. 'Fix something important (@bedatty)'. If a bullet combines multiple commits, list all unique handles. Omit handles only when none were detected. 7) ALWAYS wrap version references in backticks - this includes tag names (\`v1\`, \`v1.28.8\`, \`v2.0.0-beta.1\`), action refs (\`@v1\`, \`@v1.28.8\`), and any semver-like token. Never emit a bare version."

--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -265,50 +265,36 @@ runs:
             VERSION=$(echo "$LAST_TAG" | sed 's/^v//')
           fi
 
-          TEMP_COMMITS=$(mktemp)
-
-          if [ "$WORKING_DIR" != "." ]; then
-            git log --oneline "$SINCE".."$LAST_TAG" -- "$WORKING_DIR" > "$TEMP_COMMITS" 2>/dev/null || true
-          else
-            git log --oneline "$SINCE".."$LAST_TAG" > "$TEMP_COMMITS" 2>/dev/null || true
-          fi
-
-          COMMIT_COUNT=$(wc -l < "$TEMP_COMMITS" | tr -d ' ')
-          echo "📊 Found $COMMIT_COUNT commits for $APP_NAME"
-
-          if [ "$COMMIT_COUNT" -eq 0 ]; then
-            echo "⚠️ No commits found for $APP_NAME in range - skipping"
-            rm -f "$TEMP_COMMITS"
-            continue
-          fi
-
-          COMMITS_TEXT=$(cat "$TEMP_COMMITS")
-          rm -f "$TEMP_COMMITS"
-
           if [ "$WORKING_DIR" != "." ]; then
             SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' -- "$WORKING_DIR" 2>/dev/null)
           else
             SHAS=$(git log "$SINCE".."$LAST_TAG" --format='%H' 2>/dev/null)
           fi
 
-          USERNAMES_FILE=$(mktemp)
+          COMMIT_COUNT=$(echo "$SHAS" | grep -c . || true)
+          echo "📊 Found $COMMIT_COUNT commits for $APP_NAME"
+
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "⚠️ No commits found for $APP_NAME in range - skipping"
+            continue
+          fi
+
+          # Build annotated commit list: "short-hash subject [@author]"
+          # Each commit carries its author handle so GPT can attribute inline.
+          COMMITS_ANNOTATED=""
           for SHA in $SHAS; do
+            COMMIT_LINE=$(git log -1 --format='%h %s' "$SHA" 2>/dev/null || true)
             LOGIN=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" \
               --jq '.author.login // empty' 2>/dev/null || true)
             if [[ -n "$LOGIN" && "$LOGIN" != *"[bot]" ]]; then
-              echo "$LOGIN" >> "$USERNAMES_FILE"
+              COMMITS_ANNOTATED+="${COMMIT_LINE} [@${LOGIN}]"$'\n'
+            else
+              COMMITS_ANNOTATED+="${COMMIT_LINE}"$'\n'
             fi
           done
+          echo "📝 Annotated commits:"$'\n'"${COMMITS_ANNOTATED}"
 
-          if [ -s "$USERNAMES_FILE" ]; then
-            CONTRIBUTORS=$(sort -u "$USERNAMES_FILE" | sed 's/^/@/' | tr '\n' ', ' | sed 's/, $//')
-          else
-            CONTRIBUTORS=""
-          fi
-          rm -f "$USERNAMES_FILE"
-          echo "👥 Contributors: $CONTRIBUTORS"
-
-          PROMPT="Generate a changelog for ${APP_NAME} ONLY. Commits: ${COMMITS_TEXT} --- STRICT RULES: 1) NEVER mention other components - only ${APP_NAME}. 2) Use bullet points. 3) Group by Features, Fixes, Improvements (skip empty sections). 4) No markdown headers. 5) Max 5 bullet points. 6) End with Contributors: ${CONTRIBUTORS}. 7) ALWAYS wrap version references in backticks - this includes tag names (\`v1\`, \`v1.28.8\`, \`v2.0.0-beta.1\`), action refs (\`@v1\`, \`@v1.28.8\`), and any semver-like token. Never emit a bare version."
+          PROMPT="Generate a changelog for ${APP_NAME} ONLY. Each commit below includes the author handle in brackets. Commits: ${COMMITS_ANNOTATED} --- STRICT RULES: 1) NEVER mention other components - only ${APP_NAME}. 2) Use bullet points. 3) Group by Features, Fixes, Improvements (skip empty sections). 4) No markdown headers. 5) Max 5 bullet points. 6) For each bullet point add the GitHub handle(s) of the author(s) in parentheses at the end, e.g. 'Fix something important (@bedatty)'. If a bullet combines multiple commits, list all unique handles. Omit handles only when none were detected. 7) ALWAYS wrap version references in backticks - this includes tag names (\`v1\`, \`v1.28.8\`, \`v2.0.0-beta.1\`), action refs (\`@v1\`, \`@v1.28.8\`), and any semver-like token. Never emit a bare version."
 
           REQUEST_BODY=$(jq -n \
             --arg model "$OPENAI_MODEL" \


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Previously the changelog ended with a generic `Contributors: @a, @b` list — the same information GitHub already shows on the release page, adding no value.

This PR changes the attribution model so each bullet point includes the `@handle` of the author inline:

**Before:**
```
Fixes:
- Ensure normalize_to_filter is a boolean, not a string, in extra_build.
- Prevent code injection via coverage_threshold interpolation.

Contributors: @bedatty, @gandalf-at-lerian
```

**After:**
```
Fixes:
- Ensure normalize_to_filter is a boolean, not a string, in extra_build. (@gandalf-at-lerian)
- Prevent code injection via coverage_threshold interpolation. (@bedatty)
```

**Implementation:**
- Replaces the two-pass approach (`git log --oneline` + separate SHA loop for contributors) with a single annotated pass: for each commit SHA, fetch the subject line and the GitHub author login, building `COMMITS_ANNOTATED` as `"short-hash subject [@author]"` lines
- Passes the annotated list to GPT with updated prompt rule 6: attach `@handle(s)` in parentheses at the end of each bullet; list all unique handles when a bullet groups multiple commits
- Removes the `TEMP_COMMITS` temp file and the `USERNAMES_FILE` temp file (no longer needed)

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The changelog content format changes (richer attribution per item) but no inputs, outputs, or caller contracts change.

## Testing

- [x] YAML syntax validated locally
- [x] Traced the annotated commit list build: SHA → `git log -1 --format='%h %s'` + GitHub API login → `"abc1234 fix(x): desc [@author]"`
- [x] Verified the prompt correctly instructs GPT to attach handles inline
- [x] Confirmed temp file cleanup is no longer needed (removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved changelog generation by using more direct commit tracking.
  * Enhanced contributor attribution by attaching author handles to each commit entry when available.
  * Updated the generated prompt format to rely on per-commit author information, removing the need for a separate consolidated contributors summary step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->