### PR TITLE
fix(release): guard release.yml against prerelease published after stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,11 @@ on:
         required: false
         type: boolean
         default: false
+      prerelease_branches:
+        description: 'Comma-separated list of branches treated as prerelease lines (beta/rc). Before calculating a version on these branches, backmerge_source is merged in first; if that merge cannot complete directly, the release is skipped for this run. A defensive check then fails the run if the calculated version would still land on an X.Y.Z that already has a stable release.'
+        required: false
+        type: string
+        default: 'develop,release-candidate'
 
 permissions:
   contents: read
@@ -191,21 +196,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: '20'
-
-      - name: Init package.json
-        working-directory: ${{ matrix.app.working_dir }}
-        run: npm init -y
-
-      - name: Install semantic-release plugins
-        working-directory: ${{ matrix.app.working_dir }}
-        run: |
-          npm install --save-dev \
-            @semantic-release/exec
-
       # ----------------- Backmerge config preflight -----------------
       - name: Validate backmerge inputs
         if: inputs.backmerge_enabled
@@ -234,9 +224,91 @@ jobs:
             exit 1
           fi
 
+      # ----------------- Prerelease staleness guard -----------------
+      - name: Classify branch
+        id: classify
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          PRERELEASE_BRANCHES: ${{ inputs.prerelease_branches }}
+        run: |
+          is_prerelease=false
+          IFS=',' read -ra BR <<< "$PRERELEASE_BRANCHES"
+          for b in "${BR[@]}"; do
+            b_trimmed="$(echo "$b" | xargs)"
+            if [ "$b_trimmed" = "$REF_NAME" ]; then
+              is_prerelease=true
+              break
+            fi
+          done
+          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
+
+      - name: Sync ${{ inputs.backmerge_source }} → ${{ github.ref_name }} before calculating version
+        id: pre_sync
+        if: inputs.backmerge_enabled && steps.classify.outputs.is_prerelease == 'true'
+        uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          source-branch: ${{ inputs.backmerge_source }}
+          target-branch: ${{ github.ref_name }}
+          mode: ${{ inputs.backmerge_mode }}
+          dry-run: ${{ inputs.dry_run }}
+          commit-message: "chore(release): sync ${source} into ${target} before release [skip ci]"
+          pr-title: "chore(release): sync ${source} → ${target}"
+          git-user-name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          git-user-email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+
+      - name: Warn about pending backmerge sync
+        if: steps.pre_sync.outputs.action == 'pr-opened' || steps.pre_sync.outputs.action == 'pr-existing'
+        run: |
+          echo "::warning::Release skipped for ${{ matrix.app.name }} — ${{ inputs.backmerge_source }} could not be auto-merged into ${{ github.ref_name }} (PR: ${{ steps.pre_sync.outputs.pr-url }}). Merge it and push again to release."
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+
+      - name: Init package.json
+        working-directory: ${{ matrix.app.working_dir }}
+        run: npm init -y
+
+      - name: Install semantic-release plugins
+        working-directory: ${{ matrix.app.working_dir }}
+        run: |
+          npm install --save-dev \
+            @semantic-release/exec
+
+      - name: Determine next version (dry-run)
+        id: semantic_dry
+        if: |
+          steps.classify.outputs.is_prerelease == 'true' &&
+          steps.pre_sync.outputs.action != 'pr-opened' &&
+          steps.pre_sync.outputs.action != 'pr-existing'
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
+        with:
+          ci: false
+          dry_run: true
+          semantic_version: ${{ inputs.semantic_version }}
+          working_directory: ${{ matrix.app.working_dir }}
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@v7.0.2
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Guard against stale prerelease
+        id: guard
+        if: steps.semantic_dry.outputs.new_release_published == 'true'
+        uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1
+        with:
+          calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}
+          source-branch: ${{ inputs.backmerge_source }}
+          target-branch: ${{ github.ref_name }}
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
         id: semantic
+        if: |
+          steps.classify.outputs.is_prerelease != 'true' ||
+          (steps.pre_sync.outputs.action != 'pr-opened' && steps.pre_sync.outputs.action != 'pr-existing')
         with:
           ci: false
           dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           source-branch: ${{ inputs.backmerge_source }}
           target-branch: ${{ github.ref_name }}
-          mode: ${{ inputs.backmerge_mode }}
+          mode: direct-with-pr-fallback
           dry-run: ${{ inputs.dry_run }}
           commit-message: "chore(release): sync ${source} into ${target} before release [skip ci]"
           pr-title: "chore(release): sync ${source} → ${target}"
@@ -259,8 +259,13 @@ jobs:
 
       - name: Warn about pending backmerge sync
         if: steps.pre_sync.outputs.action == 'pr-opened' || steps.pre_sync.outputs.action == 'pr-existing'
+        env:
+          APP_NAME: ${{ matrix.app.name }}
+          BACKMERGE_SOURCE: ${{ inputs.backmerge_source }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_URL: ${{ steps.pre_sync.outputs.pr-url }}
         run: |
-          echo "::warning::Release skipped for ${{ matrix.app.name }} — ${{ inputs.backmerge_source }} could not be auto-merged into ${{ github.ref_name }} (PR: ${{ steps.pre_sync.outputs.pr-url }}). Merge it and push again to release."
+          printf '::warning::Release skipped for %s — %s could not be auto-merged into %s (PR: %s). Merge it and push again to release.\n' "$APP_NAME" "$BACKMERGE_SOURCE" "$REF_NAME" "$PR_URL"
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/src/config/prerelease-guard/README.md
+++ b/src/config/prerelease-guard/README.md
@@ -1,0 +1,47 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>prerelease-guard</h1></td>
+  </tr>
+</table>
+
+Fails the run if a calculated beta/rc version's `X.Y.Z` has already been published as a stable release. Used as a defensive check in `release.yml`, after a `semantic-release` dry-run on a prerelease branch (`develop`, `release-candidate`), to catch cases where the branch is still out of sync with the stable branch even after the pre-sync gate — for example concurrent pushes, or a pending backmerge PR that was merged manually without re-triggering the release.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `calculated-version` | The prerelease version `semantic-release` would publish (e.g. `1.10.0-beta.6`) | Yes | |
+| `source-branch` | Name of the stable branch the prerelease is compared against (for the error message only) | No | `main` |
+| `target-branch` | Name of the prerelease branch being validated (for the error message only) | No | `${{ github.ref_name }}` |
+
+## Outputs
+
+None. The action exits non-zero (failing the job) when the calculated prerelease's `X.Y.Z` is not strictly newer than the highest stable tag already published.
+
+## Usage as composite step
+
+```yaml
+- name: Determine next version (dry-run)
+  id: semantic_dry
+  uses: cycjimmy/semantic-release-action@<sha> # v6
+  with:
+    ci: false
+    dry_run: true
+    working_directory: ${{ matrix.app.working_dir }}
+
+- name: Guard against stale prerelease
+  if: steps.semantic_dry.outputs.new_release_published == 'true'
+  uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1.x.x
+  with:
+    calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}
+    source-branch: ${{ inputs.backmerge_source }}
+    target-branch: ${{ github.ref_name }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/config/prerelease-guard/action.yml
+++ b/src/config/prerelease-guard/action.yml
@@ -1,0 +1,52 @@
+name: Prerelease Guard
+description: "Fails the run if a calculated beta/rc version's X.Y.Z has already been published as a stable release, catching prerelease branches left out of sync with the stable branch."
+
+inputs:
+  calculated-version:
+    description: The prerelease version semantic-release would publish (e.g. 1.10.0-beta.6)
+    required: true
+  source-branch:
+    description: Name of the stable branch the prerelease is compared against (for the error message only)
+    required: false
+    default: main
+  target-branch:
+    description: Name of the prerelease branch being validated (for the error message only)
+    required: false
+    default: ${{ github.ref_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compare calculated prerelease against latest stable
+      shell: bash
+      env:
+        CALCULATED_VERSION: ${{ inputs.calculated-version }}
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+      run: |
+        set -euo pipefail
+
+        git fetch --tags origin
+
+        CALCULATED_XYZ="${CALCULATED_VERSION%%-*}"
+
+        HIGHEST_STABLE=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1 || true)
+
+        if [ -z "$HIGHEST_STABLE" ]; then
+          echo "::notice::No stable release found yet — nothing to compare against"
+          exit 0
+        fi
+
+        echo "::notice::Calculated prerelease base: ${CALCULATED_XYZ} — highest stable published: ${HIGHEST_STABLE}"
+
+        # sort -V ranks the two versions; if the calculated X.Y.Z isn't strictly
+        # newer than the highest stable already published, the prerelease branch
+        # is stale relative to the stable branch.
+        NEWEST=$(printf '%s\n%s\n' "$CALCULATED_XYZ" "$HIGHEST_STABLE" | sort -V | tail -1)
+
+        if [ "$NEWEST" != "$CALCULATED_XYZ" ] || [ "$CALCULATED_XYZ" = "$HIGHEST_STABLE" ]; then
+          echo "::error::Prerelease v${CALCULATED_VERSION} would be published for version ${CALCULATED_XYZ}, but v${HIGHEST_STABLE} is already released as stable. ${TARGET_BRANCH} is out of sync with ${SOURCE_BRANCH} — merge the pending backmerge (or resolve conflicts manually) and push again."
+          exit 1
+        fi
+
+        echo "::notice::${CALCULATED_XYZ} is newer than the highest stable (${HIGHEST_STABLE}) — prerelease is valid"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

An audit across 9 LerianStudio repos found `-beta.N`/`-rc.N` tags being published **after** the corresponding stable `vX.Y.Z` tag already existed — a semver ordering violation. Root cause: `release.yml` runs `semantic-release` on every push to `develop`/`release-candidate`, and semantic-release only looks at the history reachable from the pushing branch — it never checks whether that `X.Y.Z` was already promoted to stable on `main`. The post-release backmerge (`main` → `develop`) is async and can lag behind normal pushes, so a routine merge to `develop` right after a release cut re-emits a prerelease for a version that's already stable.

This PR adds two gates to `release.yml`'s `publish_release` job, both scoped to a new `prerelease_branches` input (default: `develop,release-candidate`; `main` is never affected):

1. **Pre-sync gate** — before calculating the next version, merge `backmerge_source` (default `main`) into the current branch via the existing `backmerge-sync` composite action. Most pushes are no-ops (target already contains source). If a direct merge isn't possible (conflict), the release is skipped for this run (job succeeds, nothing published) with a `::warning::` annotation instead of failing — a human needs to resolve the pending sync PR first.
2. **Defensive guard** — a dry-run of `semantic-release` calculates what version *would* be published; a new composite action, `src/config/prerelease-guard`, compares that version's `X.Y.Z` against the highest stable tag already released and **fails the run** if the prerelease would land on an already-stable version. This catches residual races even after gate 1 (e.g. concurrent pushes).

Both `go-release.yml` and `js-release.yml` delegate internally to `release.yml` (`uses: ./.github/workflows/release.yml`), so this fix covers both without any changes to those wrapper workflows. `typescript-release.yml` has its own separate flow and is out of scope for this change.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The new `prerelease_branches` input has a backward-compatible default; callers pinned to older tags are unaffected until they bump their `uses:` ref.

## Testing

- [x] YAML syntax validated locally (`python3 -c "yaml.safe_load(...)"` on both files)
- [x] Ran `yamllint` locally — only pre-existing-style warnings (line length / comment spacing), consistent with the rest of the file; no errors
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (new input has a default; existing steps' conditions were only extended, not replaced, for the `main` branch path)
- [x] Confirmed no secrets or tokens are printed in logs (guard/sync steps reuse the existing `app-token` and `LERIAN_CI_CD_USER_*` secrets the same way the existing post-release backmerge step does)
- [x] Checked that unrelated workflows are not affected (only `release.yml` and the new `prerelease-guard` action were touched)

**Caller repo / workflow run:** Not yet triggered against a live caller — pending follow-up migration of `backoffice-console`, `matcher`, `tracer`, and `product-console` to the tag cut from this PR.

## Related Issues

Closes #