### PR TITLE
feat: add reusable workflows for Helm alpha release and cleanup

### DIFF
--- a/.github/workflows/helm-alpha-cleanup.yml
+++ b/.github/workflows/helm-alpha-cleanup.yml
@@ -8,6 +8,9 @@ name: Helm Alpha Cleanup
 # GITHUB_TOKEN cannot delete org-level packages, so a PAT with delete:packages
 # is required (GHCR_CLEANUP_PAT).
 #
+# workflow_call only — the schedule/manual entrypoint is a self-* caller in the
+# consuming repo (e.g. helm/.github/workflows/helm-alpha-cleanup.yml).
+#
 # Usage:
 #   jobs:
 #     cleanup:
@@ -45,11 +48,6 @@ on:
         required: false
         type: number
         default: 5
-      runner_type:
-        description: GitHub runner to use
-        required: false
-        type: string
-        default: "ubuntu-latest"
       dry_run:
         description: Preview deletions without applying them
         required: false
@@ -59,28 +57,32 @@ on:
       GHCR_CLEANUP_PAT:
         description: PAT with delete:packages (GITHUB_TOKEN cannot delete org-level packages)
         required: true
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Preview deletions without applying them
-        type: boolean
-        default: true
 
+# Least privilege: read by default, escalate per-job.
 permissions:
-  packages: write
+  contents: read
+
+# Serialize runs so overlapping schedule/dispatch invocations don't race on the
+# same GHCR package versions.
+concurrency:
+  group: helm-alpha-cleanup-${{ github.repository }}
+  cancel-in-progress: false
 
 jobs:
   cleanup:
     name: Prune alpha packages past TTL
-    runs-on: ${{ inputs.runner_type || 'ubuntu-latest' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      packages: write # delete alpha package versions from GHCR
     steps:
       - name: Prune alphas
-        uses: ./src/config/ghcr-alpha-cleanup
+        # TODO: pin to @v1 once released; @develop for testing.
+        uses: LerianStudio/github-actions-shared-workflows/src/config/ghcr-alpha-cleanup@develop
         with:
-          account: ${{ inputs.account || 'lerianstudio' }}
+          account: ${{ inputs.account }}
           token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          image-names: ${{ inputs.image_names || 'alpha/*' }}
-          image-tags: ${{ inputs.image_tags || '*-alpha*' }}
-          cut-off: ${{ inputs.cut_off || '3d' }}
-          keep-n-most-recent: ${{ inputs.keep_n_most_recent || 5 }}
+          image-names: ${{ inputs.image_names }}
+          image-tags: ${{ inputs.image_tags }}
+          cut-off: ${{ inputs.cut_off }}
+          keep-n-most-recent: ${{ inputs.keep_n_most_recent }}
           dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/helm-alpha-cleanup.yml
+++ b/.github/workflows/helm-alpha-cleanup.yml
@@ -1,0 +1,86 @@
+name: Helm Alpha Cleanup
+
+# Reusable workflow that enforces the TTL of alpha Helm chart packages: deletes
+# packages under the alpha/ namespace (image_names, default alpha/*) with alpha
+# tags older than cut_off. Real releases (ghcr.io/lerianstudio/<chart>) are a
+# different package path and are guarded out.
+#
+# GITHUB_TOKEN cannot delete org-level packages, so a PAT with delete:packages
+# is required (GHCR_CLEANUP_PAT).
+#
+# Usage:
+#   jobs:
+#     cleanup:
+#       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-cleanup.yml@v1
+#       with:
+#         dry_run: false
+#       secrets:
+#         GHCR_CLEANUP_PAT: ${{ secrets.GHCR_CLEANUP_PAT }}
+
+on:
+  workflow_call:
+    inputs:
+      account:
+        description: GitHub org/user that owns the packages
+        required: false
+        type: string
+        default: "lerianstudio"
+      image_names:
+        description: Package name globs to target (must be alpha/ scoped)
+        required: false
+        type: string
+        default: "alpha/*"
+      image_tags:
+        description: Tag globs to target
+        required: false
+        type: string
+        default: "*-alpha*"
+      cut_off:
+        description: Delete versions older than this (e.g. "3d", "1w")
+        required: false
+        type: string
+        default: "3d"
+      keep_n_most_recent:
+        description: Always keep at least this many recent versions per package
+        required: false
+        type: number
+        default: 5
+      runner_type:
+        description: GitHub runner to use
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      dry_run:
+        description: Preview deletions without applying them
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GHCR_CLEANUP_PAT:
+        description: PAT with delete:packages (GITHUB_TOKEN cannot delete org-level packages)
+        required: true
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview deletions without applying them
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Prune alpha packages past TTL
+    runs-on: ${{ inputs.runner_type || 'ubuntu-latest' }}
+    steps:
+      - name: Prune alphas
+        uses: ./src/config/ghcr-alpha-cleanup
+        with:
+          account: ${{ inputs.account || 'lerianstudio' }}
+          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+          image-names: ${{ inputs.image_names || 'alpha/*' }}
+          image-tags: ${{ inputs.image_tags || '*-alpha*' }}
+          cut-off: ${{ inputs.cut_off || '3d' }}
+          keep-n-most-recent: ${{ inputs.keep_n_most_recent || 5 }}
+          dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/helm-alpha-release.yml
+++ b/.github/workflows/helm-alpha-release.yml
@@ -7,6 +7,9 @@ name: Helm Alpha Release
 # TTL is enforced separately by helm-alpha-cleanup.yml. Does NOT run
 # semantic-release: no Chart.yaml commit, git tag, CHANGELOG, back-merge or notes.
 #
+# workflow_call only — the manual entrypoint is a self-* caller in the consuming
+# repo (e.g. helm/.github/workflows/helm-alpha.yml).
+#
 # Usage:
 #   jobs:
 #     alpha:
@@ -31,35 +34,23 @@ on:
         required: false
         type: string
         default: "oci://ghcr.io/lerianstudio/alpha"
-      runner_type:
-        description: GitHub runner to use
-        required: false
-        type: string
-        default: "ubuntu-latest"
       dry_run:
         description: Package and validate but do not push
         required: false
         type: boolean
         default: false
-  workflow_dispatch:
-    inputs:
-      chart:
-        description: Chart directory name under charts/ (may be a new chart on your branch)
-        required: true
-        type: string
-      dry_run:
-        description: Package and validate but do not push
-        type: boolean
-        default: true
 
+# Least privilege: read by default, escalate per-job.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   alpha:
     name: "Publish alpha • ${{ inputs.chart }}"
-    runs-on: ${{ inputs.runner_type || 'ubuntu-latest' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read # checkout the chart source
+      packages: write # push the packaged chart to GHCR
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -69,11 +60,12 @@ jobs:
 
       - name: Publish alpha
         id: alpha
-        uses: ./src/build/helm-alpha-publish
+        # TODO: pin to @v1 once released; @develop for testing.
+        uses: LerianStudio/github-actions-shared-workflows/src/build/helm-alpha-publish@develop
         with:
           chart: ${{ inputs.chart }}
-          charts-path: ${{ inputs.charts_path || 'charts' }}
-          registry: ${{ inputs.registry || 'oci://ghcr.io/lerianstudio/alpha' }}
+          charts-path: ${{ inputs.charts_path }}
+          registry: ${{ inputs.registry }}
           registry-host: ghcr.io
           registry-username: ${{ github.actor }}
           registry-password: ${{ github.token }}

--- a/.github/workflows/helm-alpha-release.yml
+++ b/.github/workflows/helm-alpha-release.yml
@@ -1,0 +1,91 @@
+name: Helm Alpha Release
+
+# Reusable workflow that publishes a disposable ALPHA prerelease of a Helm chart
+# to an isolated OCI namespace: each chart becomes its own package under
+# ghcr.io/lerianstudio/alpha/<chart>. Authenticates with the built-in
+# GITHUB_TOKEN (same org, packages:write) — no App token, no static secret.
+# TTL is enforced separately by helm-alpha-cleanup.yml. Does NOT run
+# semantic-release: no Chart.yaml commit, git tag, CHANGELOG, back-merge or notes.
+#
+# Usage:
+#   jobs:
+#     alpha:
+#       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-release.yml@v1
+#       with:
+#         chart: flowker
+
+on:
+  workflow_call:
+    inputs:
+      chart:
+        description: Chart directory name under charts_path
+        required: true
+        type: string
+      charts_path:
+        description: Path to the charts directory
+        required: false
+        type: string
+        default: "charts"
+      registry:
+        description: OCI namespace to push the alpha chart to (each chart becomes alpha/<chart>)
+        required: false
+        type: string
+        default: "oci://ghcr.io/lerianstudio/alpha"
+      runner_type:
+        description: GitHub runner to use
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      dry_run:
+        description: Package and validate but do not push
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      chart:
+        description: Chart directory name under charts/ (may be a new chart on your branch)
+        required: true
+        type: string
+      dry_run:
+        description: Package and validate but do not push
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  alpha:
+    name: "Publish alpha • ${{ inputs.chart }}"
+    runs-on: ${{ inputs.runner_type || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Publish alpha
+        id: alpha
+        uses: ./src/build/helm-alpha-publish
+        with:
+          chart: ${{ inputs.chart }}
+          charts-path: ${{ inputs.charts_path || 'charts' }}
+          registry: ${{ inputs.registry || 'oci://ghcr.io/lerianstudio/alpha' }}
+          registry-host: ghcr.io
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ github.token }}
+          dry-run: ${{ inputs.dry_run }}
+
+      - name: Summary
+        if: ${{ !inputs.dry_run }}
+        run: |
+          {
+            echo "### 🚀 Alpha published"
+            echo ""
+            echo "\`${{ steps.alpha.outputs.reference }}\`"
+            echo ""
+            echo "> TTL ~3 days — pruned by the *Helm Alpha Cleanup* workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/helm-alpha-release.yml
+++ b/.github/workflows/helm-alpha-release.yml
@@ -73,11 +73,14 @@ jobs:
 
       - name: Summary
         if: ${{ !inputs.dry_run }}
+        env:
+          # Pass via env (not direct ${{ }} in run) to avoid script injection.
+          REFERENCE: ${{ steps.alpha.outputs.reference }}
         run: |
           {
             echo "### 🚀 Alpha published"
             echo ""
-            echo "\`${{ steps.alpha.outputs.reference }}\`"
+            echo "\`${REFERENCE}\`"
             echo ""
             echo "> TTL ~3 days — pruned by the *Helm Alpha Cleanup* workflow."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/helm-alpha-cleanup.md
+++ b/docs/helm-alpha-cleanup.md
@@ -1,0 +1,77 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>helm-alpha-cleanup</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that enforces the TTL of alpha Helm chart packages published by [`helm-alpha-release`](./helm-alpha-release.md). It deletes GHCR package versions in the alpha namespace with alpha tags older than a cut-off.
+
+## What it does
+
+Three filters combine (AND) — nothing outside scope is ever deleted:
+
+| Filter | Guards against |
+|---|---|
+| `image_names: alpha/*` | Deleting a **real release** (different package name → invisible here) |
+| `cut_off: 3d` | Deleting an alpha **within its TTL** (fresh alphas stay) |
+| `image_tags: *-alpha*` | Deleting anything without an alpha tag |
+| `keep_n_most_recent: 5` | Wiping a package entirely |
+
+Manual dispatch defaults to **dry-run** (preview only); the scheduled run deletes for real.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|:---:|---|---|
+| `account` | `string` | No | `lerianstudio` | Org/user owning the packages |
+| `image_names` | `string` | No | `alpha/*` | Package name globs |
+| `image_tags` | `string` | No | `*-alpha*` | Tag globs |
+| `cut_off` | `string` | No | `3d` | Age threshold |
+| `keep_n_most_recent` | `number` | No | `5` | Minimum versions kept per package |
+| `runner_type` | `string` | No | `ubuntu-latest` | Runner label |
+| `dry_run` | `boolean` | No | `false` | Preview without applying |
+
+## Secrets
+
+| Secret | Required | Description |
+|---|---|---|
+| `GHCR_CLEANUP_PAT` | Yes | PAT with `delete:packages` (`GITHUB_TOKEN` cannot delete org-level packages) |
+
+## Usage
+
+### Scheduled caller (per repo)
+
+```yaml
+# .github/workflows/helm-alpha-cleanup.yml
+name: Helm Alpha Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * *"   # daily, 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    # Testing: pin to @develop. Production: pin to a stable @vX.Y.Z.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-cleanup.yml@v1
+    with:
+      # schedule deletes for real; manual dispatch previews unless you flip dry_run
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    secrets:
+      GHCR_CLEANUP_PAT: ${{ secrets.GHCR_CLEANUP_PAT }}
+```
+
+## Permissions required
+
+```yaml
+permissions:
+  packages: write
+```

--- a/docs/helm-alpha-cleanup.md
+++ b/docs/helm-alpha-cleanup.md
@@ -5,7 +5,9 @@
   </tr>
 </table>
 
-Reusable workflow that enforces the TTL of alpha Helm chart packages published by [`helm-alpha-release`](./helm-alpha-release.md). It deletes GHCR package versions in the alpha namespace with alpha tags older than a cut-off.
+Reusable workflow that enforces the TTL of alpha Helm chart packages published by [`helm-alpha-release`](./helm-alpha-release.md). It deletes GHCR package versions under the alpha namespace with alpha tags older than a cut-off.
+
+`workflow_call` only — the schedule/manual entrypoint is a caller workflow in the consuming repo. Runs are serialized via `concurrency` so overlapping schedule/dispatch invocations don't race on the same package versions.
 
 ## What it does
 
@@ -13,23 +15,22 @@ Three filters combine (AND) — nothing outside scope is ever deleted:
 
 | Filter | Guards against |
 |---|---|
-| `image_names: alpha/*` | Deleting a **real release** (different package name → invisible here) |
+| `image_names: alpha/*` (guarded per-entry) | Deleting a **real release** (different package path → out of scope) |
 | `cut_off: 3d` | Deleting an alpha **within its TTL** (fresh alphas stay) |
 | `image_tags: *-alpha*` | Deleting anything without an alpha tag |
 | `keep_n_most_recent: 5` | Wiping a package entirely |
 
-Manual dispatch defaults to **dry-run** (preview only); the scheduled run deletes for real.
+The composite refuses to run if any `image_names` entry is not under `alpha/`.
 
 ## Inputs
 
 | Input | Type | Required | Default | Description |
 |---|---|:---:|---|---|
 | `account` | `string` | No | `lerianstudio` | Org/user owning the packages |
-| `image_names` | `string` | No | `alpha/*` | Package name globs |
+| `image_names` | `string` | No | `alpha/*` | Package name globs (must be alpha-scoped) |
 | `image_tags` | `string` | No | `*-alpha*` | Tag globs |
 | `cut_off` | `string` | No | `3d` | Age threshold |
 | `keep_n_most_recent` | `number` | No | `5` | Minimum versions kept per package |
-| `runner_type` | `string` | No | `ubuntu-latest` | Runner label |
 | `dry_run` | `boolean` | No | `false` | Preview without applying |
 
 ## Secrets
@@ -56,12 +57,13 @@ on:
         default: true
 
 permissions:
+  contents: read
   packages: write
 
 jobs:
   cleanup:
-    # Testing: pin to @develop. Production: pin to a stable @vX.Y.Z.
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-cleanup.yml@v1
+    # Testing: @develop. Production: a stable @vX.Y.Z.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-cleanup.yml@develop
     with:
       # schedule deletes for real; manual dispatch previews unless you flip dry_run
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/docs/helm-alpha-release.md
+++ b/docs/helm-alpha-release.md
@@ -1,0 +1,79 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>helm-alpha-release</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that publishes a **disposable alpha prerelease** of a Helm chart to an isolated OCI namespace, for testing a chart before it is released through the normal `develop`/`main` pipeline. Alphas have a short TTL enforced by [`helm-alpha-cleanup`](./helm-alpha-cleanup.md).
+
+## What it does
+
+| Step | Behavior |
+|---|---|
+| Resolve version | `<chart-version>-alpha.<UTC-timestamp>.<short-sha>` from the checked-out ref |
+| Validate | `helm dependency update` + `helm lint`; fails with the chart list if `chart` is not found |
+| Publish | `helm package` + `helm push` to `registry` (default `oci://ghcr.io/lerianstudio/alpha`) |
+
+Because the checkout uses the caller's ref, **a chart that only exists on a work branch is published as long as the workflow is dispatched from that branch**. It does **not** touch git history, CHANGELOG, tags or notifications.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+|---|---|:---:|---|---|
+| `chart` | `string` | Yes | — | Chart directory name under `charts_path` |
+| `charts_path` | `string` | No | `charts` | Path to the charts directory |
+| `registry` | `string` | No | `oci://ghcr.io/lerianstudio/alpha` | OCI namespace to push to |
+| `registry_host` | `string` | No | `ghcr.io` | Registry host for login |
+| `registry_username` | `string` | No | `lerianstudio` | Registry login user |
+| `runner_type` | `string` | No | `ubuntu-latest` | Runner label |
+| `dry_run` | `boolean` | No | `false` | Package/validate but do not push |
+
+## Secrets
+
+| Secret | Required | Description |
+|---|---|---|
+| `REGISTRY_PASSWORD` | No | Token with `packages:write`. Falls back to `GITHUB_TOKEN` when omitted. |
+
+## Usage
+
+### Manual dispatch caller (per repo)
+
+```yaml
+# .github/workflows/helm-alpha.yml
+name: Helm Alpha Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      chart:
+        description: "Chart (dir under charts/) — may be a new chart on your branch"
+        required: true
+        type: string
+      dry_run:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  alpha:
+    # Testing: pin to @develop. Production: pin to a stable @vX.Y.Z.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-release.yml@v1
+    with:
+      chart: ${{ inputs.chart }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+```
+
+> Dispatch from your work branch (the branch selector in **Run workflow**) so the checkout uses that ref and picks up new charts.
+
+## Permissions required
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```

--- a/docs/helm-alpha-release.md
+++ b/docs/helm-alpha-release.md
@@ -5,7 +5,9 @@
   </tr>
 </table>
 
-Reusable workflow that publishes a **disposable alpha prerelease** of a Helm chart to an isolated OCI namespace, for testing a chart before it is released through the normal `develop`/`main` pipeline. Alphas have a short TTL enforced by [`helm-alpha-cleanup`](./helm-alpha-cleanup.md).
+Reusable workflow that publishes a **disposable alpha prerelease** of a Helm chart to an isolated OCI namespace, for testing a chart before it goes through the normal `develop`/`main` pipeline. Each chart becomes its own package under `ghcr.io/lerianstudio/alpha/<chart>`. Alphas have a short TTL enforced by [`helm-alpha-cleanup`](./helm-alpha-cleanup.md).
+
+Authenticates with the built-in `GITHUB_TOKEN` (same org, `packages: write`) — no App token, no static secret. Does **not** run semantic-release: no git tag, CHANGELOG, version bump or notifications.
 
 ## What it does
 
@@ -15,7 +17,9 @@ Reusable workflow that publishes a **disposable alpha prerelease** of a Helm cha
 | Validate | `helm dependency update` + `helm lint`; fails with the chart list if `chart` is not found |
 | Publish | `helm package` + `helm push` to `registry` (default `oci://ghcr.io/lerianstudio/alpha`) |
 
-Because the checkout uses the caller's ref, **a chart that only exists on a work branch is published as long as the workflow is dispatched from that branch**. It does **not** touch git history, CHANGELOG, tags or notifications.
+Because the checkout uses the caller's ref, **a chart that only exists on a work branch is published as long as the caller is dispatched from that branch**.
+
+`workflow_call` only — the manual entrypoint is a caller workflow in the consuming repo.
 
 ## Inputs
 
@@ -24,16 +28,11 @@ Because the checkout uses the caller's ref, **a chart that only exists on a work
 | `chart` | `string` | Yes | — | Chart directory name under `charts_path` |
 | `charts_path` | `string` | No | `charts` | Path to the charts directory |
 | `registry` | `string` | No | `oci://ghcr.io/lerianstudio/alpha` | OCI namespace to push to |
-| `registry_host` | `string` | No | `ghcr.io` | Registry host for login |
-| `registry_username` | `string` | No | `lerianstudio` | Registry login user |
-| `runner_type` | `string` | No | `ubuntu-latest` | Runner label |
 | `dry_run` | `boolean` | No | `false` | Package/validate but do not push |
 
 ## Secrets
 
-| Secret | Required | Description |
-|---|---|---|
-| `REGISTRY_PASSWORD` | No | Token with `packages:write`. Falls back to `GITHUB_TOKEN` when omitted. |
+None — the job's `GITHUB_TOKEN` (`packages: write`) is used for the push.
 
 ## Usage
 
@@ -60,12 +59,11 @@ permissions:
 
 jobs:
   alpha:
-    # Testing: pin to @develop. Production: pin to a stable @vX.Y.Z.
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-release.yml@v1
+    # Testing: @develop. Production: a stable @vX.Y.Z.
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-release.yml@develop
     with:
       chart: ${{ inputs.chart }}
       dry_run: ${{ inputs.dry_run }}
-    secrets: inherit
 ```
 
 > Dispatch from your work branch (the branch selector in **Run workflow**) so the checkout uses that ref and picks up new charts.

--- a/src/build/helm-alpha-publish/README.md
+++ b/src/build/helm-alpha-publish/README.md
@@ -1,0 +1,69 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>helm-alpha-publish</h1></td>
+  </tr>
+</table>
+
+Composite action that packages a Helm chart as a **disposable alpha prerelease** and pushes it to an isolated OCI namespace (default `oci://ghcr.io/lerianstudio/alpha`). The alpha version is `<chart-version>-alpha.<UTC-timestamp>.<short-sha>`. Isolating alphas in their own namespace lets the retention job prune them without ever touching real releases.
+
+Does **not** run semantic-release: no `Chart.yaml` commit, git tag, CHANGELOG, back-merge or notifications.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|:---:|---|
+| `chart` | Chart directory name under `charts-path` | Yes | — |
+| `charts-path` | Path to the charts directory | No | `charts` |
+| `registry` | OCI registry/namespace to push to | No | `oci://ghcr.io/lerianstudio/alpha` |
+| `registry-host` | Registry host for `helm registry login` | No | `ghcr.io` |
+| `registry-username` | Username for registry login | No | `lerianstudio` |
+| `registry-password` | Token with `packages:write` | Yes | — |
+| `dry-run` | Package and validate but do not push | No | `false` |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `version` | Generated alpha version |
+| `reference` | Full OCI reference of the pushed chart |
+
+## Usage
+
+### As a composite action
+
+```yaml
+jobs:
+  alpha:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: LerianStudio/github-actions-shared-workflows/src/build/helm-alpha-publish@v1
+        with:
+          chart: flowker
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### As a reusable workflow (recommended)
+
+```yaml
+jobs:
+  alpha:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-release.yml@v1
+    with:
+      chart: flowker
+    secrets: inherit
+```
+
+## Permissions required
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+```

--- a/src/build/helm-alpha-publish/README.md
+++ b/src/build/helm-alpha-publish/README.md
@@ -9,6 +9,8 @@ Composite action that packages a Helm chart as a **disposable alpha prerelease**
 
 Does **not** run semantic-release: no `Chart.yaml` commit, git tag, CHANGELOG, back-merge or notifications.
 
+Depends on [`azure/setup-helm`](https://github.com/Azure/setup-helm) to install the `helm` CLI on the runner — required for `helm dependency update`, `helm lint`, `helm package`, and `helm push` to the OCI registry. It is the maintained, official installer, avoiding a hand-rolled download/verify step.
+
 ## Inputs
 
 | Input | Description | Required | Default |

--- a/src/build/helm-alpha-publish/action.yml
+++ b/src/build/helm-alpha-publish/action.yml
@@ -64,9 +64,10 @@ runs:
           exit 1
         fi
 
-        # Read name/version without depending on yq being on PATH.
-        NAME="$(grep -E '^name:' "$DIR/Chart.yaml" | head -1 | sed -E 's/^name:[[:space:]]*//; s/["'\'']//g')"
-        BASE="$(grep -E '^version:' "$DIR/Chart.yaml" | head -1 | sed -E 's/^version:[[:space:]]*//; s/["'\'']//g')"
+        # Parse Chart.yaml with a real YAML parser (yq ships on the runner image)
+        # so inline comments / quoting never leak into the values.
+        NAME="$(yq '.name' "$DIR/Chart.yaml")"
+        BASE="$(yq '.version' "$DIR/Chart.yaml")"
         ALPHA="${BASE}-alpha.$(date -u +%Y%m%d%H%M).$(git rev-parse --short HEAD)"
 
         echo "version=$ALPHA" >> "$GITHUB_OUTPUT"

--- a/src/build/helm-alpha-publish/action.yml
+++ b/src/build/helm-alpha-publish/action.yml
@@ -1,0 +1,89 @@
+name: Helm Alpha Publish
+description: Packages a Helm chart as a disposable alpha prerelease and pushes it to an isolated OCI namespace.
+
+inputs:
+  chart:
+    description: Chart directory name under charts-path
+    required: true
+  charts-path:
+    description: Path to the charts directory
+    required: false
+    default: "charts"
+  registry:
+    description: OCI registry/namespace to push the alpha chart to (isolated alpha namespace)
+    required: false
+    default: "oci://ghcr.io/lerianstudio/alpha"
+  registry-host:
+    description: Registry host used for helm registry login
+    required: false
+    default: "ghcr.io"
+  registry-username:
+    description: Username for registry login
+    required: false
+    default: "lerianstudio"
+  registry-password:
+    description: Token/password for registry login (needs packages:write)
+    required: true
+  dry-run:
+    description: Package and validate but do not push
+    required: false
+    default: "false"
+
+outputs:
+  version:
+    description: The generated alpha version (e.g. 1.2.3-alpha.202607011200.abc1234)
+    value: ${{ steps.publish.outputs.version }}
+  reference:
+    description: Full OCI reference of the pushed chart
+    value: ${{ steps.publish.outputs.reference }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Helm
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+    - name: Package & push alpha
+      id: publish
+      shell: bash
+      env:
+        CHART: ${{ inputs.chart }}
+        CHARTS_PATH: ${{ inputs.charts-path }}
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_HOST: ${{ inputs.registry-host }}
+        REGISTRY_USERNAME: ${{ inputs.registry-username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+
+        DIR="$CHARTS_PATH/$CHART"
+        if [ ! -f "$DIR/Chart.yaml" ]; then
+          echo "::error::chart '$CHART' not found in $CHARTS_PATH/ (this ref)."
+          echo "Charts available on this branch:"; ls -1 "$CHARTS_PATH" || true
+          exit 1
+        fi
+
+        # Read name/version without depending on yq being on PATH.
+        NAME="$(grep -E '^name:' "$DIR/Chart.yaml" | head -1 | sed -E 's/^name:[[:space:]]*//; s/["'\'']//g')"
+        BASE="$(grep -E '^version:' "$DIR/Chart.yaml" | head -1 | sed -E 's/^version:[[:space:]]*//; s/["'\'']//g')"
+        ALPHA="${BASE}-alpha.$(date -u +%Y%m%d%H%M).$(git rev-parse --short HEAD)"
+
+        echo "version=$ALPHA" >> "$GITHUB_OUTPUT"
+        echo "reference=${REGISTRY}/${NAME}:${ALPHA}" >> "$GITHUB_OUTPUT"
+
+        helm dependency update "$DIR"
+        helm lint "$DIR"
+        PKG="$(helm package "$DIR" --version "$ALPHA" -d "$RUNNER_TEMP" | awk '{print $NF}')"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "::notice::DRY RUN — chart packaged ($ALPHA) but NOT pushed"
+          echo "  chart    : $NAME"
+          echo "  package  : $PKG"
+          echo "  target   : $REGISTRY"
+          exit 0
+        fi
+
+        echo "$REGISTRY_PASSWORD" | helm registry login "$REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        helm push "$PKG" "$REGISTRY"
+        echo "::notice::alpha published: ${REGISTRY}/${NAME}:${ALPHA}"

--- a/src/config/ghcr-alpha-cleanup/README.md
+++ b/src/config/ghcr-alpha-cleanup/README.md
@@ -1,0 +1,59 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>ghcr-alpha-cleanup</h1></td>
+  </tr>
+</table>
+
+Composite action that enforces the TTL of alpha Helm chart packages on GHCR: it deletes package versions matching the alpha namespace and tag globs that are older than a cut-off. Wraps [snok/container-retention-policy](https://github.com/snok/container-retention-policy).
+
+Three filters combine (AND) so nothing outside scope is ever removed:
+
+- `image-names: alpha/*` — only the alpha namespace; **real releases are a different package name and are invisible to this action**.
+- `image-tags: *-alpha*` — only alpha tags.
+- `cut-off: 3d` — only versions older than the cut-off (fresh alphas are kept).
+
+Plus `keep-n-most-recent` as a floor so it never wipes a package entirely, and `dry-run` (default `true`) to preview.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|:---:|---|
+| `account` | Org/user that owns the packages | No | `lerianstudio` |
+| `token` | Token with `delete:packages` (org-level needs a PAT) | Yes | — |
+| `image-names` | Package name globs (space-separated) | No | `alpha/*` |
+| `image-tags` | Tag globs to target | No | `*-alpha*` |
+| `cut-off` | Delete versions older than this | No | `3d` |
+| `keep-n-most-recent` | Minimum recent versions to keep per package | No | `5` |
+| `dry-run` | Preview deletions without applying | No | `true` |
+
+## Usage
+
+### As a composite action
+
+```yaml
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: LerianStudio/github-actions-shared-workflows/src/config/ghcr-alpha-cleanup@v1
+        with:
+          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+          dry-run: "true"
+```
+
+### As a reusable workflow (recommended)
+
+```yaml
+jobs:
+  cleanup:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-alpha-cleanup.yml@v1
+    with:
+      dry_run: false
+    secrets:
+      GHCR_CLEANUP_PAT: ${{ secrets.GHCR_CLEANUP_PAT }}
+```
+
+## Permissions / token
+
+`GITHUB_TOKEN` cannot delete org-level packages — provide a **PAT with `delete:packages`** (and `read:packages`) via `token`.

--- a/src/config/ghcr-alpha-cleanup/action.yml
+++ b/src/config/ghcr-alpha-cleanup/action.yml
@@ -40,6 +40,7 @@ runs:
       env:
         IMAGE_NAMES: ${{ inputs.image-names }}
       run: |
+        set -f # disable globbing so a pattern like alpha/* is validated literally
         # Every entry must live under the alpha/ namespace — a stray "*" or a
         # release package name (e.g. "*-helm") must never slip through.
         for n in $IMAGE_NAMES; do

--- a/src/config/ghcr-alpha-cleanup/action.yml
+++ b/src/config/ghcr-alpha-cleanup/action.yml
@@ -1,0 +1,68 @@
+name: GHCR Alpha Cleanup
+description: Deletes alpha Helm chart packages from GHCR older than a cut-off, keeping real releases untouched. Wraps snok/container-retention-policy.
+
+inputs:
+  account:
+    description: GitHub org/user that owns the packages
+    required: false
+    default: "lerianstudio"
+  token:
+    description: Token with delete:packages (org-level deletion may require a PAT — App tokens are not guaranteed to delete org packages)
+    required: true
+  image-names:
+    description: Package name globs to target (space-separated). MUST be scoped to the alpha namespace.
+    required: false
+    default: "alpha/*"
+  image-tags:
+    description: Tag globs to target
+    required: false
+    default: "*-alpha*"
+  cut-off:
+    description: Delete versions older than this (e.g. "3d", "1w")
+    required: false
+    default: "3d"
+  keep-n-most-recent:
+    description: Always keep at least this many recent versions per package (safety net)
+    required: false
+    default: "5"
+  dry-run:
+    description: Preview deletions without applying them
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    # Safety guard: refuse to run against unscoped image-names so a stray "*"
+    # can never reach real releases (which live outside the alpha/ namespace).
+    - name: Guard — enforce alpha scope
+      shell: bash
+      env:
+        IMAGE_NAMES: ${{ inputs.image-names }}
+      run: |
+        # Every entry must live under the alpha/ namespace — a stray "*" or a
+        # release package name (e.g. "*-helm") must never slip through.
+        for n in $IMAGE_NAMES; do
+          case "$n" in
+            alpha/*) : ;;
+            *)
+              echo "::error::image-names entry '$n' is not under the alpha/ namespace. Refusing to run."
+              exit 1
+              ;;
+          esac
+        done
+
+    # NOTE: pin to a commit SHA before release, and confirm the exact input
+    # names/accepted values (tag-selection, cut-off format) for the pinned
+    # version. Composites under src/** are not tracked by Dependabot here.
+    - name: Container retention policy
+      uses: snok/container-retention-policy@v3.0.0
+      with:
+        account: ${{ inputs.account }}
+        token: ${{ inputs.token }}
+        image-names: ${{ inputs.image-names }}
+        image-tags: ${{ inputs.image-tags }}
+        tag-selection: tagged
+        cut-off: ${{ inputs.cut-off }}
+        keep-n-most-recent: ${{ inputs.keep-n-most-recent }}
+        dry-run: ${{ inputs.dry-run }}

--- a/src/config/ghcr-alpha-cleanup/action.yml
+++ b/src/config/ghcr-alpha-cleanup/action.yml
@@ -52,11 +52,10 @@ runs:
           esac
         done
 
-    # NOTE: pin to a commit SHA before release, and confirm the exact input
-    # names/accepted values (tag-selection, cut-off format) for the pinned
-    # version. Composites under src/** are not tracked by Dependabot here.
+    # Pinned by SHA (Dependabot does not track composites under src/** here, so
+    # bump this manually). Inputs verified against v3.1.0.
     - name: Container retention policy
-      uses: snok/container-retention-policy@v3.0.0
+      uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
       with:
         account: ${{ inputs.account }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
- Introduced `helm-alpha-release.yml` for publishing disposable alpha prereleases of Helm charts.
- Added `helm-alpha-cleanup.yml` to enforce TTL on alpha Helm chart packages.
- Created documentation for both workflows in `helm-alpha-release.md` and `helm-alpha-cleanup.md`.
- Implemented `ghcr-alpha-cleanup` composite action to manage package retention.
- Updated `README.md` files for clarity on usage and permissions.

<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

<!-- Summarize what this PR does and why. List which workflow(s) are affected and what behavior changes. -->

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

<!-- If applicable, describe exactly what breaks and how callers should migrate. Remove this section if not applicable. -->

None.

## Testing

<!-- Shared workflows can't be unit-tested locally. Describe how you validated the change. -->

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [ ] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- Link to the Actions run that validated this change -->

## Related Issues

Closes #
