### PR TITLE
feat(security): promote prerelease allow-file to main

### DIFF
--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -15,6 +15,7 @@ Composite action that scans dependency files for unstable version pins. Only sta
 | `app-name` | Application name for reporting context | No | `''` |
 | `target-branch` | PR target branch (e.g. `github.base_ref`). Selects the annotation level (see below). Empty = warning | No | `''` |
 | `block-branches` | Comma-separated branches where pre-release pins annotate as error. Must match the downstream gate | No | `release-candidate,main` |
+| `allow-file` | Path (relative to each scanned base) to a file of accepted pre-release pins. Matching findings are exempted (reported as `::notice::`). Absent file = no exemptions | No | `.prerelease-allow` |
 
 ## Outputs
 
@@ -37,6 +38,21 @@ For `go.mod` and `package.json`: matches any semver with a pre-release suffix st
 | `go.mod` | `vX.Y.Z-<letter...>` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` |
 | `package.json` | `"[~^>=]*X.Y.Z-<letter...>"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
 | `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
+
+## Allowlisting accepted pins
+
+Some pre-release pins cannot be remediated by upgrade — a direct dependency whose upstream ships no stable release (only `beta`/`rc`), or a pre-release version reached transitively through a dependency you do not control. For these, list the accepted entries in an allow-file (default `.prerelease-allow`, resolved relative to each scanned base — the `scan-ref` directory and the repository root — so a monorepo component can carry its own). Matching findings are exempted and reported as `::notice::` instead of blocking — the same discipline `.trivyignore` applies to CVEs with no fixed version. Any pin **not** listed still blocks.
+
+```text
+# .prerelease-allow — one accepted entry per line; '#' comments and blank lines ignored.
+# go-imap v2 has no stable upstream release (v2 is beta-only). Direct dep.
+# Review by: 2026-09-30
+github.com/emersion/go-imap/v2 v2.0.0-beta.8
+```
+
+Matching is on the **first two whitespace-delimited tokens of the raw scanned line**. For `go.mod` that is `module version` (a trailing `// indirect` does not affect the match). For `package.json` and `Dockerfile` findings the entry must mirror the raw scan output verbatim, punctuation and all — e.g. `"pkg": "^2.0.0-beta.1"` or `FROM node:20.0.0-rc1`.
+
+> **Security — review your exemptions.** The allow-file is read from the scanned working tree, so — exactly like `.trivyignore` — a PR can add its own entry and self-exempt a pin. Put `.prerelease-allow` under `CODEOWNERS` in consuming repos so every exemption gets a dedicated review rather than being self-approved.
 
 ## Usage
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -113,30 +113,29 @@ runs:
 
         # ----------------- allowlist (accepted pre-release pins) -----------------
         # Exempt pins explicitly accepted in an allow-file: one entry per line,
-        # matched on the raw scanned line's first two whitespace tokens (for
-        # go.mod: "module version"); '#' comments and blank lines ignored. Same discipline
-        # .trivyignore applies to CVEs that cannot be remediated by upgrade — a
-        # direct dependency whose upstream ships no stable release (only beta/rc)
-        # stays visible in the report as a notice, but does not block promotion.
-        # Absent file (the default) = zero exemptions = unchanged behavior.
+        # keyed as "module version" — a leading `require` keyword (go.mod
+        # single-line form `require <module> <version>`) is stripped so it keys
+        # the same as the indented block form; '#' comments and blank lines
+        # ignored. Same discipline .trivyignore applies to CVEs that cannot be
+        # remediated by upgrade — a direct dependency whose upstream ships no
+        # stable release (only beta/rc) stays visible as a notice but does not
+        # block promotion. Absent file (the default) = zero exemptions = unchanged.
+        norm_key() {
+          echo "$1" | sed 's/^[[:space:]]*//; s/^require[[:space:]]\{1,\}//' | awk '{print $1, $2}'
+        }
         ALLOW_ENTRIES=()
-        ALLOW_SEEN=()
         if [ -n "$ALLOW_FILE" ]; then
           for base in "${SCAN_PATHS[@]}"; do
             af="$base/$ALLOW_FILE"
             [ -f "$af" ] || continue
             real=$(realpath "$af")
-            dup=false
-            for s in "${ALLOW_SEEN[@]}"; do
-              if [ "$s" = "$real" ]; then dup=true; break; fi
-            done
-            if [ "$dup" = "true" ]; then continue; fi
-            ALLOW_SEEN+=("$real")
+            already_seen "$real" && continue
+            SEEN_FILES+=("$real")
             while IFS= read -r line || [ -n "$line" ]; do
               line="${line%%#*}"
               line=$(echo "$line" | xargs)
               if [ -z "$line" ]; then continue; fi
-              ALLOW_ENTRIES+=("$(echo "$line" | awk '{print $1, $2}')")
+              ALLOW_ENTRIES+=("$(norm_key "$line")")
             done < "$af"
           done
         fi
@@ -146,7 +145,7 @@ runs:
           for f in "${FINDINGS[@]}"; do
             REST="${f#*|}"
             CONTENT="${REST#*:}"
-            KEY=$(echo "$CONTENT" | sed 's/^[[:space:]]*//' | awk '{print $1, $2}')
+            KEY=$(norm_key "$CONTENT")
             allowed=false
             for a in "${ALLOW_ENTRIES[@]}"; do
               if [ "$KEY" = "$a" ]; then allowed=true; break; fi

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Comma-separated branches where pre-release pins are blocking (annotated as error). Must match the downstream gate. Default: release-candidate,main.'
     required: false
     default: 'release-candidate,main'
+  allow-file:
+    description: 'Path (relative to each scanned base) to a file listing accepted pre-release pins as "module version" lines (# comments allowed). Matching findings are exempted and reported as notices — the same discipline .trivyignore applies to CVEs that cannot be remediated by upgrade (e.g. a direct dependency with no stable upstream release). Auto-discovered at the default path when present; absent file = no exemptions.'
+    required: false
+    default: '.prerelease-allow'
 
 outputs:
   has-findings:
@@ -41,6 +45,7 @@ runs:
         APP_NAME: ${{ inputs.app-name }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
         BLOCK_BRANCHES: ${{ inputs.block-branches }}
+        ALLOW_FILE: ${{ inputs.allow-file }}
       run: |
         # Matches x.y.z-<letter...> — any semver with a pre-release suffix starting
         # with a letter (alpha, beta, rc, dev, preview, canary, snapshot, etc.).
@@ -105,6 +110,55 @@ runs:
             done < <(grep -nE ":${DOCKER_PRERELEASE}" "$df" || true)
           done
         done
+
+        # ----------------- allowlist (accepted pre-release pins) -----------------
+        # Exempt pins explicitly accepted in an allow-file: one entry per line,
+        # matched on the raw scanned line's first two whitespace tokens (for
+        # go.mod: "module version"); '#' comments and blank lines ignored. Same discipline
+        # .trivyignore applies to CVEs that cannot be remediated by upgrade — a
+        # direct dependency whose upstream ships no stable release (only beta/rc)
+        # stays visible in the report as a notice, but does not block promotion.
+        # Absent file (the default) = zero exemptions = unchanged behavior.
+        ALLOW_ENTRIES=()
+        ALLOW_SEEN=()
+        if [ -n "$ALLOW_FILE" ]; then
+          for base in "${SCAN_PATHS[@]}"; do
+            af="$base/$ALLOW_FILE"
+            [ -f "$af" ] || continue
+            real=$(realpath "$af")
+            dup=false
+            for s in "${ALLOW_SEEN[@]}"; do
+              if [ "$s" = "$real" ]; then dup=true; break; fi
+            done
+            if [ "$dup" = "true" ]; then continue; fi
+            ALLOW_SEEN+=("$real")
+            while IFS= read -r line || [ -n "$line" ]; do
+              line="${line%%#*}"
+              line=$(echo "$line" | xargs)
+              if [ -z "$line" ]; then continue; fi
+              ALLOW_ENTRIES+=("$(echo "$line" | awk '{print $1, $2}')")
+            done < "$af"
+          done
+        fi
+
+        if [ ${#ALLOW_ENTRIES[@]} -gt 0 ] && [ ${#FINDINGS[@]} -gt 0 ]; then
+          KEPT=()
+          for f in "${FINDINGS[@]}"; do
+            REST="${f#*|}"
+            CONTENT="${REST#*:}"
+            KEY=$(echo "$CONTENT" | sed 's/^[[:space:]]*//' | awk '{print $1, $2}')
+            allowed=false
+            for a in "${ALLOW_ENTRIES[@]}"; do
+              if [ "$KEY" = "$a" ]; then allowed=true; break; fi
+            done
+            if [ "$allowed" = "true" ]; then
+              echo "::notice::Accepted pre-release pin (allow-file): $KEY"
+            else
+              KEPT+=("$f")
+            fi
+          done
+          FINDINGS=("${KEPT[@]}")
+        fi
 
         COUNT=${#FINDINGS[@]}
         echo "findings_count=$COUNT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Promote develop → main

Cuts the stable release that ships the `prerelease-check` **allow-file** feature (#549) and advances the floating `@v1` major tag so consumers pick it up.

### Payload (vs `main`)

- `554ff11` **feat(security): allowlist accepted pre-release pins in prerelease-check** (#549) — optional `allow-file` input (default `.prerelease-allow`) that exempts explicitly-accepted pre-release dependency pins from the branch-aware gate, mirroring `.trivyignore`'s discipline for unfixable CVEs. **Backward-compatible**: absent file = byte-identical behavior for every existing consumer.
- Two `chore: backmerge main into develop [skip ci]` bookkeeping commits.

### Why now

Unblocks `matcher`'s promotion to `release-candidate`/`main`, which is gated on two pre-release pins that cannot be remediated by upgrade (`go-imap/v2 beta.8` direct — no stable v2 upstream; `yaml/v4 rc.6` indirect via `anthropic-sdk-go`), both already shipped on `matcher` main. matcher consumes this action via the floating `@v1`, so the fix only reaches it once this stable release advances `v1` (`enable_major_tag` fires on `main`).

### Note on trust model

The allow-file is read from the scanned working tree (same as `.trivyignore`). The README recommends consuming repos place `.prerelease-allow` under `CODEOWNERS` so exemptions get dedicated review.

https://claude.ai/code/session_0184duUW1P6N36YKTtbRsrpc
