### PR TITLE
fix(prerelease-check): drop vars expression from input description

### DIFF
--- a/src/security/prerelease-check/action.yml
+++ b/src/security/prerelease-check/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: '.prerelease-allow'
   prerelease-pattern:
-    description: 'Override the semver pre-release regex used for go.mod, package.json and Dockerfile scanning. Wire from an org/repo variable (e.g. ${{ vars.PRERELEASE_PATTERN }}) to tune the policy without a release. Empty (the default) uses the built-in allowlist: [0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly).'
+    description: 'Override the semver pre-release regex used for go.mod, package.json and Dockerfile scanning. Wire from an org/repo Actions variable named PRERELEASE_PATTERN to tune the policy without a release. Empty (the default) uses the built-in allowlist: [0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc|dev|preview|canary|snapshot|nightly).'
     required: false
     default: ''
 


### PR DESCRIPTION
## Description

The `prerelease-pattern` input description (added in #563) contained the literal example `\${{ vars.PRERELEASE_PATTERN }}`. GitHub evaluates `\${{ }}` expressions when it loads a composite action manifest, and composite actions cannot access the `vars` context. As a result the manifest fails to load with:

```
Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.PRERELEASE_PATTERN
```

This breaks **every** consumer of `pr-security-scan` (observed on `LerianStudio/br-ccs`), since the `prerelease-check` composite can no longer be loaded. The actual wiring `prerelease-pattern: \${{ vars.PRERELEASE_PATTERN }}` in `pr-security-scan.yml` is fine (a reusable workflow can read `vars`); only the example text inside the composite description was the problem.

Fix: reference the variable by name in prose instead of embedding an expression.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. Restores the composite manifest so consumers load again; no input/output/default changes.

## Testing

- [x] YAML syntax validated locally
- [x] Confirmed no remaining `\${{ }}` expressions in the composite reference an invalid context (only `inputs.*` and `steps.*` remain)

## Related Issues

Follow-up to #563 (#526).