### PR TITLE
feat(security): allowlist accepted pre-release pins in prerelease-check

### DIFF
--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -41,7 +41,7 @@ For `go.mod` and `package.json`: matches any semver with a pre-release suffix st
 
 ## Allowlisting accepted pins
 
-Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted entries in an allow-file (default `.prerelease-allow`, auto-discovered at the scanned root). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
+Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted entries in an allow-file (default `.prerelease-allow`, resolved relative to each scanned base — the `scan-ref` directory and the repository root — so a monorepo component can carry its own). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
 
 ```text
 # .prerelease-allow — one accepted entry per line; '#' comments and blank lines ignored.

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -15,6 +15,7 @@ Composite action that scans dependency files for unstable version pins. Only sta
 | `app-name` | Application name for reporting context | No | `''` |
 | `target-branch` | PR target branch (e.g. `github.base_ref`). Selects the annotation level (see below). Empty = warning | No | `''` |
 | `block-branches` | Comma-separated branches where pre-release pins annotate as error. Must match the downstream gate | No | `release-candidate,main` |
+| `allow-file` | Path (relative to each scanned base) to a file of accepted pre-release pins. Matching findings are exempted (reported as `::notice::`). Absent file = no exemptions | No | `.prerelease-allow` |
 
 ## Outputs
 
@@ -37,6 +38,19 @@ For `go.mod` and `package.json`: matches any semver with a pre-release suffix st
 | `go.mod` | `vX.Y.Z-<letter...>` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` |
 | `package.json` | `"[~^>=]*X.Y.Z-<letter...>"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
 | `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
+
+## Allowlisting accepted pins
+
+Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted `module version` pairs in an allow-file (default `.prerelease-allow`, auto-discovered at the scanned root). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
+
+```
+# .prerelease-allow — one "module version" per line; '#' comments and blank lines ignored.
+# go-imap v2 has no stable upstream release (v2 is beta-only). Direct dep.
+# Review by: 2026-09-30
+github.com/emersion/go-imap/v2 v2.0.0-beta.8
+```
+
+The key is the first two whitespace-delimited tokens of the offending line (module + version), so a `// indirect` suffix on the `go.mod` line does not affect the match.
 
 ## Usage
 

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -41,16 +41,18 @@ For `go.mod` and `package.json`: matches any semver with a pre-release suffix st
 
 ## Allowlisting accepted pins
 
-Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted `module version` pairs in an allow-file (default `.prerelease-allow`, auto-discovered at the scanned root). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
+Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted entries in an allow-file (default `.prerelease-allow`, auto-discovered at the scanned root). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
 
-```
-# .prerelease-allow — one "module version" per line; '#' comments and blank lines ignored.
+```text
+# .prerelease-allow — one accepted entry per line; '#' comments and blank lines ignored.
 # go-imap v2 has no stable upstream release (v2 is beta-only). Direct dep.
 # Review by: 2026-09-30
 github.com/emersion/go-imap/v2 v2.0.0-beta.8
 ```
 
-The key is the first two whitespace-delimited tokens of the offending line (module + version), so a `// indirect` suffix on the `go.mod` line does not affect the match.
+Matching is on the **first two whitespace-delimited tokens of the raw scanned line**. For `go.mod` that is `module version` (a trailing `// indirect` does not affect the match). For `package.json` and `Dockerfile` findings the entry must mirror the raw scan output verbatim, punctuation and all — e.g. `"pkg": "^2.0.0-beta.1"` or `FROM node:20.0.0-rc1`.
+
+> **Security — review your exemptions.** The allow-file is read from the scanned working tree, so — exactly like `.trivyignore` — a PR can add its own entry and self-exempt a pin. Put `.prerelease-allow` under `CODEOWNERS` in consuming repos so every exemption gets a dedicated review rather than being self-approved.
 
 ## Usage
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -112,8 +112,9 @@ runs:
         done
 
         # ----------------- allowlist (accepted pre-release pins) -----------------
-        # Exempt pins explicitly accepted in an allow-file: one "module version"
-        # per line, '#' comments and blank lines ignored. Same discipline
+        # Exempt pins explicitly accepted in an allow-file: one entry per line,
+        # matched on the raw scanned line's first two whitespace tokens (for
+        # go.mod: "module version"); '#' comments and blank lines ignored. Same discipline
         # .trivyignore applies to CVEs that cannot be remediated by upgrade — a
         # direct dependency whose upstream ships no stable release (only beta/rc)
         # stays visible in the report as a notice, but does not block promotion.

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Comma-separated branches where pre-release pins are blocking (annotated as error). Must match the downstream gate. Default: release-candidate,main.'
     required: false
     default: 'release-candidate,main'
+  allow-file:
+    description: 'Path (relative to each scanned base) to a file listing accepted pre-release pins as "module version" lines (# comments allowed). Matching findings are exempted and reported as notices — the same discipline .trivyignore applies to CVEs that cannot be remediated by upgrade (e.g. a direct dependency with no stable upstream release). Auto-discovered at the default path when present; absent file = no exemptions.'
+    required: false
+    default: '.prerelease-allow'
 
 outputs:
   has-findings:
@@ -41,6 +45,7 @@ runs:
         APP_NAME: ${{ inputs.app-name }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
         BLOCK_BRANCHES: ${{ inputs.block-branches }}
+        ALLOW_FILE: ${{ inputs.allow-file }}
       run: |
         # Matches x.y.z-<letter...> — any semver with a pre-release suffix starting
         # with a letter (alpha, beta, rc, dev, preview, canary, snapshot, etc.).
@@ -105,6 +110,54 @@ runs:
             done < <(grep -nE ":${DOCKER_PRERELEASE}" "$df" || true)
           done
         done
+
+        # ----------------- allowlist (accepted pre-release pins) -----------------
+        # Exempt pins explicitly accepted in an allow-file: one "module version"
+        # per line, '#' comments and blank lines ignored. Same discipline
+        # .trivyignore applies to CVEs that cannot be remediated by upgrade — a
+        # direct dependency whose upstream ships no stable release (only beta/rc)
+        # stays visible in the report as a notice, but does not block promotion.
+        # Absent file (the default) = zero exemptions = unchanged behavior.
+        ALLOW_ENTRIES=()
+        ALLOW_SEEN=()
+        if [ -n "$ALLOW_FILE" ]; then
+          for base in "${SCAN_PATHS[@]}"; do
+            af="$base/$ALLOW_FILE"
+            [ -f "$af" ] || continue
+            real=$(realpath "$af")
+            dup=false
+            for s in "${ALLOW_SEEN[@]}"; do
+              if [ "$s" = "$real" ]; then dup=true; break; fi
+            done
+            if [ "$dup" = "true" ]; then continue; fi
+            ALLOW_SEEN+=("$real")
+            while IFS= read -r line || [ -n "$line" ]; do
+              line="${line%%#*}"
+              line=$(echo "$line" | xargs)
+              if [ -z "$line" ]; then continue; fi
+              ALLOW_ENTRIES+=("$(echo "$line" | awk '{print $1, $2}')")
+            done < "$af"
+          done
+        fi
+
+        if [ ${#ALLOW_ENTRIES[@]} -gt 0 ] && [ ${#FINDINGS[@]} -gt 0 ]; then
+          KEPT=()
+          for f in "${FINDINGS[@]}"; do
+            REST="${f#*|}"
+            CONTENT="${REST#*:}"
+            KEY=$(echo "$CONTENT" | sed 's/^[[:space:]]*//' | awk '{print $1, $2}')
+            allowed=false
+            for a in "${ALLOW_ENTRIES[@]}"; do
+              if [ "$KEY" = "$a" ]; then allowed=true; break; fi
+            done
+            if [ "$allowed" = "true" ]; then
+              echo "::notice::Accepted pre-release pin (allow-file): $KEY"
+            else
+              KEPT+=("$f")
+            fi
+          done
+          FINDINGS=("${KEPT[@]}")
+        fi
 
         COUNT=${#FINDINGS[@]}
         echo "findings_count=$COUNT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Adds an optional `allow-file` input to the `prerelease-check` composite action so a consuming repo can accept specific, unavoidable pre-release dependency pins without disabling the gate.

## Why

The branch-aware pre-release gate correctly blocks promotion to `release-candidate`/`main` when `go.mod`/`package.json`/`Dockerfile` pin a pre-release version. But some pins **cannot** be remediated by upgrade:

- a **direct** dependency whose upstream ships no stable release (e.g. a `/v2` module that only publishes `beta`), or
- a pre-release version reached **transitively** through a dependency you do not control.

Today the only escape is to relax `block-branches` (turns the gate off for everyone) — too blunt. This mirrors the discipline `.trivyignore` already provides for CVEs with no fixed version: an explicit, auditable, per-pin exemption with rationale, while every **other** pin still blocks.

## How

- New input `allow-file` (default `.prerelease-allow`, auto-discovered at the scanned root; empty/absent = current behavior).
- Each non-comment line is a `module version` pair (`#` comments + blanks ignored). A finding is exempted when its first two whitespace tokens (module + version) match an entry — so a `// indirect` suffix on a `go.mod` line does not affect matching.
- Exempted findings are reported as `::notice::` (still visible), not dropped silently. `has-findings`/`findings-count` exclude them, so the downstream **Gate - Fail on Pre-release Versions** passes on the accepted set and still fails on anything unlisted.

## Backward compatibility

No `allow-file` present ⇒ zero exemptions ⇒ byte-identical behavior for every existing consumer. The input default only matters when a repo actually adds a `.prerelease-allow` file.

## Verification

Filter logic unit-checked locally under the action's shell flags (`bash -eo pipefail`) against a fixture with 3 pre-release pins + a stable pin: absent file keeps all 3; a 2-entry allow-file exempts exactly those 2 and the **unlisted** pin still surfaces; all-listed ⇒ clean. README updated (Inputs table + "Allowlisting accepted pins").

## Driver

Unblocks `matcher`'s promotion to `release-candidate`/`main`: it depends on `github.com/emersion/go-imap/v2 v2.0.0-beta.8` (direct — go-imap has no stable v2 upstream) and `go.yaml.in/yaml/v4 v4.0.0-rc.6` (indirect via `anthropic-sdk-go`), both already shipped on `main` in the current stable release.

https://claude.ai/code/session_0184duUW1P6N36YKTtbRsrpc
