### PR TITLE
feat(workflows): add js-pr-validation.yml umbrella workflow for JavaScript/TypeScript repositories

### DIFF
--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -260,6 +260,8 @@ jobs:
     needs: [changes, frontend-analysis]
     if: always()
     runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
     steps:
       - name: Aggregate Frontend Analysis result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -289,6 +291,8 @@ jobs:
     needs: [changes, security]
     if: always()
     runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
     steps:
       - name: Aggregate security result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -304,14 +308,18 @@ jobs:
   # ruleset is needed.
   go-analysis-gate:
     name: Go Analysis
-    if: false
+    if: ${{ github.event_name == 'none' }}
     runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
     steps:
       - run: echo "Not applicable for JS/TS repositories"
 
   lib-version-gate:
     name: Lib Version
-    if: false
+    if: ${{ github.event_name == 'none' }}
     runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
     steps:
       - run: echo "Not applicable for JS/TS repositories"

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -298,20 +298,20 @@ jobs:
 
   # ----------------- Org ruleset compatibility stubs -----------------
   # Go Analysis and Lib Version are required status checks in the Lerian org
-  # branch-protection ruleset (designed for Go repos). These no-op stubs satisfy
-  # those checks for JS/TS repositories so callers do not need a separate ruleset.
+  # branch-protection ruleset (designed for Go repos). These stubs are
+  # intentionally skipped (if: false) for JS/TS repositories — GitHub treats
+  # a skipped conclusion as satisfying required status checks, so no separate
+  # ruleset is needed.
   go-analysis-gate:
     name: Go Analysis
-    if: always()
+    if: false
     runs-on: ${{ inputs.runner_type }}
     steps:
-      - name: Not applicable for JS/TS repositories
-        run: echo "Go Analysis does not apply to JavaScript/TypeScript repositories."
+      - run: echo "Not applicable for JS/TS repositories"
 
   lib-version-gate:
     name: Lib Version
-    if: always()
+    if: false
     runs-on: ${{ inputs.runner_type }}
     steps:
-      - name: Not applicable for JS/TS repositories
-        run: echo "Lib Version check does not apply to JavaScript/TypeScript repositories."
+      - run: echo "Not applicable for JS/TS repositories"

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -1,0 +1,297 @@
+name: "JS/TS PR Validation"
+
+# Umbrella reusable workflow for JavaScript/TypeScript repositories.
+# Orchestrates PR metadata validation, a non-doc change gate, the frontend
+# analysis pipeline and the security scan pipeline behind opt-in flags, so
+# a caller only needs to reference this single workflow.
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'GitHub runner type to use'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      dry_run:
+        description: 'Preview metadata validations without posting comments or labels'
+        required: false
+        type: boolean
+        default: false
+
+      # ----------------- Pipeline toggles -----------------
+      run_frontend_analysis:
+        description: 'Run the frontend analysis pipeline (lint, typecheck, npm audit, tests, coverage, build)'
+        type: boolean
+        default: true
+      run_security:
+        description: 'Run the security scan pipeline (Trivy, CodeQL, prerelease checks)'
+        type: boolean
+        default: true
+
+      # ----------------- Change gate -----------------
+      ignore_globs:
+        description: 'Space-separated glob patterns treated as docs/meta; when only these change, the analysis and security pipelines are skipped.'
+        type: string
+        default: '*.md docs/* .github/* LICENSE* .gitignore'
+
+      # ----------------- PR metadata (pr-validation.yml) -----------------
+      pr_title_types:
+        description: 'Allowed commit types (pipe-separated)'
+        type: string
+        default: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          chore
+          ci
+          build
+          revert
+      pr_title_scopes:
+        description: 'Allowed scopes (pipe-separated, empty = any scope allowed)'
+        type: string
+        default: ''
+      require_scope:
+        description: 'Require scope in PR title'
+        type: boolean
+        default: false
+      enable_auto_labeler:
+        description: 'Enable automatic labeling based on changed files'
+        type: boolean
+        default: true
+      labeler_config_path:
+        description: 'Path to labeler configuration file'
+        type: string
+        default: '.github/labeler.yml'
+      enforce_source_branches:
+        description: 'Enforce that PRs to protected branches come from specific source branches.'
+        type: boolean
+        default: true
+      allowed_source_branches:
+        description: 'Allowed source branches (pipe-separated, supports * prefix matching)'
+        type: string
+        default: 'develop|release-candidate|hotfix/*'
+      target_branches_for_source_check:
+        description: 'Target branches that require source branch validation (pipe-separated)'
+        type: string
+        default: 'main'
+
+      # ----------------- Frontend analysis (frontend-pr-analysis.yml) -----------------
+      node_version:
+        description: 'Node.js version to use'
+        type: string
+        default: '22'
+      package_manager:
+        description: 'Package manager to use (npm, yarn, pnpm)'
+        type: string
+        default: 'npm'
+      eslint_args:
+        description: 'Additional arguments for ESLint'
+        type: string
+        default: ''
+      audit_level:
+        description: 'npm audit severity level (low, moderate, high, critical)'
+        type: string
+        default: 'high'
+      coverage_threshold:
+        description: 'Minimum coverage percentage required (0-100)'
+        type: number
+        default: 80
+      fail_on_coverage_threshold:
+        description: 'Fail the workflow if coverage is below threshold'
+        type: boolean
+        default: false
+      app_name_prefix:
+        description: 'Prefix used to namespace coverage/build artifacts'
+        type: string
+        default: ''
+      enable_lint:
+        description: 'Enable ESLint'
+        type: boolean
+        default: true
+      enable_typecheck:
+        description: 'Enable TypeScript type checking'
+        type: boolean
+        default: true
+      enable_security:
+        description: 'Enable security scanning (npm audit)'
+        type: boolean
+        default: true
+      enable_tests:
+        description: 'Enable unit tests'
+        type: boolean
+        default: true
+      enable_coverage:
+        description: 'Enable coverage check with PR comment'
+        type: boolean
+        default: true
+      enable_build:
+        description: 'Enable build verification'
+        type: boolean
+        default: true
+      enable_i18n_check:
+        description: 'Enable i18n key validation'
+        type: boolean
+        default: false
+      i18n_check_script:
+        description: 'npm script name for extraction-parity check'
+        type: string
+        default: 'check:i18n'
+      i18n_keys_check_script:
+        description: 'npm script name for locale-parity check'
+        type: string
+        default: 'check:i18n:keys'
+      i18n_check_fail_on_violation:
+        description: 'Fail the workflow if any i18n check reports violations'
+        type: boolean
+        default: true
+
+      # ----------------- Security (pr-security-scan.yml) -----------------
+      prerelease_block_branches:
+        description: 'Comma-separated list of PR target branches where pre-release versions cause a hard failure'
+        type: string
+        default: 'release-candidate,main'
+      enable_docker_scan:
+        description: 'Build and scan a Docker image with Trivy. Set to false for repos without a Dockerfile (e.g. Node.js CLIs or libraries).'
+        type: boolean
+        default: true
+      dockerfile_path:
+        description: 'Explicit path to a single Dockerfile to build and scan (e.g. Dockerfile). Leave empty to auto-discover.'
+        type: string
+        default: ''
+      enable_codeql:
+        description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
+        type: boolean
+        default: false
+      codeql_languages:
+        description: 'Languages to analyze with CodeQL (comma-separated, e.g., "javascript-typescript")'
+        type: string
+        default: ''
+      ignore_file:
+        description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml)'
+        type: string
+        default: ''
+      trivy_skip_dirs:
+        description: 'Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list).'
+        type: string
+        default: ''
+    secrets:
+      MANAGE_TOKEN:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  # ----------------- PR Metadata Validation -----------------
+  metadata:
+    name: PR Metadata
+    uses: ./.github/workflows/pr-validation.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      dry_run: ${{ inputs.dry_run }}
+      pr_title_types: ${{ inputs.pr_title_types }}
+      pr_title_scopes: ${{ inputs.pr_title_scopes }}
+      require_scope: ${{ inputs.require_scope }}
+      enable_auto_labeler: ${{ inputs.enable_auto_labeler }}
+      labeler_config_path: ${{ inputs.labeler_config_path }}
+      enforce_source_branches: ${{ inputs.enforce_source_branches }}
+      allowed_source_branches: ${{ inputs.allowed_source_branches }}
+      target_branches_for_source_check: ${{ inputs.target_branches_for_source_check }}
+    secrets: inherit
+
+  # ----------------- Change Detection (gate) -----------------
+  changes:
+    name: Detect non-doc changes
+    if: contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)
+    runs-on: ${{ inputs.runner_type }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
+    steps:
+      - name: Non-doc change gate
+        id: gate
+        uses: LerianStudio/github-actions-shared-workflows/src/config/non-doc-changes@v1
+        with:
+          github-token: ${{ github.token }}
+          ignore-globs: ${{ inputs.ignore_globs }}
+
+  # ----------------- Frontend Analysis -----------------
+  frontend-analysis:
+    name: Frontend Analysis (pipeline)
+    needs: changes
+    if: inputs.run_frontend_analysis && needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/frontend-pr-analysis.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      node_version: ${{ inputs.node_version }}
+      package_manager: ${{ inputs.package_manager }}
+      eslint_args: ${{ inputs.eslint_args }}
+      audit_level: ${{ inputs.audit_level }}
+      coverage_threshold: ${{ inputs.coverage_threshold }}
+      fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
+      app_name_prefix: ${{ inputs.app_name_prefix }}
+      enable_lint: ${{ inputs.enable_lint }}
+      enable_typecheck: ${{ inputs.enable_typecheck }}
+      enable_security: ${{ inputs.enable_security }}
+      enable_tests: ${{ inputs.enable_tests }}
+      enable_coverage: ${{ inputs.enable_coverage }}
+      enable_build: ${{ inputs.enable_build }}
+      enable_i18n_check: ${{ inputs.enable_i18n_check }}
+      i18n_check_script: ${{ inputs.i18n_check_script }}
+      i18n_keys_check_script: ${{ inputs.i18n_keys_check_script }}
+      i18n_check_fail_on_violation: ${{ inputs.i18n_check_fail_on_violation }}
+    secrets: inherit
+
+  frontend-analysis-gate:
+    name: Frontend Analysis
+    needs: [changes, frontend-analysis]
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Aggregate Frontend Analysis result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        with:
+          result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.frontend-analysis.result }}
+          label: Frontend Analysis
+
+  # ----------------- Security Scan -----------------
+  security:
+    name: Security (pipeline)
+    needs: changes
+    if: inputs.run_security && needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/pr-security-scan.yml
+    with:
+      runner_type: ${{ inputs.runner_type }}
+      ignore_file: ${{ inputs.ignore_file }}
+      enable_docker_scan: ${{ inputs.enable_docker_scan }}
+      dockerfile_path: ${{ inputs.dockerfile_path }}
+      enable_codeql: ${{ inputs.enable_codeql }}
+      codeql_languages: ${{ inputs.codeql_languages }}
+      prerelease_block_branches: ${{ inputs.prerelease_block_branches }}
+      trivy_skip_dirs: ${{ inputs.trivy_skip_dirs }}
+    secrets: inherit
+
+  security-gate:
+    name: Security
+    needs: [changes, security]
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Aggregate security result
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
+        with:
+          result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.security.result }}
+          label: Security

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -295,3 +295,23 @@ jobs:
         with:
           result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.security.result }}
           label: Security
+
+  # ----------------- Org ruleset compatibility stubs -----------------
+  # Go Analysis and Lib Version are required status checks in the Lerian org
+  # branch-protection ruleset (designed for Go repos). These no-op stubs satisfy
+  # those checks for JS/TS repositories so callers do not need a separate ruleset.
+  go-analysis-gate:
+    name: Go Analysis
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Not applicable for JS/TS repositories
+        run: echo "Go Analysis does not apply to JavaScript/TypeScript repositories."
+
+  lib-version-gate:
+    name: Lib Version
+    if: always()
+    runs-on: ${{ inputs.runner_type }}
+    steps:
+      - name: Not applicable for JS/TS repositories
+        run: echo "Lib Version check does not apply to JavaScript/TypeScript repositories."

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -1,0 +1,139 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>js-pr-validation</h1></td>
+  </tr>
+</table>
+
+Umbrella reusable workflow for JavaScript/TypeScript repositories. A caller references this single workflow and it orchestrates everything a JS/TS PR needs:
+
+1. **PR metadata** — title, source branch, size, labels (delegates to `pr-validation.yml`).
+2. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
+3. **Frontend analysis** — lint, typecheck, npm audit, tests, coverage and build (delegates to `frontend-pr-analysis.yml`), opt-in via `run_frontend_analysis`.
+4. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
+
+The `frontend-analysis` and `security` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Frontend Analysis`, `Security`) for branch protection, regardless of the internal job names. Both are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing.
+
+## Inputs
+
+| Input | Description | Type | Default |
+|-------|-------------|------|---------|
+| `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_frontend_analysis` | Run the frontend analysis pipeline | boolean | `true` |
+| `run_security` | Run the security scan pipeline | boolean | `true` |
+| `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
+| `pr_title_types` | Allowed commit types (pipe-separated) | string | conventional set |
+| `pr_title_scopes` | Allowed scopes (pipe-separated, empty = any) | string | `''` |
+| `require_scope` | Require scope in PR title | boolean | `false` |
+| `enable_auto_labeler` | Auto-label by changed files | boolean | `true` |
+| `labeler_config_path` | Path to labeler config | string | `.github/labeler.yml` |
+| `enforce_source_branches` | Enforce source branches into protected branches | boolean | `true` |
+| `allowed_source_branches` | Allowed source branches (pipe-separated, `*` prefix) | string | `develop\|release-candidate\|hotfix/*` |
+| `target_branches_for_source_check` | Target branches requiring source validation | string | `main` |
+| `node_version` | Node.js version | string | `22` |
+| `package_manager` | Package manager (`npm`, `yarn`, `pnpm`) | string | `npm` |
+| `eslint_args` | Additional arguments for ESLint | string | `''` |
+| `audit_level` | npm audit severity level (`low`, `moderate`, `high`, `critical`) | string | `high` |
+| `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
+| `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
+| `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
+| `enable_lint` | Enable ESLint | boolean | `true` |
+| `enable_typecheck` | Enable TypeScript type checking | boolean | `true` |
+| `enable_security` | Enable npm audit | boolean | `true` |
+| `enable_tests` | Enable unit tests | boolean | `true` |
+| `enable_coverage` | Enable coverage check with PR comment | boolean | `true` |
+| `enable_build` | Enable build verification | boolean | `true` |
+| `enable_i18n_check` | Enable i18n key validation | boolean | `false` |
+| `i18n_check_script` | npm script for extraction-parity check | string | `check:i18n` |
+| `i18n_keys_check_script` | npm script for locale-parity check | string | `check:i18n:keys` |
+| `i18n_check_fail_on_violation` | Fail when any i18n check reports violations | boolean | `true` |
+| `prerelease_block_branches` | Target branches where pre-release versions are hard failures (comma-separated) | string | `release-candidate,main` |
+| `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a Dockerfile (CLIs, libraries) | boolean | `true` |
+| `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `Dockerfile`) | string | `''` |
+| `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
+| `codeql_languages` | CodeQL languages (comma-separated, e.g. `javascript-typescript`) | string | `''` |
+| `ignore_file` | Path to Trivy ignore file (e.g. `.trivyignore.yaml`) | string | `''` |
+| `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan | string | `''` |
+
+> **Monorepo note:** `filter_paths` is not exposed at the umbrella level because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input. For monorepo setups with per-component scanning, call the individual primitives directly.
+
+## Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `MANAGE_TOKEN` | Token for PR operations and private package access | No |
+| `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+
+All other secrets required by the underlying primitives (e.g. `DOCKER_USERNAME`, `DOCKERHUB_IMAGE_PULL_TOKEN`, `NPMRC_TOKEN`) are forwarded automatically via `secrets: inherit`.
+
+## Usage
+
+```yaml
+name: PR Validation
+on:
+  pull_request:
+    branches: [develop, release-candidate, main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  validate:
+    # Testing: @develop or @feat/<branch> · Production: pinned @vX.Y.Z
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-pr-validation.yml@v1
+    with:
+      app_name_prefix: "lerian-map"
+      coverage_threshold: 85
+      pr_title_scopes: |
+        components
+        pages
+        hooks
+        lib
+        api
+    secrets: inherit
+```
+
+### NestJS backend (no Docker)
+
+```yaml
+jobs:
+  validate:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-pr-validation.yml@v1
+    with:
+      enable_docker_scan: false
+      coverage_threshold: 80
+      fail_on_coverage_threshold: true
+    secrets: inherit
+```
+
+### TypeScript library (no Docker, no build step)
+
+```yaml
+jobs:
+  validate:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-pr-validation.yml@v1
+    with:
+      enable_docker_scan: false
+      enable_build: false
+      coverage_threshold: 90
+      fail_on_coverage_threshold: true
+    secrets: inherit
+```
+
+## Branch protection
+
+Require the aggregator checks `Frontend Analysis` and `Security` (plus the PR metadata checks from `pr-validation.yml`). These names are stable even when the underlying analysis steps change.
+
+## Related
+
+- [frontend-pr-analysis](./frontend-pr-analysis-workflow.md) — the frontend analysis pipeline this umbrella calls
+- [pr-security-scan](./pr-security-scan-workflow.md) — the security pipeline this umbrella calls
+- [pr-validation](./pr-validation.md) — the PR metadata validation this umbrella calls
+- [go-pr-validation](./go-pr-validation.md) — the equivalent umbrella for Go repositories

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -23,7 +23,7 @@ The `frontend-analysis` and `security` pipelines each have a `*-gate` aggregator
 | `run_frontend_analysis` | Run the frontend analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
-| `pr_title_types` | Allowed commit types (pipe-separated) | string | conventional set |
+| `pr_title_types` | Allowed commit types (pipe-separated) | string | `feat\|fix\|docs\|style\|refactor\|perf\|test\|chore\|ci\|build\|revert` |
 | `pr_title_scopes` | Allowed scopes (pipe-separated, empty = any) | string | `''` |
 | `require_scope` | Require scope in PR title | boolean | `false` |
 | `enable_auto_labeler` | Auto-label by changed files | boolean | `true` |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds `js-pr-validation.yml` — a single-file umbrella reusable workflow for JavaScript/TypeScript repositories, analogous to `go-pr-validation.yml` for Go services.

**Problem:** JS/TS repositories currently require three separate caller files to get full PR coverage:
- `pr-validation.yml` — PR metadata (title, labels, source branch)
- `frontend-pr-analysis.yml` — lint, typecheck, npm audit, tests, coverage, build
- `pr-security-scan.yml` — Trivy, CodeQL, prerelease checks

**Solution:** A single `js-pr-validation.yml` umbrella that orchestrates all three behind opt-in flags (`run_frontend_analysis`, `run_security`) and a non-doc change gate (`ignore_globs`), so callers drop from three files to one.

The umbrella mirrors `go-pr-validation.yml` in structure:
- Non-doc change gate via `src/config/non-doc-changes@v1`
- PR metadata job delegates to `pr-validation.yml`
- Frontend analysis job delegates to `frontend-pr-analysis.yml` (gated by change detector + toggle)
- Security job delegates to `pr-security-scan.yml` (gated by change detector + toggle)
- Aggregator gate jobs (`Frontend Analysis`, `Security`) expose stable status-check names for branch protection

All inputs from the three underlying primitives are forwarded individually. The three primitives are unchanged — this is a pure orchestration layer.

Also adds `docs/js-pr-validation.md` with full inputs table, usage examples for Next.js, NestJS, and TypeScript library repos.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** First consumer candidate is `LerianStudio/lerian-map` — to be validated post-merge using `@develop`.

## Related Issues

Closes #517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable JavaScript/TypeScript “PR Validation” workflow to standardize automated PR checks across repositories.
  * Includes PR metadata validation, docs-aware change gating, optional frontend analysis, and optional security scanning.
  * Adds compatibility stub checks to keep expected status-check names consistent even when checks are gated.
* **Documentation**
  * Added documentation describing workflow behavior, available inputs/secrets, usage examples, and recommended branch protection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->