### PR TITLE
chore(matrix): rename gestao-acessos-console to severino

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -90,7 +90,7 @@ apps:
     - backoffice-console
     - cs-platform
     - forge
-    - gestao-acessos-console
+    - severino
     - lerian-map
     - tenant-manager
 
@@ -145,7 +145,7 @@ clusters:
       backoffice-console: cross
       cs-platform: cross
       forge: cross
-      gestao-acessos-console: cross
+      severino: cross
       lerian-map: cross
       rosiehr: cross
       tenant-manager: cross
@@ -171,7 +171,7 @@ clusters:
       - backoffice-console
       - cs-platform
       - forge
-      - gestao-acessos-console
+      - severino
       - lerian-map
       - tenant-manager
       - notifications


### PR DESCRIPTION
Source repo renamed `LerianStudio/gestao-acessos-console` → `LerianStudio/severino`.

Aligning the deployment matrix so future auto-bumps target the correct app name and gitops path. Chart, image, gitops namespace, DNS and Vault path were already updated in parallel.

See migration runbook at `~/changename.md` (Fase 6).