### PR TITLE
fix(release): sort tags with versionsort.suffix to rank stable above prerelease

### DIFF
--- a/src/config/release-tag-check/action.yml
+++ b/src/config/release-tag-check/action.yml
@@ -24,7 +24,7 @@ runs:
         PREVIOUS_TAG: ${{ inputs.previous-tag }}
       run: |
         git fetch --tags origin
-        NEW_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1 || true)
+        NEW_TAG=$(git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname | head -1 || true)
         if [ "$NEW_TAG" != "$PREVIOUS_TAG" ] && [ -n "$NEW_TAG" ]; then
           echo "release_published=true" >> "$GITHUB_OUTPUT"
           VERSION="${NEW_TAG#v}"

--- a/src/config/release-tag-snapshot/action.yml
+++ b/src/config/release-tag-snapshot/action.yml
@@ -14,5 +14,5 @@ runs:
       shell: bash
       run: |
         git fetch --tags origin
-        LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1 || true)
+        LATEST_TAG=$(git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname | head -1 || true)
         echo "latest_tag=${LATEST_TAG:-none}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`release-tag-check` and `release-tag-snapshot` both select the latest release tag with `git tag -l 'v*' --sort=-v:refname | head -1`. Without `versionsort.suffix` configured, git's version sort ranks a prerelease tag (e.g. `v2.0.0-beta.2`) **above** its stable counterpart (`v2.0.0`), so `head -1` returns the prerelease even when a newer stable tag exists.

Impact: when semantic-release publishes a stable release but a post-publish step fails (e.g. the backmerge plugin breaks on a dirty working tree), `release-tag-check` runs to detect whether the release actually went out. Because both the pre-release snapshot (`release-tag-snapshot`) and the post-release check compute the "latest tag" the same broken way, they return the same value, `release-published` comes back `false`, and the job fails with a misleading "Semantic release failed before publishing a new version" message — even though the stable release, tag, and GitHub release were all created successfully, and the backmerge fallback step is silently skipped.

Fix: pass `-c versionsort.suffix=-` to `git tag` in both composites, so any tag containing `-` (prerelease suffixes) sorts below the bare version.

Reproduced and verified locally:
```
tags: v1.14.1, v2.0.0, v2.0.0-beta.1, v2.0.0-beta.2
git tag -l 'v*' --sort=-v:refname | head -1                        => v2.0.0-beta.2  (wrong)
git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname | head -1 => v2.0.0         (correct)
```

Closes #384.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. No inputs, outputs, or interfaces changed — only the internal tag-sorting behavior, which now correctly identifies the latest stable tag instead of misranking prereleases above it.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — recommend validating against the linked tenant-manager scenario (run #26594352945) with mixed stable/prerelease tags before/after tagging a release_

## Related Issues

Closes #384