### PR TITLE
fix(release): point prerelease-guard ref at develop until v1 catches up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Guard against stale prerelease
         id: guard
         if: steps.semantic_dry.outputs.new_release_published == 'true'
-        uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@develop
         with:
           calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}
           source-branch: ${{ inputs.backmerge_source }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Follow-up to #530. That PR added `src/config/prerelease-guard` and referenced it from `release.yml` as `LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1` — but the `v1` floating major tag doesn't include this new action yet (it only exists on `develop` so far). GitHub Actions resolves every `uses:` in a job at "Set up job" time, even for steps whose `if:` would be false, so this broke **every** run of `release.yml`, including this repo's own self-release pipeline (see PR #531 / run https://github.com/LerianStudio/github-actions-shared-workflows/actions/runs/28540037227), with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action 'LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1'.
```

Since `v1` only advances via a successful self-release (`update_major_tag` job, which requires `publish_release` to succeed first), this was a chicken-and-egg lock: the pipeline could never succeed to advance `v1` past this point on its own.

This PR points the reference at `@develop` as an interim fix to unblock the pipeline.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** This repo's own self-release (blocked run linked above).

## Related Issues

Follow-up to #530. Once this merges and a self-release run succeeds, `v1` will advance to include `prerelease-guard`; a later PR can switch this back to `@v1` for consistency with the other internal action references in this file.