### PR TITLE
fix(go-release): skip update_gitops cleanly when only extra_build ran

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -477,6 +477,13 @@ jobs:
     secrets: inherit
 
   # ----------------- GitOps Update (tag push) -----------------
+  # Gated on the primary build actually producing artifacts (has_builds).
+  # extra_build succeeding alone is not enough: this job's artifact_pattern
+  # and gitops_yaml_key_mappings target the primary app_name, so it has
+  # nothing valid to download/apply when only an extra_builds group ran.
+  # Callers whose extra_builds groups need their own gitops-update (e.g. a
+  # component deployed as a separate ArgoCD Application) should add a
+  # dedicated gitops-update.yml job of their own, independent of this one.
   update_gitops:
     needs: [build, extra_build]
     if: >-
@@ -484,8 +491,7 @@ jobs:
       needs.build.result != 'failure' && needs.extra_build.result != 'failure' &&
       (
         (github.ref_type == 'tag' &&
-          ((needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
-           needs.extra_build.result == 'success')) ||
+          needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
         (inputs.build_on_release && github.ref_type == 'branch' &&
           needs.build.result == 'success' && needs.build.outputs.has_builds == 'true')
       )

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -158,6 +158,8 @@ Set `extra_builds` to a JSON array of build groups. Each group runs a parallel `
 
 > **Important** — `update_gitops` downloads artifacts by `gitops_artifact_pattern` (default `gitops-tags-<repo-name>*`). When an extra build produces an image whose name does **not** start with the repo name (e.g. `mock-btg-server`), set `gitops_artifact_pattern` to a wildcard that captures every image (e.g. `gitops-tags-*`), otherwise that image's tag artifact is skipped.
 
+> **Separate ArgoCD Application** — the wildcard-pattern approach above only works when the extra image is deployed *within the same app's* `values.yaml` (different nested key, same `app_name`/directory). If the extra build's component is its own, independent ArgoCD Application (its own `environments/*/helmfile/applications/<other-app-name>/values.yaml`), the single `update_gitops` job can't target it — `app_name` is one value per job call. Add a second, dedicated job in your caller `release.yml` that calls `gitops-update.yml` directly with that component's own `app_name`, `artifact_pattern`, and `yaml_key_mappings`, independent of the primary `update_gitops`. The primary `update_gitops` job only runs when the primary build actually produced artifacts (`needs.build.outputs.has_builds == 'true'`), so it skips cleanly — instead of failing — on releases where only an `extra_builds` group changed.
+
 ```yaml
 jobs:
   pipeline:


### PR DESCRIPTION
## Context

`update_gitops`'s trigger condition currently allows `extra_build.result == 'success'` alone to satisfy it, even when the primary build never ran (empty matrix, `has_builds != 'true'`):

```yaml
if: >-
  ... &&
  (github.ref_type == 'tag' &&
    ((needs.build.result == 'success' && needs.build.outputs.has_builds == 'true') ||
     needs.extra_build.result == 'success')) ||
  ...
```

Since this job's `artifact_pattern`/`gitops_yaml_key_mappings` target the **primary** `app_name`, it then tries to download an artifact that was never produced (only the extra build ran) and fails hard with `0 artifact(s) downloaded` — a false positive, since nothing was actually broken.

**Surfaced in `plugin-br-pix-indirect-btg`**: a tag where only its `tools/mock-btg-server` `extra_builds` group changed (the primary `filter_paths` components were untouched) failed the whole run: https://github.com/LerianStudio/plugin-br-pix-indirect-btg/actions/runs/28676230616

## Change

Removes the `extra_build` fallback from the tag-push branch of `update_gitops`'s condition. It now only runs when the primary build actually produced artifacts (`needs.build.outputs.has_builds == 'true'`) — cleanly **skipped** (not failed) when only an `extra_builds` group changed.

## What callers should do instead

Documented in `docs/go-release-workflow.md`, alongside the existing wildcard-pattern guidance for extra images nested in the *same* app's `values.yaml`:

- **Same ArgoCD Application** (extra image is a nested key in the primary app's own `values.yaml`, e.g. `plugin-access-manager`'s `casdoor`/`casdoor-migrations`): unaffected, keep using `gitops_artifact_pattern: "gitops-tags-*"` on the single `update_gitops`.
- **Separate ArgoCD Application** (extra component deploys as its own app, its own `environments/*/helmfile/applications/<other-app-name>/values.yaml` — our `mock-btg-server` case): add a second, independent job in the caller `release.yml` calling `gitops-update.yml` directly with that component's own `app_name`/`artifact_pattern`/`yaml_key_mappings`. `plugin-br-pix-indirect-btg` already does this (`update_mock_gitops`); this fix stops its neighbor's spurious failure from marking the whole run red.

## Verified no other caller is affected

Checked every current user of `extra_builds` in the org:

- **`plugin-access-manager`**: sets `force_full_matrix: true` — the primary build always builds every `filter_paths` component regardless of diff, so `has_builds` is always `true` independent of this condition.
- **`plugin-br-bank-transfer`**: has no top-level `filter_paths` — the primary build runs in single-app fallback mode, which always builds (no diff-based skip), so `has_builds` is always `true` there too.

Both are structurally unaffected by removing the fallback.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/go-release.yml'))"` — parses cleanly.
