### PR TITLE
chore(release): mark the temporary prerelease-guard@develop pin with a TODO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,7 @@ jobs:
       - name: Guard against stale prerelease
         id: guard
         if: steps.semantic_dry.outputs.new_release_published == 'true'
+        # TODO: revert to `@v1` once prerelease-guard is included in a v1 release (see #530 / #532 follow-up)
         uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@develop
         with:
           calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Follow-up to #532. CodeRabbit left an "outside diff range" comment on that PR (couldn't be posted inline, so it was easy to miss before merge — see review https://github.com/LerianStudio/github-actions-shared-workflows/pull/532#pullrequestreview-4612309401) pointing out that the temporary `prerelease-guard@develop` pin has no marker in the diff signaling it's meant to be reverted to `@v1` once that tag includes the action — risking the workaround silently becoming permanent.

Adds the inline `# TODO` CodeRabbit suggested, referencing this follow-up chain (#530 / #532).

## Type of Change

- [x] `chore`: Dependency bumps, config updates, maintenance

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** N/A — comment-only change, no behavior impact.

## Related Issues

Follow-up to #530 / #532.