### PR TITLE
fix(prerelease-guard): don't rely on unevaluated expression as input default

### DIFF
--- a/src/config/prerelease-guard/README.md
+++ b/src/config/prerelease-guard/README.md
@@ -13,7 +13,7 @@ Fails the run if a calculated beta/rc version's `X.Y.Z` has already been publish
 |-------|-------------|----------|---------|
 | `calculated-version` | The prerelease version `semantic-release` would publish (e.g. `1.10.0-beta.6`) | Yes | |
 | `source-branch` | Name of the stable branch the prerelease is compared against (for the error message only) | No | `main` |
-| `target-branch` | Name of the prerelease branch being validated (for the error message only) | No | `${{ github.ref_name }}` |
+| `target-branch` | Name of the prerelease branch being validated (for the error message only). Defaults to the current ref if omitted. | No | `''` |
 
 ## Outputs
 

--- a/src/config/prerelease-guard/action.yml
+++ b/src/config/prerelease-guard/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: main
   target-branch:
-    description: Name of the prerelease branch being validated (for the error message only)
+    description: Name of the prerelease branch being validated (for the error message only). Defaults to the current ref if omitted.
     required: false
-    default: ${{ github.ref_name }}
+    default: ''
 
 runs:
   using: composite
@@ -22,9 +22,12 @@ runs:
       env:
         CALCULATED_VERSION: ${{ inputs.calculated-version }}
         SOURCE_BRANCH: ${{ inputs.source-branch }}
-        TARGET_BRANCH: ${{ inputs.target-branch }}
+        TARGET_BRANCH_INPUT: ${{ inputs.target-branch }}
+        CURRENT_REF_NAME: ${{ github.ref_name }}
       run: |
         set -euo pipefail
+
+        TARGET_BRANCH="${TARGET_BRANCH_INPUT:-$CURRENT_REF_NAME}"
 
         git fetch --tags origin
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

CodeRabbit caught this on PR #531 (the develop→main promotion PR): `src/config/prerelease-guard/action.yml`'s `target-branch` input declared `default: ${{ github.ref_name }}`. Composite action input defaults are literal strings, not evaluated expressions — so any caller that omits `target-branch` would get the literal text `${{ github.ref_name }}` baked into the guard's error message instead of the actual branch name.

This was pushed as a follow-up commit onto the `fix/prerelease-guard-ref-hotfix` branch, but PR #532 (which contained that branch's first commit) was already merged before this second commit landed, so it never made it into `develop`. Opening this as its own PR to land it properly.

Fix: default `target-branch` to `''` and fall back to `github.ref_name` inside the step's `env:`/script, where expressions do evaluate correctly.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — no caller currently omits `target-branch` (release.yml always passes it explicitly), so this fixes a latent issue rather than an observed failure.

## Related Issues

Follow-up to #530 / #532, per CodeRabbit review on #531.