### PR TITLE
fix(ungoliant): bump curl-timeout default from 300s to 900s

### DIFF
--- a/src/validate/ungoliant-release-diff/README.md
+++ b/src/validate/ungoliant-release-diff/README.md
@@ -34,7 +34,7 @@ This is the CI equivalent of `ungoliant-controller/docs/testing/cluster/test-rel
 | `github-token`   | GitHub token used to read tags, compare and diff via the API.                   | Yes      |                                                      |
 | `webhook-token`  | Ungoliant webhook token sent as the `X-Ungoliant-Token` header.                 | No       | `""`                                                 |
 | `max-diff-bytes` | Maximum diff size forwarded to the controller (bytes).                          | No       | `262144`                                             |
-| `curl-timeout`   | Timeout for the webhook POST in seconds.                                         | No       | `900`                                                |
+| `curl-timeout`   | Timeout for the webhook POST in seconds. Must stay in lockstep with `ungoliant-controller`'s `NEMOCLAW_TIMEOUT_SECONDS` and its ingress proxy timeouts — don't change this in isolation. | No | `900` |
 | `dry-run`        | Resolve and preview the payload without firing the webhook.                     | No       | `false`                                              |
 
 ## Outputs

--- a/src/validate/ungoliant-release-diff/README.md
+++ b/src/validate/ungoliant-release-diff/README.md
@@ -34,7 +34,7 @@ This is the CI equivalent of `ungoliant-controller/docs/testing/cluster/test-rel
 | `github-token`   | GitHub token used to read tags, compare and diff via the API.                   | Yes      |                                                      |
 | `webhook-token`  | Ungoliant webhook token sent as the `X-Ungoliant-Token` header.                 | No       | `""`                                                 |
 | `max-diff-bytes` | Maximum diff size forwarded to the controller (bytes).                          | No       | `262144`                                             |
-| `curl-timeout`   | Timeout for the webhook POST in seconds.                                         | No       | `300`                                                |
+| `curl-timeout`   | Timeout for the webhook POST in seconds.                                         | No       | `900`                                                |
 | `dry-run`        | Resolve and preview the payload without firing the webhook.                     | No       | `false`                                              |
 
 ## Outputs

--- a/src/validate/ungoliant-release-diff/action.yml
+++ b/src/validate/ungoliant-release-diff/action.yml
@@ -48,9 +48,9 @@ inputs:
     required: false
     default: "262144"
   curl-timeout:
-    description: Timeout for the webhook POST in seconds (LLM inference can take 60-120s)
+    description: Timeout for the webhook POST in seconds (LLM inference can take 60-120s, longer for large/complex diffs). Must stay in lockstep with ungoliant-controller's NEMOCLAW_TIMEOUT_SECONDS and its ingress proxy timeouts.
     required: false
-    default: "300"
+    default: "900"
   dry-run:
     description: Resolve and preview the payload without firing the webhook
     required: false


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Affects: `src/validate/ungoliant-release-diff` (composite action used by `go-release.yml`'s `ungoliant_release_diff` job).

Bumps the `curl-timeout` input's default from 300s to 900s. `midaz`'s release-diff timed out at exactly 300s ([run](https://github.com/LerianStudio/midaz/actions/runs/29279206313)) — its diff is large/complex enough that inference + schema validation on the controller side exceeds the previous default.

This must move in lockstep with two companion changes in `lerian-internal-gitops` (`ungoliant-controller`'s `NEMOCLAW_TIMEOUT_SECONDS` env var and its ingress `proxy-read-timeout`/`proxy-send-timeout` annotations, both bumped to 900/960s) — a client-side timeout shorter than the controller's own budget fails the CI job even when the controller would have eventually succeeded.

No caller repo sets `curl-timeout` explicitly (confirmed via `go-release.yml`, which doesn't pass this input through), so every consumer picks up the new default automatically once this releases and the `@v1` tag moves.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None — only a default value change; any caller can still override it explicitly.

## Testing

- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Not triggered on a caller repo in this PR — the failure this fixes is already reproduced in production (linked run above); recommend re-running `midaz`'s release-diff after this merges and releases
- [x] Verified all existing inputs still work with default values (only the default value itself changed, no logic touched)
- [x] Confirmed no secrets or tokens are printed in logs (no logging changes)
- [x] Checked that unrelated workflows are not affected (change is scoped to one composite action's single input default + its README)

**Caller repo / workflow run:** https://github.com/LerianStudio/midaz/actions/runs/29279206313 (the failure this fixes)

## Related Issues

Closes #
