### PR TITLE
fix(release): revert prerelease-guard ref back to @v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Guard against stale prerelease
         id: guard
         if: steps.semantic_dry.outputs.new_release_published == 'true'
-        uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@develop
+        uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1
         with:
           calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}
           source-branch: ${{ inputs.backmerge_source }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Follow-up to #530 / #532. PR #532 temporarily pointed the "Guard against stale prerelease" step at `LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@develop` because the `v1` floating major tag didn't include this new action yet, which blocked every run of `release.yml` (including this repo's own self-release).

Since then, PR #531 merged `develop` into `main` and cut `v1.41.0`, which does include `src/config/prerelease-guard`. Confirmed the `v1` floating tag now points at that same commit (`Update Major Tag` job ran successfully on the `v1.41.0` release). Reverting the pin back to `@v1`, consistent with every other internal action reference in this file.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Confirmed `v1` tag now resolves to a commit containing `src/config/prerelease-guard/action.yml` (`git show v1:src/config/prerelease-guard/action.yml`).

## Related Issues

Follow-up to #530 / #531 / #532.