### PR TITLE
fix(prerelease-check): use keyword allowlist to avoid vendor-suffix false positives

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -245,6 +245,7 @@ jobs:
           app-name: ${{ env.APP_NAME }}
           target-branch: ${{ github.base_ref }}
           block-branches: ${{ inputs.prerelease_block_branches }}
+          prerelease-pattern: ${{ vars.PRERELEASE_PATTERN }}
 
       # ----------------- Results & Security Gate -----------------
       - name: Post Security Scan Results to PR

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -179,6 +179,8 @@ jobs:
 
 When enabled, the workflow scans `go.mod`, `package.json`, and `Dockerfile` for unstable version pins (`-alpha`, `-beta`, `-rc`, `-dev`, etc.). On branches listed in `prerelease_block_branches` (default: `release-candidate,main`) the PR is blocked. On other branches (e.g., `develop`) findings are reported as warnings only.
 
+The detection regex can be overridden centrally through the optional **organization variable `PRERELEASE_PATTERN`** — the workflow forwards `${{ vars.PRERELEASE_PATTERN }}` to the `prerelease-check` action. Define it once at the org level (Settings → Secrets and variables → Actions → Variables) to tune the policy across every consuming repo without cutting a new release; leave it undefined to keep the built-in allowlist (`[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)`). This is a global policy knob, so restrict who can manage Actions variables and prefer a per-pin `.prerelease-allow` allow-file for narrow, reviewable exemptions.
+
 ## Inputs
 
 | Input | Type | Default | Description |

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -16,6 +16,7 @@ Composite action that scans dependency files for unstable version pins. Only sta
 | `target-branch` | PR target branch (e.g. `github.base_ref`). Selects the annotation level (see below). Empty = warning | No | `''` |
 | `block-branches` | Comma-separated branches where pre-release pins annotate as error. Must match the downstream gate | No | `release-candidate,main` |
 | `allow-file` | Path (relative to each scanned base) to a file of accepted pre-release pins. Matching findings are exempted (reported as `::notice::`). Absent file = no exemptions | No | `.prerelease-allow` |
+| `prerelease-pattern` | Override the semver pre-release regex (applied to `go.mod`, `package.json` and `Dockerfile`). Wire from an org/repo variable to tune the policy without a release. Empty = built-in allowlist | No | `''` |
 
 ## Outputs
 
@@ -38,6 +39,16 @@ For all file types, only known pre-release keywords (`alpha`, `beta`, `rc`, `dev
 | `go.mod` | `vX.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v1.0.1-vault-7`, `v0.0.0-20240101-abcdef012345` |
 | `package.json` | `"[~^>=]*X.Y.Z-(alpha\|beta\|rc\|dev\|...)"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
 | `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
+
+## Overriding the pattern
+
+The regex is fixed in the action but overridable through the `prerelease-pattern` input, wired from an organization (or repository) variable so the policy can be tuned centrally without cutting a new release. The `pr-security-scan` reusable workflow already forwards `${{ vars.PRERELEASE_PATTERN }}`; define that variable once at the org level to apply it across every consuming repo.
+
+- Set it in **Settings → Secrets and variables → Actions → Variables** (organization scope) with a value such as `[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)`.
+- Leaving the variable undefined (the default) falls back to the built-in allowlist above — behavior is unchanged for repos that never set it.
+- The same override applies to `go.mod`, `package.json` and `Dockerfile` scanning.
+
+> **Security — this is a global policy knob.** Because the variable is read at org scope, anyone able to edit org variables can loosen (or tighten) the pre-release gate for **every** repository at once. Restrict who can manage Actions variables and prefer the per-pin `.prerelease-allow` allow-file for narrow, reviewable exemptions.
 
 ## Allowlisting accepted pins
 

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -31,7 +31,7 @@ This action never fails the job itself — it only reports. The summary annotati
 
 ## What it scans
 
-For all file types, only known pre-release keywords (`alpha`, `beta`, `rc`, `dev`, `preview`, `canary`, `snapshot`, `nightly`) are matched. This allowlist avoids false positives on stable vendor-suffixed releases (e.g. HashiCorp's `v1.0.1-vault-7`) and stable image variants (e.g. `-slim`, `-alpine`, `-bookworm`).
+For all file types, only known pre-release keywords (`alpha`, `beta`, `rc`, `dev`, `preview`, `canary`, `snapshot`, `nightly`) are matched. This allowlist avoids false positives on stable vendor-suffixed releases (e.g. the `-vault-N` suffix, such as `v1.0.1-vault-7`) and stable image variants (e.g. `-slim`, `-alpine`, `-bookworm`).
 
 | File | Scanned patterns | Blocked (unstable) | Allowed (stable) |
 |---|---|---|---|

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -36,8 +36,8 @@ For all file types, only known pre-release keywords (`alpha`, `beta`, `rc`, `dev
 
 | File | Scanned patterns | Blocked (unstable) | Allowed (stable) |
 |---|---|---|---|
-| `go.mod` | `vX.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v1.0.1-vault-7`, `v0.0.0-20240101-abcdef012345` |
-| `package.json` | `"[~^>=]*X.Y.Z-(alpha\|beta\|rc\|dev\|...)"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
+| `go.mod` | `vX.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v1.0.1-vault-7`, `v0.0.0-20240101120000-abcdef012345` |
+| `package.json` | `"[~^<>=]*X.Y.Z-(alpha\|beta\|rc\|dev\|...)"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"`, `"<2.0.0-beta.1"` | `"2.0.0"` |
 | `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
 
 ## Overriding the pattern

--- a/src/security/prerelease-check/README.md
+++ b/src/security/prerelease-check/README.md
@@ -31,12 +31,12 @@ This action never fails the job itself — it only reports. The summary annotati
 
 ## What it scans
 
-For `go.mod` and `package.json`: matches any semver with a pre-release suffix starting with a letter (`x.y.z-<letter...>`). For `Dockerfile`: only matches known pre-release prefixes to avoid false positives on stable image variants.
+For all file types, only known pre-release keywords (`alpha`, `beta`, `rc`, `dev`, `preview`, `canary`, `snapshot`, `nightly`) are matched. This allowlist avoids false positives on stable vendor-suffixed releases (e.g. HashiCorp's `v1.0.1-vault-7`) and stable image variants (e.g. `-slim`, `-alpine`, `-bookworm`).
 
 | File | Scanned patterns | Blocked (unstable) | Allowed (stable) |
 |---|---|---|---|
-| `go.mod` | `vX.Y.Z-<letter...>` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v0.0.0-20240101-abcdef012345` |
-| `package.json` | `"[~^>=]*X.Y.Z-<letter...>"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
+| `go.mod` | `vX.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `v1.2.3-beta.1`, `v1.2.3-rc.1`, `v1.2.3-alpha.1` | `v1.2.3`, `v1.0.1-vault-7`, `v0.0.0-20240101-abcdef012345` |
+| `package.json` | `"[~^>=]*X.Y.Z-(alpha\|beta\|rc\|dev\|...)"` | `"^2.0.0-beta.1"`, `"~1.0.0-rc.3"` | `"2.0.0"` |
 | `Dockerfile`, `*.dockerfile`, `Dockerfile.*` | `:X.Y.Z-(alpha\|beta\|rc\|dev\|...)` | `golang:1.21.0-beta1` | `golang:1.21.0`, `python:3.12-slim`, `node:20-alpine` |
 
 ## Allowlisting accepted pins

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Path (relative to each scanned base) to a file listing accepted pre-release pins as "module version" lines (# comments allowed). Matching findings are exempted and reported as notices — the same discipline .trivyignore applies to CVEs that cannot be remediated by upgrade (e.g. a direct dependency with no stable upstream release). Auto-discovered at the default path when present; absent file = no exemptions.'
     required: false
     default: '.prerelease-allow'
+  prerelease-pattern:
+    description: 'Override the semver pre-release regex used for go.mod, package.json and Dockerfile scanning. Wire from an org/repo variable (e.g. ${{ vars.PRERELEASE_PATTERN }}) to tune the policy without a release. Empty (the default) uses the built-in allowlist: [0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly).'
+    required: false
+    default: ''
 
 outputs:
   has-findings:
@@ -46,17 +50,19 @@ runs:
         TARGET_BRANCH: ${{ inputs.target-branch }}
         BLOCK_BRANCHES: ${{ inputs.block-branches }}
         ALLOW_FILE: ${{ inputs.allow-file }}
+        PRERELEASE_PATTERN: ${{ inputs.prerelease-pattern }}
       run: |
         # Matches x.y.z-<keyword> — only known pre-release suffixes (alpha, beta,
         # rc, dev, preview, canary, snapshot, nightly). An allowlist avoids false
         # positives on stable vendor-suffixed releases (e.g. the -vault-N suffix,
         # such as v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha)
         # and SHA pins are also allowed because their suffix is not a known keyword.
-        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)'
-
-        # Docker-specific pattern: only match known pre-release prefixes to avoid
-        # false positives on stable image variants like -slim, -alpine, -bookworm.
-        DOCKER_PRERELEASE='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)'
+        # The pattern is overridable via the prerelease-pattern input (wired from an
+        # org/repo variable); an empty value falls back to the built-in allowlist.
+        # The same pattern drives go.mod, package.json and Dockerfile scanning so
+        # stable image variants like -slim, -alpine, -bookworm never match either.
+        PRERELEASE_PATTERN="${PRERELEASE_PATTERN:-[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)}"
+        DOCKER_PRERELEASE="$PRERELEASE_PATTERN"
         FINDINGS=()
 
         # Scan the component scan-ref AND the repo root. In Go monorepos a single

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -57,11 +57,14 @@ runs:
         # positives on stable vendor-suffixed releases (e.g. the -vault-N suffix,
         # such as v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha)
         # and SHA pins are also allowed because their suffix is not a known keyword.
+        # A token boundary after each keyword keeps prefix-matches like -devtools-7
+        # or -rca from being flagged as -dev/-rc, while still accepting numeric and
+        # dot/plus-separated forms such as -beta1, -beta.1 and -rc.2.
         # The pattern is overridable via the prerelease-pattern input (wired from an
         # org/repo variable); an empty value falls back to the built-in allowlist.
         # The same pattern drives go.mod, package.json and Dockerfile scanning so
         # stable image variants like -slim, -alpine, -bookworm never match either.
-        PRERELEASE_PATTERN="${PRERELEASE_PATTERN:-[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)}"
+        PRERELEASE_PATTERN="${PRERELEASE_PATTERN:-[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)([[:digit:]]+|[.][[:alnum:]-]+|[+][[:alnum:].-]+)?([^[:alnum:]-]|\$)}"
         DOCKER_PRERELEASE="$PRERELEASE_PATTERN"
         FINDINGS=()
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -57,14 +57,27 @@ runs:
         # positives on stable vendor-suffixed releases (e.g. the -vault-N suffix,
         # such as v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha)
         # and SHA pins are also allowed because their suffix is not a known keyword.
-        # A token boundary after each keyword keeps prefix-matches like -devtools-7
-        # or -rca from being flagged as -dev/-rc, while still accepting numeric and
+        # A token boundary after each keyword keeps prefix-matches like -devtools-7,
+        # -rca or -dev_build from being flagged as -dev/-rc (underscore counts as
+        # part of the token, not a delimiter), while still accepting numeric and
         # dot/plus-separated forms such as -beta1, -beta.1 and -rc.2.
         # The pattern is overridable via the prerelease-pattern input (wired from an
         # org/repo variable); an empty value falls back to the built-in allowlist.
         # The same pattern drives go.mod, package.json and Dockerfile scanning so
         # stable image variants like -slim, -alpine, -bookworm never match either.
-        PRERELEASE_PATTERN="${PRERELEASE_PATTERN:-[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)([[:digit:]]+|[.][[:alnum:]-]+|[+][[:alnum:].-]+)?([^[:alnum:]-]|\$)}"
+        DEFAULT_PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)([[:digit:]]+|[.][[:alnum:]-]+|[+][[:alnum:].-]+)?([^[:alnum:]_-]|$)'
+        PRERELEASE_PATTERN="${PRERELEASE_PATTERN:-$DEFAULT_PRERELEASE_PATTERN}"
+
+        # Guard against a malformed override: an invalid ERE would make every
+        # "grep -E ... || true" below look like zero findings and silently disable
+        # the gate. Probe the resolved pattern (grep exits >=2 on a bad regex) and
+        # fall back to the built-in allowlist with a warning if it is unusable.
+        PROBE_RC=0
+        printf '' | grep -Eq "$PRERELEASE_PATTERN" 2>/dev/null || PROBE_RC=$?
+        if [ "$PROBE_RC" -ge 2 ]; then
+          echo "::warning::Invalid prerelease-pattern override; falling back to the built-in allowlist."
+          PRERELEASE_PATTERN="$DEFAULT_PRERELEASE_PATTERN"
+        fi
         DOCKER_PRERELEASE="$PRERELEASE_PATTERN"
         FINDINGS=()
 

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -49,9 +49,9 @@ runs:
       run: |
         # Matches x.y.z-<keyword> — only known pre-release suffixes (alpha, beta,
         # rc, dev, preview, canary, snapshot, nightly). An allowlist avoids false
-        # positives on stable vendor-suffixed releases (e.g. HashiCorp's
-        # v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha) and
-        # SHA pins are also allowed because their suffix is not a known keyword.
+        # positives on stable vendor-suffixed releases (e.g. the -vault-N suffix,
+        # such as v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha)
+        # and SHA pins are also allowed because their suffix is not a known keyword.
         PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)'
 
         # Docker-specific pattern: only match known pre-release prefixes to avoid

--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -47,11 +47,12 @@ runs:
         BLOCK_BRANCHES: ${{ inputs.block-branches }}
         ALLOW_FILE: ${{ inputs.allow-file }}
       run: |
-        # Matches x.y.z-<letter...> — any semver with a pre-release suffix starting
-        # with a letter (alpha, beta, rc, dev, preview, canary, snapshot, etc.).
-        # Excludes Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha) because
-        # their suffix starts with digits, not letters. SHA pins are also allowed.
-        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z]'
+        # Matches x.y.z-<keyword> — only known pre-release suffixes (alpha, beta,
+        # rc, dev, preview, canary, snapshot, nightly). An allowlist avoids false
+        # positives on stable vendor-suffixed releases (e.g. HashiCorp's
+        # v1.0.1-vault-7). Go pseudo-versions (v0.0.0-YYYYMMDDHHMMSS-commitsha) and
+        # SHA pins are also allowed because their suffix is not a known keyword.
+        PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly)'
 
         # Docker-specific pattern: only match known pre-release prefixes to avoid
         # false positives on stable image variants like -slim, -alpine, -bookworm.


### PR DESCRIPTION
## Description

The `prerelease-check` composite scanned `go.mod`/`package.json` with `PRERELEASE_PATTERN='[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z]'`, which matches **any** alphabetical suffix after a semver. Stable vendor-suffixed releases such as HashiCorp's `github.com/hashicorp/hcl v1.0.1-vault-7` were therefore wrongly flagged as pre-release, blocking on `release-candidate`/`main`.

This aligns `go.mod`/`package.json` scanning with the keyword allowlist already used for Dockerfiles, so only real pre-release suffixes (`alpha|beta|rc|dev|preview|canary|snapshot|nightly`) match. README "What it scans" section and table updated accordingly.

Affected workflow: Security (`go-security`, `pr-security-scan`).

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. This only narrows matching (fewer false positives); previously-flagged real pre-release suffixes still match.

## Testing

- [x] YAML syntax validated locally
- [x] Validated the new regex against sample `go.mod` lines: `-vault-7` and Go pseudo-versions no longer match; `-beta.8` and `-rc.1` still match
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

## Related Issues

Closes #526