### PR TITLE
fix(release): fetch git notes so semantic-release can promote prereleases to stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
           git fetch origin ${{ github.ref_name }}
           git reset --hard origin/${{ github.ref_name }}
 
+      - name: Fetch semantic-release git notes
+        run: git fetch origin "+refs/notes/*:refs/notes/*"
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         id: import_gpg

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -221,10 +221,11 @@ plugins:
 1. **Create GitHub App Token**: Generate authentication token with higher rate limits
 2. **Checkout Repository**: Clone with full history for versioning
 3. **Sync with Remote**: Ensure latest changes are pulled
-4. **Import GPG Key**: Import and configure GPG key for signing
-5. **Initialize package.json**: Create if doesn't exist
-6. **Install Plugins**: Install semantic-release plugins
-7. **Run Semantic Release**: Calculate version and create release using `.releaserc.yml`
+4. **Fetch git notes**: Fetch `refs/notes/*` so semantic-release can resolve which prerelease channels each tag was published to (required to promote a prerelease to stable on the release branch)
+5. **Import GPG Key**: Import and configure GPG key for signing
+6. **Initialize package.json**: Create if doesn't exist
+7. **Install Plugins**: Install semantic-release plugins
+8. **Run Semantic Release**: Calculate version and create release using `.releaserc.yml`
 
 ## GPG Signing
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

When `release.yml` runs on a release branch (`main`) of a repo that uses prerelease channels (`develop`→beta, `release-candidate`→rc), semantic-release does not promote the latest prerelease to its stable version. Instead it reports "no previous release" and resets to `1.0.0`, even though a higher prerelease line (e.g. `v3.0.0-rc.1`) is fully merged into `main` and a prior stable tag exists.

Root cause: semantic-release stores the tag ↔ channel mapping (which prerelease channels a release was published to) in git notes (`refs/notes/semantic-release`), not in the tag name itself. The checkout + sync steps in `publish_release` (`.github/workflows/release.yml`) fetch branches and tags but never fetch notes, so on the release branch semantic-release can't recognize that a prerelease tag is promotable to stable, and falls back to treating the repo as if it had no previous release at all.

Fix: add a step right after "Sync with remote branch" that fetches `+refs/notes/*:refs/notes/*`, making the channel mapping available before semantic-release runs. `docs/release-workflow.md`'s step list is updated to include it.

Closes #392.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. No inputs, outputs, or interfaces changed — one additional `git fetch` step runs before semantic-release, with no effect on repos that don't use prerelease channels.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — recommend validating against the linked plugin-access-manager scenario (main release after an rc line) before/after tagging a release_

## Related Issues

Closes #392