### PR TITLE
feat(go-release): build_on_release — publish GA images in-run (opt-in)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,14 @@ on:
         description: 'When true, continue to GitOps artifact upload even if cosign signing fails after all retries. Image stays in registry unsigned and a warning is emitted; manual signing is required afterwards.'
         type: boolean
         default: false
+      release_version:
+        description: 'Explicit image version (semver, leading v optional). When set (e.g. same-run build after semantic-release on a branch push), used as the image tag instead of parsing the git tag from GITHUB_REF.'
+        type: string
+        default: ''
+      checkout_ref:
+        description: 'Git ref to build (e.g. the freshly-created release tag). Empty = the workflow run ref.'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -255,6 +263,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.checkout_ref }}   # empty string = default run ref
 
       - name: Set up QEMU
         if: contains(needs.prepare.outputs.platforms, 'arm64')
@@ -310,15 +320,23 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          # Strip app prefix by finding -v and extracting from there
-          # e.g., agent-v1.0.0-beta.1 -> v1.0.0-beta.1
-          # e.g., control-plane-v1.0.0-beta.1 -> v1.0.0-beta.1
-          # shellcheck disable=SC2001
-          VERSION=$(echo "$TAG" | sed 's/.*-\(v[0-9]\)/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Extracted version: $VERSION from tag: $TAG"
+          if [ -n "$RELEASE_VERSION" ]; then
+            # Branch-push build (same run as semantic-release): no tag in GITHUB_REF.
+            echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+            echo "Using explicit release version: $RELEASE_VERSION"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            # Strip app prefix by finding -v and extracting from there
+            # e.g., agent-v1.0.0-beta.1 -> v1.0.0-beta.1
+            # e.g., control-plane-v1.0.0-beta.1 -> v1.0.0-beta.1
+            # shellcheck disable=SC2001
+            VERSION=$(echo "$TAG" | sed 's/.*-\(v[0-9]\)/\1/')
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Extracted version: $VERSION from tag: $TAG"
+          fi
 
       - name: Pre-flight tag existence check
         id: preflight

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -96,6 +96,10 @@ on:
         description: 'Timeout in seconds for argocd app wait after sync. Increase for larger applications or clusters under load.'
         type: number
         default: 480
+      force_env:
+        description: 'Override tag-based environment detection with development|staging|production|sandbox. Set when running on a branch (no tag in GITHUB_REF), e.g. same-run gitops update after a stable release. Empty = detect from the tag.'
+        type: string
+        default: ''
 
 jobs:
   update_gitops:
@@ -441,11 +445,31 @@ jobs:
           KUSTOMIZE_ENVIRONMENTS: ${{ inputs.kustomize_environments }}
           MANIFEST_FILE: shared-workflows/${{ inputs.deployment_matrix_file }}
           UPDATE_SANDBOX: ${{ inputs.update_sandbox }}
+          FORCE_ENV: ${{ inputs.force_env }}
         run: |
           set -euo pipefail
 
-          # Determine environments to update based on tag type (IS_* from job env)
-          if [[ "$IS_BETA" == "true" ]]; then
+          # Determine environments to update. force_env overrides tag-based detection
+          # (used on branch-push runs where GITHUB_REF has no tag); otherwise IS_* from job env.
+          if [[ -n "$FORCE_ENV" ]]; then
+            case "$FORCE_ENV" in
+              production)
+                if [[ "$UPDATE_SANDBOX" == "true" ]]; then
+                  ENVIRONMENTS="dev stg prd sandbox"
+                else
+                  ENVIRONMENTS="dev stg prd"
+                fi
+                ENV_LABEL="production"
+                ;;
+              staging)     ENVIRONMENTS="stg"; ENV_LABEL="rc/stg" ;;
+              development) ENVIRONMENTS="dev"; ENV_LABEL="beta/dev" ;;
+              sandbox)     ENVIRONMENTS="sandbox"; ENV_LABEL="sandbox" ;;
+              *)
+                echo "::error::Invalid force_env '$FORCE_ENV' (must be: development, staging, production, sandbox)"
+                exit 1
+                ;;
+            esac
+          elif [[ "$IS_BETA" == "true" ]]; then
             ENVIRONMENTS="dev"
             ENV_LABEL="beta/dev"
           elif [[ "$IS_RC" == "true" ]]; then

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -115,6 +115,10 @@ on:
         description: 'When true, build all filter_paths components on every run regardless of what changed. Use for repos where components must always share the same image tag (e.g., auth + identity always released together).'
         type: boolean
         default: false
+      build_on_release:
+        description: 'Publish container images (and run gitops-update) for STABLE releases in the same run as semantic-release, gated on the release output, instead of on the [skip ci]-suppressed stable tag push. Beta/rc still build on their tag push. Single-app repos only. Default false preserves the tag-push build path for all consumers.'
+        type: boolean
+        default: false
 
       # ----------------- GitOps Update (gitops-update.yml) -----------------
       enable_gitops_update:
@@ -256,9 +260,19 @@ jobs:
       filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}
     secrets: inherit
 
-  # ----------------- Build (tag push) -----------------
+  # ----------------- Build (tag push, or same-run stable release when build_on_release) -----------------
   build:
-    if: github.ref_type == 'tag'
+    needs: [release]
+    if: >-
+      !cancelled() &&
+      (
+        (github.ref_type == 'tag' &&
+          (!inputs.build_on_release || contains(github.ref, '-beta.') || contains(github.ref, '-rc.'))) ||
+        (inputs.build_on_release && github.ref_type == 'branch' &&
+          needs.release.result == 'success' &&
+          needs.release.outputs.new_release_published == 'true' &&
+          !contains(needs.release.outputs.new_release_version, '-'))
+      )
     permissions:
       id-token: write
       contents: read
@@ -266,6 +280,8 @@ jobs:
       packages: write
     uses: ./.github/workflows/build.yml
     with:
+      release_version: ${{ github.ref_type == 'branch' && needs.release.outputs.new_release_version || '' }}
+      checkout_ref: ${{ github.ref_type == 'branch' && needs.release.outputs.new_release_git_tag || '' }}
       runner_type: ${{ inputs.runner_type }}
       enable_dockerhub: ${{ inputs.enable_dockerhub }}
       enable_ghcr: ${{ inputs.enable_ghcr }}
@@ -459,10 +475,15 @@ jobs:
   update_gitops:
     needs: [build, extra_build]
     if: >-
-      github.ref_type == 'tag' && inputs.enable_gitops_update && !cancelled() &&
+      inputs.enable_gitops_update && !cancelled() &&
       needs.build.result != 'failure' && needs.extra_build.result != 'failure' &&
-      ((needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
-       needs.extra_build.result == 'success')
+      (
+        (github.ref_type == 'tag' &&
+          ((needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
+           needs.extra_build.result == 'success')) ||
+        (inputs.build_on_release && github.ref_type == 'branch' &&
+          needs.build.result == 'success' && needs.build.outputs.has_builds == 'true')
+      )
     permissions:
       id-token: write
       contents: read
@@ -481,6 +502,7 @@ jobs:
       use_dynamic_mapping: ${{ inputs.use_dynamic_mapping }}
       configmap_updates: ${{ inputs.configmap_updates }}
       enable_docker_login: ${{ inputs.enable_docker_login }}
+      force_env: ${{ github.ref_type == 'branch' && inputs.build_on_release && 'production' || '' }}
     secrets: inherit
 
   # ----------------- API Dog E2E Tests (tag push, post-gitops, opt-in) -----------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ name: "Release Workflow"
 
 on:
   workflow_call:
+    outputs:
+      new_release_published:
+        description: 'true when at least one matrix leg published a release.'
+        value: ${{ jobs.publish_release_status.outputs.release_published }}
+      new_release_version:
+        description: 'Published version (single-app mode; last matrix leg wins in monorepo).'
+        value: ${{ jobs.publish_release.outputs.new_release_version }}
+      new_release_git_tag:
+        description: 'Git tag semantic-release created (single-app mode; last leg wins in monorepo).'
+        value: ${{ jobs.publish_release.outputs.new_release_git_tag }}
     inputs:
       semantic_version:
         description: 'Semantic release version to use'
@@ -165,6 +175,8 @@ jobs:
 
     outputs:
       gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
 
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
## Problem
GA (main) releases don't publish container images. semantic-release tags the changelog commit (`chore(release): X [skip ci]`); GitHub honors `[skip ci]` on the **tag** push and suppresses all workflows, so the tag-gated `build` never runs. matcher `v4.0.0` (manual re-trigger) and `v4.1.0` (no image) both hit this. Beta/rc tags point at real commits → build fine.

## Fix (opt-in, default false)
New `build_on_release` input. When `true`, STABLE releases build in the **same run** as semantic-release, gated on the release output (`new_release_published` + non-prerelease version), checking out the freshly-created tag so the image is the released code. Beta/rc still build on their tag push.
- **No loop**: the branch path reads the release OUTPUT, creates nothing.
- **No double-build**: with the flag on, stable tag-push build is disabled; beta/rc are the only tag builds.

## Safety — default false is byte-identical for all 20+ consumers
- `build.if` @false → `!cancelled() && ref_type=='tag'` (`needs:[release]` doesn't block on tag push since release is skipped + `!cancelled()`).
- `update_gitops.if` @false → algebraically identical to today (`force_env` → `''` → tag detection unchanged).
- actionlint exit 0; all 4 workflows parse.

## Files
- `release.yml`: expose `new_release_{published,version,git_tag}` outputs.
- `build.yml`: `release_version` + `checkout_ref` inputs.
- `gitops-update.yml`: `force_env` input.
- `go-release.yml`: `build_on_release` input + `build`/`update_gitops` wiring.

## Caveats (review before merge)
- **Single-app repos only** — version outputs are matrix last-writer-wins (documented, not code-guarded).
- `s3_upload`/`api_dog` stay tag-only (don't run on the branch-stable path) — fine for matcher.
- **Needs a live-run validation** on a non-critical `build_on_release: true` consumer before matcher adopts — actionlint can't deeply check cross-workflow reusable outputs.

## Pairs with
#536 (backmerge fetch retry) — that fix makes the `release` job green; this makes it publish the image.

## Adoption (matcher, after merge + a shared stable release advances `@v1`)
Bump matcher's `go-release.yml@vX` pin + set `build_on_release: true`.

https://claude.ai/code/session_012y7cAy9sBT6JDE8FkMqXSE