### PR TITLE
feat(release): add prerelease_backmerge_sync_enabled input (opt-in, default false)

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -45,6 +45,10 @@ on:
         description: 'Space-separated list of GitHub login substrings to exclude from the changelog (bot authors). Logins ending in [bot] are always excluded. Extends the default list inside the gptchangelog composite action.'
         type: string
         default: ''
+      prerelease_backmerge_sync_enabled:
+        description: 'Merge main into a prerelease branch (develop/release-candidate) before calculating its next version. Defaults to false (opt-in) — set to true to enable this pre-version-calculation sync, which can skip/block a release on those branches when the merge cannot complete directly. The post-release backmerge on main after a stable release is unaffected by this input either way.'
+        type: boolean
+        default: false
 
       # ----------------- Build (build.yml) -----------------
       enable_dockerhub:
@@ -256,6 +260,7 @@ jobs:
       enable_major_tag: ${{ inputs.enable_major_tag }}
       stable_releases_only: ${{ inputs.stable_releases_only }}
       changelog_bot_ignore_list: ${{ inputs.changelog_bot_ignore_list }}
+      prerelease_backmerge_sync_enabled: ${{ inputs.prerelease_backmerge_sync_enabled }}
       shared_paths: ${{ inputs.shared_paths }}
       filter_paths: ${{ !inputs.release_single_app && inputs.filter_paths || '' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,11 @@ on:
         required: false
         type: string
         default: 'develop,release-candidate'
+      prerelease_backmerge_sync_enabled:
+        description: 'Merge backmerge_source into a prerelease branch (see prerelease_branches) before calculating its next version. Independent of backmerge_enabled, which also gates the separate post-release backmerge on backmerge_source itself. Defaults to false (opt-in) — set to true to enable this pre-version-calculation sync, which can skip/block a release on prerelease branches when the merge cannot complete directly. The post-release backmerge on backmerge_source is unaffected by this input either way.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -256,7 +261,7 @@ jobs:
 
       - name: Sync ${{ inputs.backmerge_source }} → ${{ github.ref_name }} before calculating version
         id: pre_sync
-        if: inputs.backmerge_enabled && steps.classify.outputs.is_prerelease == 'true'
+        if: inputs.backmerge_enabled && inputs.prerelease_backmerge_sync_enabled && steps.classify.outputs.is_prerelease == 'true'
         uses: LerianStudio/github-actions-shared-workflows/src/config/backmerge-sync@v1
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -88,6 +88,8 @@ jobs:
 | `backmerge_target` | string | `develop` | Branch that receives the backmerge |
 | `backmerge_mode` | string | `direct-with-pr-fallback` | Backmerge strategy: `direct`, `pr`, or `direct-with-pr-fallback` |
 | `dry_run` | boolean | `false` | Run semantic-release in dry-run mode (no tags/releases) and preview the backmerge instead of applying it |
+| `prerelease_branches` | string | `develop,release-candidate` | Comma-separated list of branches treated as prerelease lines (beta/rc) |
+| `prerelease_backmerge_sync_enabled` | boolean | `false` | Merge `backmerge_source` into a prerelease branch before calculating its next version. Independent of `backmerge_enabled`, which also gates the separate post-release backmerge on `backmerge_source` itself. Opt-in — set to `true` to enable this pre-version-calculation sync, which can skip/block a release on prerelease branches when the merge cannot complete directly |
 
 ## Secrets
 


### PR DESCRIPTION
## Context

`backmerge_enabled` currently gates two unrelated behaviors under a single flag:

1. **Post-release backmerge** on `backmerge_source` (e.g. `main`) right after a stable release — proactive, low blast radius (only fires when a release just happened on that branch).
2. **Pre-version-calculation sync** on prerelease branches (`develop`, `release-candidate`) — reactive: merges `backmerge_source` in *before* calculating the next version, and skips/blocks the release for that run (opening a PR instead) if the merge can't complete directly. This can fire on **any** push to those branches, regardless of what the triggering commit touches — surfaced this in `plugin-br-pix-indirect-btg` (bumping to `v1.42.0` blocked an unrelated CI-only PR's release because `main`/`develop` had drifted for months).

Callers who want (1) without (2) had no way to disable just the reactive part — `backmerge_enabled: false` disables both.

## Changes

- Adds `prerelease_backmerge_sync_enabled` (boolean, **default `false`, opt-in**) to `release.yml`, gating the `pre_sync` step independently: `if: inputs.backmerge_enabled && inputs.prerelease_backmerge_sync_enabled && ...`.
- Exposes it as a pass-through input in `go-release.yml`.
- Documents it (and the pre-existing, previously undocumented `prerelease_branches` input) in `docs/release-workflow.md`.

## Behavior

- **Default (`false`)**: the pre-version-calculation sync never runs. Callers keep computing the next prerelease version from local branch history only — no skip/block, no automatic PR against `develop`/`release-candidate`. The post-release backmerge on `backmerge_source` (e.g. right after a `main` hotfix) is unaffected either way.
- **Opt-in (`true`)**: restores the pre-sync check for callers who want the stricter guarantee (next prerelease version always calculated against a `develop`/`release-candidate` that's up to date with `backmerge_source`).

## Note on defaulting to false

This input is new, so there's no existing caller relying on the pre-sync behavior via this specific flag — defaulting to `false` here doesn't silently change anyone's pinned behavior. It does mean callers who upgrade to a version of `go-release.yml`/`release.yml` where the underlying `pre_sync` step first shipped (`v1.41.0`+) and want that stricter guarantee need to explicitly opt in with `prerelease_backmerge_sync_enabled: true`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` / same for `go-release.yml` — both parse cleanly.
- Traced all downstream references to `steps.pre_sync.outputs.action` (the "warn about pending sync", "determine next version (dry-run)", and "Semantic Release" steps) — all treat a skipped `pre_sync` step the same as `action` not being `pr-opened`/`pr-existing` (empty string), so disabling the step falls through to normal version calculation, as intended.
