### PR TITLE
fix(gitops-update): make argocd app wait timeout configurable with retry backoff

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -95,7 +95,7 @@ on:
       argocd_sync_timeout:
         description: 'Timeout in seconds for argocd app wait after sync. Increase for larger applications or clusters under load.'
         type: number
-        default: 480
+        default: 600
       force_env:
         description: 'Override tag-based environment detection with development|staging|production|sandbox. Set when running on a branch (no tag in GITHUB_REF), e.g. same-run gitops update after a stable release. Empty = detect from the tag.'
         type: string
@@ -974,11 +974,20 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::argocd app wait $APP_NAME"
-          if ! argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --timeout "$ARGOCD_SYNC_TIMEOUT"; then
-            echo "::endgroup::"
-            echo "::error::Timeout waiting for sync completion of $APP_NAME"
-            exit 1
-          fi
+          wait_delay=30
+          for attempt in 1 2 3; do
+            if argocd app wait "$APP_NAME" --server "$ARGOCD_URL" --auth-token "$ARGOCD_TOKEN" --grpc-web --timeout "$ARGOCD_SYNC_TIMEOUT"; then
+              break
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              echo "::endgroup::"
+              echo "::error::Timeout waiting for sync completion of $APP_NAME after 3 attempts"
+              exit 1
+            fi
+            echo "Wait attempt $attempt failed, retrying in ${wait_delay}s..."
+            sleep "$wait_delay"
+            wait_delay=$((wait_delay * 2))
+          done
           echo "::endgroup::"
 
   # Slack notification

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -139,6 +139,7 @@ update_gitops:
 | `kustomize_environments` | string | - | Optional space-separated env list overriding the default tag-based env loop when `gitops_layout=kustomize`. Leave empty for layouts without env split |
 | `kustomize_version` | string | `v5.4.3` | Version of kustomize CLI to install (only when `gitops_layout=kustomize`) |
 | `argocd_app_name_template` | string | `{server}-{app}-{env}` | Template for the ArgoCD application name. Supports `{server}`, `{app}`, `{env}`. For kustomize layouts without env split, use e.g. `{server}-{app}` |
+| `argocd_sync_timeout` | number | `600` | Timeout in seconds for `argocd app wait` after sync. Increase for larger applications or clusters under load. |
 | `beta_environments` | string | `dev` | Space-separated environments updated by a beta release (`develop` branch) |
 | `rc_environments` | string | `stg` | Space-separated environments updated by an rc release (`release-candidate` branch) |
 | `stable_environments` | string | `prd` | Space-separated environments updated by a stable release (`main` branch). Default `prd` so a hotfix does not overwrite features still in dev/stg. Set to `dev stg prd` to refresh lower environments too. Sandbox is controlled separately by `update_sandbox` |
@@ -414,7 +415,9 @@ The workflow uses a matrix strategy for ArgoCD sync:
 
 ### Sync Command Behavior
 
-The `argocd app sync` call uses `--async --timeout 180`, dispatching the sync without blocking on completion. A subsequent `argocd app wait --timeout 180` confirms the rollout. On failure, the step retries up to 5 times with a 30s interval between attempts.
+The `argocd app sync` call uses `--async --timeout 180`, dispatching the sync without blocking on completion. On failure, the sync step retries up to 5 times with a 30s interval between attempts.
+
+A subsequent `argocd app wait --timeout` (configurable via `argocd_sync_timeout`, default `600`) confirms the rollout. On failure, the wait step retries up to 3 times with exponential backoff (30s, then 60s between attempts).
 
 When `argocd_prune` is `true`, `--prune` is appended so orphaned resources left behind by previous renames/removals are cleaned up automatically. Keep this disabled by default in production and enable per-caller when you knowingly need cleanup.
 

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -415,9 +415,9 @@ The workflow uses a matrix strategy for ArgoCD sync:
 
 ### Sync Command Behavior
 
-The `argocd app sync` call uses `--async --timeout 180`, dispatching the sync without blocking on completion. On failure, the sync step retries up to 5 times with a 30s interval between attempts.
+The `argocd app sync` call uses `--async --timeout 180`, dispatching the sync without blocking on completion. On failure, the sync step makes up to 5 attempts with a 30s interval between attempts.
 
-A subsequent `argocd app wait --timeout` (configurable via `argocd_sync_timeout`, default `600`) confirms the rollout. On failure, the wait step retries up to 3 times with exponential backoff (30s, then 60s between attempts).
+A subsequent `argocd app wait --timeout` (configurable via `argocd_sync_timeout`, default `600`) confirms the rollout. On failure, the wait step makes up to 3 attempts with exponential backoff (30s, then 60s between attempts).
 
 When `argocd_prune` is `true`, `--prune` is appended so orphaned resources left behind by previous renames/removals are cleaned up automatically. Keep this disabled by default in production and enable per-caller when you knowingly need cleanup.
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`gitops-update.yml` was reporting `ArgoCD Sync` failures for downstream apps even when ArgoCD itself converged successfully a short time later. Root cause: a hard-coded 180s timeout on `argocd app wait`, shorter than the time some apps take to finish PostSync hooks on slower/busier clusters, and no retry once `app wait` timed out.

An earlier commit (81d4df3) already exposed the timeout as the `argocd_sync_timeout` input (applied to `argocd app wait`), but left the default at 480s and never updated the docs. This PR finishes closing the gap:

- Raises the `argocd_sync_timeout` default from 480s to 600s.
- Adds a 3-attempt retry loop with exponential backoff (30s, then 60s) around `argocd app wait`, mirroring the existing retry pattern already used for `argocd app sync`. This directly covers the reported scenario, where ArgoCD finishes converging shortly after the GHA step gives up.
- Updates `docs/gitops-update-workflow.md`: documents `argocd_sync_timeout` in the inputs table and corrects the "Sync Command Behavior" section, which still described a hard-coded 180s wait timeout with no retry.

Closes #381.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `argocd_sync_timeout` already existed as an input; only its default value changes (480s → 600s), and no external caller currently sets or relies on it. The wait retry loop is additive behavior — a caller that previously failed after one `app wait` timeout now gets up to 2 more attempts before failing.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — recommend validating against the linked plugin-access-manager scenario before/after tagging a release_

## Related Issues

Closes #381