### PR TITLE
fix(go-release): stop gating s3_upload on unreliable build result

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -374,7 +374,12 @@ jobs:
   s3_upload:
     name: S3 Upload
     needs: [build]
-    if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result == 'success'
+    # needs.build.result alone is unreliable here: build wraps build.yml, a
+    # reusable workflow with an internal matrix, and its caller result does
+    # not always surface as 'success' to dependents even when every matrix
+    # leg passed (same issue update_gitops and ungoliant_release_diff already
+    # guard against below with the has_builds output check).
+    if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result != 'failure' && needs.build.outputs.has_builds == 'true'
     runs-on: ${{ inputs.runner_type }}
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- `s3_upload` in `go-release.yml` gates purely on `needs.build.result == 'success'`. `build` wraps `build.yml`, a reusable workflow with an internal matrix strategy, and its caller-side `.result` does not always surface as `'success'` to dependents even when every matrix leg passed — a limitation this same file already documents and works around in `update_gitops` and `ungoliant_release_diff` via an additional `needs.build.outputs.has_builds == 'true'` check.
- `s3_upload` never got the same treatment, so it silently skips uploading migration files on tag pushes where this manifests. Observed consistently across three unrelated repos that use `release_single_app: true` (`br-sta`, `midaz`, `plugin-access-manager`) — S3 Upload succeeds on stable `vX.Y.Z` tags but is skipped on every `-beta.`/`-rc.` tag, despite `build` completing successfully with `has_builds: true` in every case (Notify job also confirms success; `update_gitops`, which does check `has_builds`, ran and succeeded in the same runs).
- Fix: relax the gate to `needs.build.result != 'failure' && needs.build.outputs.has_builds == 'true'`, since `has_builds` propagates reliably as a plain job output rather than a derived job conclusion.

## Evidence
Reproduced the skip on real production runs:
- br-sta `v1.0.0-rc.3`: https://github.com/LerianStudio/br-sta/actions/runs/29526404964/job/87717900622 — build succeeded (`Build br-sta-worker`, `Build br-sta-manager`), `update_gitops` ran and succeeded, S3 Upload skipped.
- plugin-access-manager: same skip pattern on `v3.1.0-beta.64`, `v3.1.0-beta.63`, `v3.1.0-rc.5`; succeeds on stable `v3.0.7`.
- midaz `v3.8.0-beta.34`: same skip pattern.
- Repos without `release_single_app` (e.g. `plugin-br-bank-transfer`) don't reproduce this — their primary build matrix has exactly one entry, which appears to avoid whatever GitHub-side inconsistency affects multi-entry matrices wrapped in a nested reusable-workflow call.

## Test plan
- [ ] `develop` prerelease tag push on a `release_single_app` + `s3_uploads` consumer (e.g. br-sta) shows S3 Upload running instead of skipped
- [ ] Existing stable-tag path (already working) stays green