### PR TITLE
feat(release): add npm publish support and js-pr-validation monorepo paths

### DIFF
--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -104,6 +104,15 @@ on:
         description: 'Fail the workflow if coverage is below threshold'
         type: boolean
         default: false
+      filter_paths:
+        description: 'JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]), passed through to frontend-pr-analysis.yml. If empty, treats repo as single-app and runs against root directory. Not passed to the security scan (pr-security-scan.yml uses a different, newline-separated format for its own filter_paths) — call it directly for path-scoped security scans.'
+        type: string
+        required: false
+        default: ''
+      path_level:
+        description: 'Directory depth level to extract app name, passed through to frontend-pr-analysis.yml.'
+        type: number
+        default: 2
       app_name_prefix:
         description: 'Prefix used to namespace coverage/build artifacts'
         type: string
@@ -242,6 +251,8 @@ jobs:
       audit_level: ${{ inputs.audit_level }}
       coverage_threshold: ${{ inputs.coverage_threshold }}
       fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
+      filter_paths: ${{ inputs.filter_paths }}
+      path_level: ${{ inputs.path_level }}
       app_name_prefix: ${{ inputs.app_name_prefix }}
       enable_lint: ${{ inputs.enable_lint }}
       enable_typecheck: ${{ inputs.enable_typecheck }}

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -231,6 +231,9 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: false
+      NPM_TOKEN:
+        description: 'npm registry auth token, forwarded to the release job. Only used when the caller''s own .releaserc includes @semantic-release/npm (a package with independent semver that publishes to an npm registry). Optional — omit for repos that do not publish to npm.'
+        required: false
       AWS_E2E_ARTIFACTS_ROLE_ARN:
         description: 'IAM role ARN assumed via OIDC to upload the E2E (Playwright) report to the lerian-e2e-artifacts S3 bucket. Optional — when unset, the S3 upload step is skipped and only the GitHub Actions artifact is produced.'
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,7 @@ jobs:
             conventional-changelog-conventionalcommits@v7.0.2
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Guard against stale prerelease
         id: guard
@@ -347,6 +348,7 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # ----------------- Backmerge -----------------
       - name: Backmerge ${{ inputs.backmerge_source }} → ${{ inputs.backmerge_target }}

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -37,6 +37,8 @@ The `frontend-analysis` and `security` pipelines each have a `*-gate` aggregator
 | `audit_level` | npm audit severity level (`low`, `moderate`, `high`, `critical`) | string | `high` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
+| `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml` only | string | `''` |
+| `path_level` | Directory depth level to extract app name, passed through to `frontend-pr-analysis.yml` only | number | `2` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
 | `enable_lint` | Enable ESLint | boolean | `true` |
 | `enable_typecheck` | Enable TypeScript type checking | boolean | `true` |
@@ -56,7 +58,7 @@ The `frontend-analysis` and `security` pipelines each have a `*-gate` aggregator
 | `ignore_file` | Path to Trivy ignore file (e.g. `.trivyignore.yaml`) | string | `''` |
 | `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan | string | `''` |
 
-> **Monorepo note:** `filter_paths` is not exposed at the umbrella level because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input. For monorepo setups with per-component scanning, call the individual primitives directly.
+> **Monorepo note:** `filter_paths`/`path_level` scope the `frontend-analysis` job only. They are not passed to the `security` job because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input (JSON array vs. newline-separated). For a path-scoped security scan too, call `pr-security-scan.yml` directly.
 
 ## Secrets
 

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -77,6 +77,7 @@ Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services â€
 |--------|-------------|----------|
 | `MANAGE_TOKEN` | Token for release commits, tags and private module access | No |
 | `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+| `NPM_TOKEN` | npm registry auth token, forwarded to the `release` job. Only needed when the caller's own `.releaserc` includes `@semantic-release/npm` (a component with independent semver that publishes to an npm registry) | No |
 | `AWS_E2E_ARTIFACTS_ROLE_ARN` | IAM role ARN assumed via OIDC to upload the Playwright report to the `lerian-e2e-artifacts` S3 bucket (`s3://lerian-e2e-artifacts/<repo>/<channel>/<tag>/<e2e_s3_artifact_path>/`). Unset â†’ S3 upload step is skipped, only the GitHub Actions artifact is produced | No |
 | `UNGOLIANT_WEBHOOK_TOKEN` | Token sent as the `X-Ungoliant-Token` header (used when `enable_ungoliant_release_diff`) | No |
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -104,6 +104,12 @@ jobs:
 | `lerian_ci_cd_user_name` | Git committer name |
 | `lerian_ci_cd_user_email` | Git committer email |
 
+### Optional Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `NPM_TOKEN` | npm registry auth token, forwarded to the `Semantic Release` step. Only needed when the caller's own `.releaserc` includes `@semantic-release/npm` (a package with independent semver that publishes to an npm registry). Omit for repos that do not publish to npm. |
+
 ## Outputs
 
 | Output | Description |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`matcher` (LerianStudio/matcher) is a Go repo with two embedded TS/JS subprojects — `ui/` (Docker-only Vite SPA) and `mcp/` (an npm package with independent semver, published to `@lerianstudio/matcher-mcp`). PR #575 already closed the Docker-image half of consolidating matcher's hand-maintained workflows onto the shared `go-release.yml`/`js-release.yml`/`go-pr-validation.yml`/`js-pr-validation.yml`. Two gaps remained blocking full adoption:

1. **No npm-publish path.** `js-release.yml`/`release.yml` only produce a tag/GH-release + Docker image — there was no way for a component like `mcp/`, with its own semver, to reach `npm publish`.
2. **`js-pr-validation.yml` had no monorepo path scoping.** `frontend-pr-analysis.yml` already supports `filter_paths`/`path_level` for per-component analysis, but the umbrella never exposed them, so it only ran in single-app mode at repo root — unusable for `matcher`'s `ui/` subdirectory.

### Fix

**1. npm publish** — `@semantic-release/npm` is a *default* plugin of `semantic-release` (active whenever a `package.json` isn't `private`), so publishing is already fully controllable by each caller's own `.releaserc` (which plugin list, `access: public/restricted`, etc. — `release.yml` never generates a `.releaserc`, it only runs `npm init -y` and lets the caller's own config drive everything). The only thing actually missing was the auth token itself. Added:
- `release.yml`: `NPM_TOKEN` forwarded as an env var to the `Semantic Release` and `Determine next version (dry-run)` steps (no schema declaration needed — this file has no `secrets:` schema at all, it fully relies on `secrets: inherit`, matching every other secret used here).
- `js-release.yml`: `NPM_TOKEN` declared as an optional secret for documentation/consistency with `MANAGE_TOKEN` etc. — the plumbing down to `release.yml` already works via the existing `secrets: inherit` on the `release` job.

No `enable_npm_publish`/`npm_access` inputs were added — a caller opts in simply by adding `@semantic-release/npm` (with whatever `access` it needs) to its own `.releaserc`, exactly like it already controls every other plugin.

**2. `js-pr-validation.yml` paths** — added `filter_paths` (JSON array, e.g. `["ui"]`) and `path_level` inputs, passed through **only** to the `frontend-analysis` job (`frontend-pr-analysis.yml`). They are intentionally *not* forwarded to the `security` job: `pr-security-scan.yml` uses a different, newline-separated format for its own `filter_paths`, which is exactly why the umbrella previously punted on exposing this at all (see the now-updated monorepo note in `docs/js-pr-validation.md`). A path-scoped security scan still requires calling `pr-security-scan.yml` directly.

Docs updated: `docs/release-workflow.md`, `docs/js-release.md`, `docs/js-pr-validation.md`.

Closes #576.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `NPM_TOKEN` is a new optional secret (empty by default, no effect unless a caller's own `.releaserc` uses `@semantic-release/npm`). `filter_paths`/`path_level` on `js-pr-validation.yml` default to empty/`2`, preserving current single-app-at-root behavior for every existing caller.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** _pending — recommend validating against matcher's `mcp/` (npm publish) and `ui/` (path-scoped PR validation) once tagged_

## Related Issues

Closes #576