### PR TITLE
chore(deployment-matrix): add br-slc to deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -81,6 +81,7 @@ apps:
     - plugin-bc-correios
     - underwriter
     - br-sta
+    - br-slc
     - br-ccs
 
     # Test/mock infrastructure
@@ -166,6 +167,7 @@ clusters:
       - plugin-bc-correios
       - underwriter
       - br-sta
+      - br-slc
       - br-ccs
       - mock-btg-server
       - backoffice-console


### PR DESCRIPTION
Adds `br-slc` to the deployment matrix, mirroring how `br-sta` is configured.

Changes in `config/deployment-matrix.yml`:
- Added to `apps.registry` (Plugins block), after `br-sta`
- Added to `clusters.benedita.apps`, after `br-sta`
- Not added to anacleto (matches br-sta)

Requested by: Bedatty