### PR TITLE
feat(gitops): register underwriter in the benedita deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -48,7 +48,7 @@
 #      env list is what the workflow uses to build helmfile paths and ArgoCD app names.
 #
 # Out of scope (managed manually or by other tooling — do NOT add here):
-#   - underwriter, jd-mock-api, fakebtg, control-plane,
+#   - jd-mock-api, fakebtg, control-plane,
 #     platform-console (no CI commit history in gitops repo)
 #   - ledger, dockerhub-secret (no values.yaml — kustomize / k8s Secret)
 #   - hortencia-apps (legacy umbrella, not workflow-managed)
@@ -79,6 +79,7 @@ apps:
     - plugin-br-bank-transfer
     - plugin-br-payments
     - plugin-bc-correios
+    - underwriter
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -161,6 +162,7 @@ clusters:
       - plugin-br-bank-transfer
       - plugin-br-payments
       - plugin-bc-correios
+      - underwriter
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
## Description

Registers `underwriter` (Lerian's lending/loan-product service) in `config/deployment-matrix.yml`, in the `benedita` cluster, alongside the other `plugin-*` production apps.

`underwriter`'s `.github/` is being standardized in [LerianStudio/underwriter#51](https://github.com/LerianStudio/underwriter/pull/51) to consolidate its PR/release workflows onto `go-pr-validation.yml` / `go-release.yml`. That work wants to turn on `enable_gitops_update`, but `deployment-matrix.yml` currently lists `underwriter` explicitly as **out of scope** ("no CI commit history in gitops repo"). Per `docs/gitops-update-workflow.md`, an app not in the manifest just makes `gitops-update.yml` log a warning and exit cleanly — it wouldn't fail, but it also wouldn't deploy anywhere, silently.

## Change

- `apps.registry`: add `underwriter`.
- `clusters.benedita.apps`: add `underwriter`.
- Drop `underwriter` from the "Out of scope" comment block.
- No `app_helmfile_env` override — `underwriter` uses the standard benedita path (`environments/benedita/helmfile/applications/<env>/underwriter/values.yaml`, with the `-st`/`-mt` suffix expansion), same convention as `plugin-br-payments`, `plugin-bc-correios`, etc.
- Not added to `anacleto` — that cluster is a curated chaos/fuzzing subset, not a general production cluster.

Ran the `src/lint/deployment-matrix` validation logic locally against the edited manifest — passes (27 apps registered, 2 clusters, 0 warnings).

## Scope note

This PR only makes the shared workflow *aware* that `underwriter` may resolve to `benedita`. It does **not** create the actual `underwriter/values.yaml` in the GitOps repo — someone with access to that repo still needs to add it before the first tag push with `enable_gitops_update: true` produces a real deploy. Until then, `gitops-update.yml` will resolve the cluster but the helmfile-path write will report "values file not found" and skip (non-fatal), same behavior as any other app mid-onboarding.

## Testing

- [x] Ran the deployment-matrix lint script (schema/integrity/duplicate checks from `src/lint/deployment-matrix/action.yml`) locally against the edited file — 0 violations, 0 warnings.
- [x] `yaml.safe_load` parses cleanly.

## Related Issues

Related to LerianStudio/underwriter#51.
