### PR TITLE
hotfix(deployment-matrix): register br-sta in the benedita deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -80,6 +80,7 @@ apps:
     - plugin-br-payments
     - plugin-bc-correios
     - underwriter
+    - br-sta
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -163,6 +164,7 @@ clusters:
       - plugin-br-payments
       - plugin-bc-correios
       - underwriter
+      - br-sta
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
## Description

Registers `br-sta` in the deployment matrix so `gitops-update.yml` resolves
the `benedita` cluster for it. Prerequisite for enabling
`enable_gitops_update: true` in `LerianStudio/br-sta`'s `release.yml` —
without this entry, the workflow logs "app not found in manifest" and exits
cleanly (no failure, but no update either).

`br-sta` already has a values.yaml at
`environments/benedita/helmfile/applications/dev-st/br-sta/values.yaml`
(single-tenant only, `dev-st`; no `dev-mt` yet), with two image slots:
`br-sta.image.tag` (manager) and `worker.image.tag` (worker). Mirrors the
`underwriter` entry added in #552 (same insertion points, same pattern).

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** validated locally — parsed
`config/deployment-matrix.yml` with PyYAML, confirmed `br-sta` appears
exactly once in `apps.registry` and once in `clusters.benedita.apps`, no
duplicates introduced, no unknown app names in any cluster block. The
matching `release.yml` change in `LerianStudio/br-sta` (PR #56) depends on
this PR landing first.

## Related Issues

Closes #
