### PR TITLE
feat(deployment-matrix): register mock-btg-server for benedita gitops-update

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -48,7 +48,7 @@
 #      env list is what the workflow uses to build helmfile paths and ArgoCD app names.
 #
 # Out of scope (managed manually or by other tooling — do NOT add here):
-#   - underwriter, jd-mock-api, mock-btg-server, fakebtg, control-plane,
+#   - underwriter, jd-mock-api, fakebtg, control-plane,
 #     platform-console (no CI commit history in gitops repo)
 #   - ledger, dockerhub-secret (no values.yaml — kustomize / k8s Secret)
 #   - hortencia-apps (legacy umbrella, not workflow-managed)
@@ -79,6 +79,9 @@ apps:
     - plugin-br-bank-transfer
     - plugin-br-payments
     - plugin-bc-correios
+
+    # Test/mock infrastructure
+    - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
 
     # Lerian internal platform suite (Benedita cross/)
     - backoffice-console
@@ -158,6 +161,7 @@ clusters:
       - plugin-br-bank-transfer
       - plugin-br-payments
       - plugin-bc-correios
+      - mock-btg-server
       - backoffice-console
       - cs-platform
       - forge


### PR DESCRIPTION
## Context

`plugin-br-pix-indirect-btg` publishes a `mock-btg-server` test image via `extra_builds` in its `release.yml`, but the tag was never reaching the actually-deployed mock server: it's a separate ArgoCD Application/Helmfile release (`environments/benedita/helmfile/applications/*/mock-btg-server/`), disconnected from the plugin's own gitops-update.

Fixing that requires `plugin-br-pix-indirect-btg`'s pipeline to call `gitops-update.yml` a second time with `app_name: mock-btg-server`, so it targets `environments/benedita/helmfile/applications/{env}/mock-btg-server/values.yaml` directly. That requires `mock-btg-server` to be registered in this deployment matrix — today it's explicitly listed as "out of scope (managed manually)".

## Changes

- Add `mock-btg-server` to `apps.registry`.
- Add `mock-btg-server` to `clusters.benedita.apps` (it has no `anacleto` deployment).
- Remove it from the "out of scope" comment.

## Notes

- `mock-btg-server` only exists at the benedita `-st` variant today (`dev-st`, `stg-st`). The `-mt` suffix expansion will warn and skip (`values file not found`), matching how other partial apps in this cluster already behave — no special override needed.
- Validated with `src/lint/deployment-matrix`'s validation script locally: `Deployment matrix is valid (26 apps registered, 2 clusters defined).`
- Companion change in `plugin-br-pix-indirect-btg`: adds the second `gitops-update.yml` call and fixes the built image name to match what the standalone `mock-btg-server` Helmfile app already expects (`ghcr.io/lerianstudio/mock-btg-server`, no plugin prefix).

## Related

Follow-up to LerianStudio/plugin-br-pix-indirect-btg#620.
