### PR TITLE
chore(deployment-matrix): register br-ccs for benedita

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -81,6 +81,7 @@ apps:
     - plugin-bc-correios
     - underwriter
     - br-sta
+    - br-ccs
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -165,6 +166,7 @@ clusters:
       - plugin-bc-correios
       - underwriter
       - br-sta
+      - br-ccs
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
## Why

br-ccs is being deployed to the benedita cluster (dev-st, single-tenant)
via LerianStudio/lerian-internal-gitops#1374, and the app is about to
enable the automated gitops-update job in its own release.yml
(`enable_gitops_update: true`, `gitops_yaml_key_mappings` for
`br-ccs.tag` -> `.brCcs.image.tag` and `br-ccs-migrations.tag` ->
`.brCcs.migrations.image.tag`). The gitops-update workflow resolves
clusters for an app from this manifest, so br-ccs must be registered
before that automation can find a target.

## What

- Added `br-ccs` to `apps.registry`, alongside the other BACEN-facing
  plugins (`underwriter`, `br-sta`).
- Added `br-ccs` to `clusters.benedita.apps`. No `app_helmfile_env`
  override is needed: the gitops scaffold already lives at the standard
  path `environments/benedita/helmfile/applications/dev-st/br-ccs/values.yaml`.

## Testing

- Ran the same validation logic as `src/lint/deployment-matrix` locally
  against the edited manifest: no violations, `br-ccs` present in both
  `apps.registry` and `clusters.benedita.apps`.