### PR TITLE
fix(go-release): add explicit !cancelled() to s3_upload gate

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -378,8 +378,13 @@ jobs:
     # reusable workflow with an internal matrix, and its caller result does
     # not always surface as 'success' to dependents even when every matrix
     # leg passed (same issue update_gitops and ungoliant_release_diff already
-    # guard against below with the has_builds output check).
-    if: github.ref_type == 'tag' && inputs.s3_uploads != '' && needs.build.result != 'failure' && needs.build.outputs.has_builds == 'true'
+    # guard against below with the has_builds output check). !cancelled() is
+    # required too: without an explicit status-check function, GitHub Actions
+    # implicitly prepends success() to this condition, which re-imposes the
+    # exact unreliable needs.build status check this fix works around.
+    if: >-
+      !cancelled() && github.ref_type == 'tag' && inputs.s3_uploads != '' &&
+      needs.build.result != 'failure' && needs.build.outputs.has_builds == 'true'
     runs-on: ${{ inputs.runner_type }}
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Follow-up to #586. CodeRabbit correctly flagged that the `s3_upload` job's `if:` had no explicit status-check function (`success()`/`always()`/`failure()`/`cancelled()`), so GitHub Actions implicitly prepends `success()` to it.
- That implicit `success()` re-imposes the exact unreliable `needs.build` status check #586 was trying to work around — meaning #586 alone did not actually fix the original skip.
- Adds `!cancelled()` explicitly, mirroring the pattern `update_gitops` already uses in this same file for the same reason.

## Related
Addresses review comment on #587: https://github.com/LerianStudio/github-actions-shared-workflows/pull/587#discussion_r3598487703