### PR TITLE
fix(backmerge-sync): retry fetch to survive post-push ref-advertisement lag

### DIFF
--- a/src/config/backmerge-sync/action.yml
+++ b/src/config/backmerge-sync/action.yml
@@ -97,9 +97,23 @@ runs:
         SOURCE_BRANCH: ${{ inputs.source-branch }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
       run: |
-        git fetch --no-tags --prune origin \
-          "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" \
-          "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+        set -uo pipefail
+        # GitHub's ref advertisement can briefly lag right after a push. On main
+        # this step runs immediately AFTER semantic-release commits+tags, so a
+        # fresh fetch can transiently fail with "couldn't find remote ref" and
+        # abort both refspecs (exit 128), even though the branch exists. Retry
+        # with backoff; the happy path succeeds on the first attempt.
+        for attempt in 1 2 3 4 5; do
+          if git fetch --no-tags --prune origin \
+            "+refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" \
+            "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"; then
+            exit 0
+          fi
+          echo "::warning::backmerge fetch of ${SOURCE_BRANCH}/${TARGET_BRANCH} failed (attempt ${attempt}/5) — retrying"
+          sleep $((attempt * 3))
+        done
+        echo "::error::could not fetch ${SOURCE_BRANCH}/${TARGET_BRANCH} from origin after 5 attempts"
+        exit 1
 
     # ----------------- Sync Branches -----------------
     - name: Sync branches


### PR DESCRIPTION
## Problem
On GA (main) releases, the reusable `release.yml` backmerge step fails with:
```
fatal: couldn't find remote ref refs/heads/develop
```
even though `develop` exists (protected). Root cause: `backmerge-sync`'s `Fetch branches` step does one atomic fetch of two refspecs, and on main it runs **immediately after** semantic-release pushes the release commit+tag → GitHub ref-advertisement lag → transient fetch failure (exit 128) that aborts the whole backmerge. On `develop` the step runs as `pre_sync` (before semantic-release) so it never hits this. Not a shallow-checkout issue — `release.yml` checks out `fetch-depth: 0`.

Observed: matcher run 28564526498 (job 84689137363) — `Semantic Release`=success, `Backmerge main→develop`=failure, which then skips the image `build`.

## Fix
Wrap the fetch in a bounded retry with backoff (5 attempts, 3/6/9/12s). Happy path unchanged (first attempt succeeds). Pure resilience; reaches all consumers via `@v1` with no caller change.

https://claude.ai/code/session_012y7cAy9sBT6JDE8FkMqXSE