### PR TITLE
feat(workflows): add js-release.yml umbrella workflow for JavaScript/TypeScript repositories

### DIFF
--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
       dry_run:
-        description: 'Reserved. Downstream release/build/gitops workflows do not yet expose a dry-run mode.'
+        description: 'Run semantic-release in dry-run mode (no tags/releases created) and preview the backmerge instead of applying it'
         required: false
         type: boolean
         default: false
@@ -24,15 +24,43 @@ on:
         type: string
         default: '*.md docs/* .github/* LICENSE* .gitignore'
 
-      # ----------------- Release (typescript-release.yml) -----------------
-      node_version:
-        description: 'Node.js version to use for semantic-release'
-        type: string
-        default: '20'
+      # ----------------- Release (release.yml) -----------------
       semantic_version:
         description: 'Semantic release version to use'
         type: string
         default: '23.0.8'
+      enable_changelog:
+        description: 'Generate CHANGELOG.md files via GPT after a successful release'
+        type: boolean
+        default: false
+      enable_major_tag:
+        description: 'Force-update the floating major version tag (e.g. v1) after a successful release'
+        type: boolean
+        default: false
+      stable_releases_only:
+        description: 'Only generate changelogs for stable releases (skip beta/rc/alpha tags)'
+        type: boolean
+        default: true
+      release_single_app:
+        description: 'Force single-app mode for the release job even when filter_paths is set. Use for repos with one version tag but multiple Docker images.'
+        type: boolean
+        default: false
+      backmerge_enabled:
+        description: 'Backmerge the release branch into the target branch after a successful release'
+        type: boolean
+        default: true
+      backmerge_source:
+        description: 'Release branch eligible for backmerge'
+        type: string
+        default: 'main'
+      backmerge_target:
+        description: 'Branch that receives the backmerge'
+        type: string
+        default: 'develop'
+      backmerge_mode:
+        description: 'Backmerge strategy: direct | pr | direct-with-pr-fallback'
+        type: string
+        default: 'direct-with-pr-fallback'
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
         type: string
@@ -175,14 +203,19 @@ jobs:
       issues: write
       pull-requests: write
       packages: read
-    uses: ./.github/workflows/typescript-release.yml
+    uses: ./.github/workflows/release.yml
     with:
       runner_type: ${{ inputs.runner_type }}
-      node_version: ${{ inputs.node_version }}
       semantic_version: ${{ inputs.semantic_version }}
-      filter_paths: ${{ inputs.filter_paths }}
+      enable_changelog: ${{ inputs.enable_changelog }}
+      enable_major_tag: ${{ inputs.enable_major_tag }}
+      stable_releases_only: ${{ inputs.stable_releases_only }}
+      backmerge_enabled: ${{ inputs.backmerge_enabled }}
+      backmerge_source: ${{ inputs.backmerge_source }}
+      backmerge_target: ${{ inputs.backmerge_target }}
+      backmerge_mode: ${{ inputs.backmerge_mode }}
       shared_paths: ${{ inputs.shared_paths }}
-      path_level: ${{ inputs.path_level }}
+      filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}
     secrets: inherit
 
   # ----------------- Build (tag push) -----------------

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -1,0 +1,239 @@
+name: "JS Release"
+
+# Umbrella reusable workflow for JavaScript/TypeScript service repositories.
+# On branch pushes it runs semantic-release (gated by a non-doc change detector);
+# on tag pushes it builds and pushes the container image and then updates the
+# GitOps repository. A caller only needs to reference this single workflow.
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'GitHub runner type to use'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      dry_run:
+        description: 'Reserved. Downstream release/build/gitops workflows do not yet expose a dry-run mode.'
+        required: false
+        type: boolean
+        default: false
+
+      # ----------------- Change gate -----------------
+      ignore_globs:
+        description: 'Space-separated glob patterns treated as docs/meta; when only these change on a branch push, the release is skipped.'
+        type: string
+        default: '*.md docs/* .github/* LICENSE* .gitignore'
+
+      # ----------------- Release (typescript-release.yml) -----------------
+      node_version:
+        description: 'Node.js version to use for semantic-release'
+        type: string
+        default: '20'
+      semantic_version:
+        description: 'Semantic release version to use'
+        type: string
+        default: '23.0.8'
+      filter_paths:
+        description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
+        type: string
+        default: ''
+      shared_paths:
+        description: 'Newline-separated path patterns that trigger a release/build for all components.'
+        type: string
+        default: ''
+      path_level:
+        description: 'Directory depth level to extract app name (e.g., 2 -> "apps/agent")'
+        type: string
+        default: '2'
+
+      # ----------------- Build (typescript-build.yml) -----------------
+      enable_dockerhub:
+        description: 'Enable pushing to DockerHub'
+        type: boolean
+        default: false
+      enable_ghcr:
+        description: 'Enable pushing to GitHub Container Registry'
+        type: boolean
+        default: true
+      enable_gitops_artifacts:
+        description: 'Enable GitOps artifacts upload for the downstream gitops-update job'
+        type: boolean
+        default: false
+      app_name_prefix:
+        description: 'Prefix for app names in monorepo (e.g., "midaz" -> "midaz-agent")'
+        type: string
+        default: ''
+      app_name_overrides:
+        description: 'Explicit app name mappings in "path:name" format. Overrides default extraction for matched paths.'
+        type: string
+        default: ''
+      dockerfile_name:
+        description: 'Name of the Dockerfile'
+        type: string
+        default: 'Dockerfile'
+      build_context:
+        description: 'Docker build context (defaults to repository root)'
+        type: string
+        default: '.'
+      build_secrets:
+        description: 'Additional secrets for docker build (one per line). npmrc is always included automatically.'
+        type: string
+        default: ''
+      enable_cosign_sign:
+        description: 'Sign container images with cosign keyless (OIDC) signing after push'
+        type: boolean
+        default: true
+      dockerhub_org:
+        description: 'DockerHub organization name'
+        type: string
+        default: 'lerianstudio'
+      force_full_matrix:
+        description: 'When true, build all filter_paths components on every run regardless of what changed. Use for repos where components must always share the same image tag (e.g., auth + identity always released together).'
+        type: boolean
+        default: false
+
+      # ----------------- GitOps Update (gitops-update.yml) -----------------
+      enable_gitops_update:
+        description: 'Run the gitops-update job on tag push'
+        type: boolean
+        default: true
+      gitops_repository:
+        description: 'GitOps repository to update (org/repo format). Defaults to the GITOPS_REPOSITORY org-level variable when empty.'
+        type: string
+        default: ''
+      update_sandbox:
+        description: 'Include sandbox environment on production tags. Set to false to skip sandbox even on a production release.'
+        type: boolean
+        default: false
+      gitops_artifact_pattern:
+        description: 'Pattern to download GitOps artifacts (defaults to "gitops-tags-<repo-name>*")'
+        type: string
+        default: ''
+      gitops_yaml_key_mappings:
+        description: 'JSON object mapping artifact names to YAML keys (e.g., {"app.tag": ".api.image.tag"})'
+        type: string
+        default: ''
+      deployment_matrix_ref:
+        description: 'Git ref of LerianStudio/github-actions-shared-workflows to read the deployment matrix from. Defaults to main. Override only when testing a branch.'
+        type: string
+        default: 'main'
+      enable_argocd_sync:
+        description: 'Trigger ArgoCD sync after updating the GitOps repository'
+        type: boolean
+        default: true
+      commit_message_prefix:
+        description: 'Prefix for the GitOps commit message. When empty, falls back to app_name_prefix, then the repository name.'
+        type: string
+        default: ''
+      use_dynamic_mapping:
+        description: 'Use dynamic artifact-to-YAML key mapping in gitops-update'
+        type: boolean
+        default: false
+      configmap_updates:
+        description: 'JSON object mapping artifact names to configmap keys (helmfile layout only)'
+        type: string
+        default: ''
+      enable_docker_login:
+        description: 'Log in to DockerHub in the gitops-update job (for private image digest reads)'
+        type: boolean
+        default: false
+
+    secrets:
+      MANAGE_TOKEN:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ----------------- Change Detection (release gate, branch push only) -----------------
+  changes:
+    name: Detect non-doc changes
+    if: github.ref_type == 'branch'
+    runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
+    steps:
+      - name: Non-doc change gate
+        id: gate
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        with:
+          github-token: ${{ github.token }}
+          ignore-globs: ${{ inputs.ignore_globs }}
+
+  # ----------------- Release (branch push) -----------------
+  release:
+    needs: changes
+    if: github.ref_type == 'branch' && needs.changes.outputs.code == 'true'
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: read
+    uses: ./.github/workflows/typescript-release.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      node_version: ${{ inputs.node_version }}
+      semantic_version: ${{ inputs.semantic_version }}
+      filter_paths: ${{ inputs.filter_paths }}
+      shared_paths: ${{ inputs.shared_paths }}
+      path_level: ${{ inputs.path_level }}
+    secrets: inherit
+
+  # ----------------- Build (tag push) -----------------
+  build:
+    if: github.ref_type == 'tag'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: write
+    uses: ./.github/workflows/typescript-build.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      enable_dockerhub: ${{ inputs.enable_dockerhub }}
+      enable_ghcr: ${{ inputs.enable_ghcr }}
+      enable_gitops_artifacts: ${{ inputs.enable_gitops_artifacts }}
+      app_name_prefix: ${{ inputs.app_name_prefix }}
+      app_name_overrides: ${{ inputs.app_name_overrides }}
+      dockerfile_name: ${{ inputs.dockerfile_name }}
+      build_context: ${{ inputs.build_context }}
+      build_secrets: ${{ inputs.build_secrets }}
+      enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      dockerhub_org: ${{ inputs.dockerhub_org }}
+      shared_paths: ${{ inputs.shared_paths }}
+      filter_paths: ${{ inputs.filter_paths }}
+      path_level: ${{ inputs.path_level }}
+      force_full_matrix: ${{ inputs.force_full_matrix }}
+    secrets: inherit
+
+  # ----------------- GitOps Update (tag push) -----------------
+  update_gitops:
+    needs: [build]
+    if: >-
+      github.ref_type == 'tag' && inputs.enable_gitops_update && !cancelled() &&
+      needs.build.result == 'success' && needs.build.outputs.has_builds == 'true'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      packages: write
+    uses: ./.github/workflows/gitops-update.yml
+    with:
+      gitops_repository: ${{ inputs.gitops_repository }}
+      update_sandbox: ${{ inputs.update_sandbox }}
+      app_name: ${{ inputs.app_name_prefix }}
+      artifact_pattern: ${{ inputs.gitops_artifact_pattern || format('gitops-tags-{0}*', github.event.repository.name) }}
+      yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
+      deployment_matrix_ref: ${{ inputs.deployment_matrix_ref }}
+      enable_argocd_sync: ${{ inputs.enable_argocd_sync }}
+      commit_message_prefix: ${{ inputs.commit_message_prefix || inputs.app_name_prefix }}
+      use_dynamic_mapping: ${{ inputs.use_dynamic_mapping }}
+      configmap_updates: ${{ inputs.configmap_updates }}
+      enable_docker_login: ${{ inputs.enable_docker_login }}
+    secrets: inherit

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -206,6 +206,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      dry_run: ${{ inputs.dry_run }}
       semantic_version: ${{ inputs.semantic_version }}
       enable_changelog: ${{ inputs.enable_changelog }}
       enable_major_tag: ${{ inputs.enable_major_tag }}
@@ -249,7 +250,8 @@ jobs:
   update_gitops:
     needs: [build]
     if: >-
-      github.ref_type == 'tag' && inputs.enable_gitops_update && !cancelled() &&
+      github.ref_type == 'tag' && inputs.enable_gitops_update &&
+      inputs.enable_gitops_artifacts && !cancelled() &&
       needs.build.result == 'success' && needs.build.outputs.has_builds == 'true'
     permissions:
       id-token: write

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -20,6 +20,10 @@ name: "TypeScript Build and Push Docker Images"
 
 on:
   workflow_call:
+    outputs:
+      has_builds:
+        description: 'Whether any components were detected for building (true/false). Use this to skip downstream jobs when no paths changed.'
+        value: ${{ jobs.prepare.outputs.has_builds }}
     inputs:
       runner_type:
         description: 'Runner to use for the workflow'
@@ -92,6 +96,10 @@ on:
         description: 'Normalize changed paths to their filter path. Recommended for monorepos.'
         type: boolean
         default: true
+      force_full_matrix:
+        description: 'When true, build all filter_paths components on every run regardless of what changed. Use for repos where components must always share the same image tag (e.g., auth + identity always released together).'
+        type: boolean
+        default: false
       # Helm dispatch configuration
       enable_helm_dispatch:
         description: 'Enable dispatching to Helm repository for chart updates'
@@ -171,6 +179,7 @@ jobs:
           app-name-prefix: ${{ inputs.app_name_prefix }}
           app-name-overrides: ${{ inputs.app_name_overrides }}
           normalize-to-filter: ${{ inputs.normalize_to_filter }}
+          force-full-matrix: ${{ inputs.force_full_matrix }}
 
       - name: Set matrix
         id: set-matrix

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -1,0 +1,187 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>js-release</h1></td>
+  </tr>
+</table>
+
+Umbrella reusable workflow for JavaScript/TypeScript **service** repositories (deployable apps that ship as container images). A caller references this single workflow and it drives the full release pipeline, branching on the pushed ref:
+
+- **Branch push** → change gate (`src/config/non-doc-changes`) → semantic release (`typescript-release.yml`). Documentation-only pushes skip the release.
+- **Tag push** → container build & push (`typescript-build.yml`) → GitOps update (`gitops-update.yml`), gated on the build actually producing images.
+
+Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services — providing the same single-caller DX for Next.js frontends, NestJS backends, and any JS/TS service that ships a Docker image.
+
+### Repository layouts
+
+`filter_paths` drives both the release matrix and the build matrix:
+
+- **Single app** — `filter_paths` empty: one semantic-release tag, one image.
+- **Per-component monorepo** — `filter_paths` set: each changed component gets its own release tag and its own image.
+
+### npmrc auto-injection
+
+`typescript-build.yml` always injects an npmrc for private `@lerianstudio` GitHub Packages dependencies — no extra configuration needed. Additional build secrets are additive via `build_secrets`.
+
+## Inputs
+
+| Input | Description | Type | Default |
+|-------|-------------|------|---------|
+| `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `dry_run` | Reserved (downstream workflows have no dry-run mode yet) | boolean | `false` |
+| `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
+| `node_version` | Node.js version for semantic-release | string | `20` |
+| `semantic_version` | semantic-release version | string | `23.0.8` |
+| `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
+| `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
+| `path_level` | Directory depth level to extract app name | string | `2` |
+| `enable_dockerhub` | Push image to DockerHub | boolean | `false` |
+| `enable_ghcr` | Push image to GitHub Container Registry | boolean | `true` |
+| `enable_gitops_artifacts` | Upload GitOps artifacts for the downstream update | boolean | `false` |
+| `app_name_prefix` | Prefix for app names in monorepo (e.g. `lerian-map` -> `lerian-map-agent`) | string | `''` |
+| `app_name_overrides` | Explicit `path:name` app name mappings | string | `''` |
+| `dockerfile_name` | Name of the Dockerfile | string | `Dockerfile` |
+| `build_context` | Docker build context | string | `.` |
+| `build_secrets` | Additional build secrets (one per line); npmrc is always injected | string | `''` |
+| `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
+| `dockerhub_org` | DockerHub organization name | string | `lerianstudio` |
+| `force_full_matrix` | Build all `filter_paths` components on every tag regardless of what changed (use for tightly-coupled components that must always share the same image tag) | boolean | `false` |
+| `enable_gitops_update` | Run the gitops-update job on tag push | boolean | `true` |
+| `gitops_repository` | GitOps repository to update (org/repo). Empty → `GITOPS_REPOSITORY` org-level variable | string | `''` |
+| `update_sandbox` | Include sandbox environment on production tags | boolean | `false` |
+| `gitops_artifact_pattern` | Pattern to download GitOps artifacts. Empty → `gitops-tags-<repo-name>*` | string | `''` |
+| `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
+| `deployment_matrix_ref` | Git ref of shared-workflows to read the deployment matrix from | string | `main` |
+| `enable_argocd_sync` | Trigger ArgoCD sync after updating the GitOps repo | boolean | `true` |
+| `commit_message_prefix` | Prefix for the GitOps commit message. Empty → `app_name_prefix`, then repo name | string | `''` |
+| `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
+| `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
+| `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
+
+## Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `MANAGE_TOKEN` | Token for release commits, tags and private module access | No |
+| `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+
+All other secrets required by the underlying primitives (GitHub App tokens, GPG key, DockerHub credentials, etc.) are forwarded automatically via `secrets: inherit`.
+
+## Usage
+
+### Single-app repository
+
+```yaml
+name: Release Pipeline
+on:
+  push:
+    branches: [main, release-candidate, develop]
+    tags: ['**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  pipeline:
+    # Testing: @develop or @feat/<branch> · Production: pinned @vX.Y.Z
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-release.yml@v1
+    with:
+      enable_ghcr: true
+      enable_gitops_artifacts: true
+      gitops_repository: "LerianStudio/midaz-firmino-gitops"
+      gitops_yaml_key_mappings: '{"lerian-map.tag": ".lerian-map.image.tag"}'
+    secrets: inherit
+```
+
+### Monorepo with tightly-coupled components
+
+Use `force_full_matrix: true` when components must always be released together with the same image tag:
+
+```yaml
+jobs:
+  pipeline:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-release.yml@v1
+    with:
+      enable_ghcr: true
+      enable_gitops_artifacts: true
+      app_name_prefix: "plugin-access-manager"
+      filter_paths: |
+        components/auth
+        components/identity
+      force_full_matrix: true
+      gitops_repository: "LerianStudio/midaz-firmino-gitops"
+      gitops_yaml_key_mappings: '{"plugin-access-manager-auth.tag": ".auth.image.tag", "plugin-access-manager-identity.tag": ".identity.image.tag"}'
+    secrets: inherit
+```
+
+### Replacing two caller files with one
+
+Before — two workflow files in the caller repo:
+
+```yaml
+# release.yml
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-release.yml@v1
+    secrets: inherit
+
+# build.yml
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/typescript-build.yml@v1
+    with:
+      enable_ghcr: true
+      enable_gitops_artifacts: true
+    secrets: inherit
+
+  gitops:
+    needs: build
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1
+    with:
+      gitops_repository: "LerianStudio/midaz-firmino-gitops"
+      yaml_key_mappings: '{"my-app.tag": ".api.image.tag"}'
+    secrets: inherit
+```
+
+After — one workflow file:
+
+```yaml
+# release.yml
+jobs:
+  pipeline:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-release.yml@v1
+    with:
+      enable_ghcr: true
+      enable_gitops_artifacts: true
+      gitops_repository: "LerianStudio/midaz-firmino-gitops"
+      gitops_yaml_key_mappings: '{"my-app.tag": ".api.image.tag"}'
+    secrets: inherit
+```
+
+## Permissions
+
+The single caller job must grant the union of what the internal jobs need:
+
+```yaml
+permissions:
+  id-token: write
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+```
+
+## Related
+
+- [typescript-release](./typescript-release-workflow.md) — semantic-release pipeline this umbrella calls
+- [typescript-build](./typescript-build.md) — container build & push this umbrella calls
+- [gitops-update](./gitops-update-workflow.md) — GitOps update this umbrella calls
+- [go-release](./go-release-workflow.md) — the equivalent umbrella for Go service repositories


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds a `js-release.yml` umbrella reusable workflow for JavaScript/TypeScript service repositories, analogous to `go-release.yml` for Go services. A single caller file now orchestrates the full release pipeline for JS/TS repos:

- **Branch push** → non-doc change gate → `typescript-release.yml` (semantic-release)
- **Tag push** → `typescript-build.yml` (Docker build + GHCR/DockerHub push) → `gitops-update.yml` (GitOps repo update)

This collapses two caller workflow files (`release.yml` + `build.yml`) into a single `release.yml` referencing `js-release.yml`, matching the DX that Go repos already have via `go-release.yml`.

**Prerequisite changes to `typescript-build.yml`:**
- Added `force_full_matrix` input (boolean, default `false`) — allows forcing all `filter_paths` components to build on every tag, regardless of what changed. Required for tightly-coupled components that must always share the same image tag (e.g. `components/auth` + `components/identity`).
- Exposed `has_builds` as a workflow-level output (mirroring `build.yml`) — enables `js-release.yml` to gate the gitops-update job on whether the build actually produced images.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

- `typescript-build.yml`: new inputs (`force_full_matrix`) and new output (`has_builds`) are fully additive with non-breaking defaults.
- `js-release.yml`: new file, no existing callers affected.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** pending first consumer validation on `lerian-map` (first candidate per issue #518)

## Related Issues

Closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable JavaScript/TypeScript release workflow supporting branch (semantic release) and tag (image build/push + GitOps update) flows.
  * Exposed configuration for runner/dry-run behavior, registry/build toggles, and GitOps update options (including ArgoCD sync controls).
  * Added documentation with a full inputs reference and caller workflow examples.
* **Bug Fixes**
  * Automatically skips releases for documentation-only changes.
  * Avoids GitOps updates when no buildable components are detected or builds don’t produce outputs.
* **Chores**
  * Extended the build workflow with a `has_builds` output and `force_full_matrix` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->