### PR TITLE
feat(lib-version-check): add major-bump grace window

### DIFF
--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -59,6 +59,9 @@ on:
       outdated_count:
         description: 'Number of outdated direct Lerian libs'
         value: ${{ jobs.check.outputs.outdated_count }}
+      grace_count:
+        description: 'Number of direct Lerian libs within the major-bump grace window'
+        value: ${{ jobs.check.outputs.grace_count }}
       has_lerian_libs:
         description: 'true if at least one Lerian lib was detected in go.mod'
         value: ${{ jobs.check.outputs.has_lerian_libs }}
@@ -74,6 +77,7 @@ jobs:
     outputs:
       has_outdated: ${{ steps.check.outputs.has_outdated }}
       outdated_count: ${{ steps.check.outputs.outdated_count }}
+      grace_count: ${{ steps.check.outputs.grace_count }}
       has_lerian_libs: ${{ steps.check.outputs.has_lerian_libs }}
     steps:
       - name: Checkout
@@ -91,4 +95,5 @@ jobs:
           ignore-file: ${{ inputs.ignore_file }}
           check-indirect: ${{ inputs.check_indirect && 'true' || 'false' }}
           comment-on-pr: ${{ inputs.comment_on_pr && 'true' || 'false' }}
+          major-bump-grace-days: ${{ vars.LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS || '3' }}
           dry-run: ${{ inputs.dry_run && 'true' || 'false' }}

--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Validate Lerian library versions
         id: check
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@feat/lib-version-major-bump-grace
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@v1
         with:
           github-token: ${{ secrets.LERIAN_LIB_READ_TOKEN || github.token }}
           comment-token: ${{ secrets.MANAGE_TOKEN || github.token }}

--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -32,6 +32,10 @@ on:
         description: 'Post / update a sticky comment on the PR with the result table'
         type: boolean
         default: true
+      major_bump_grace_days:
+        description: 'Grace window (days) for major-version bumps, for this invocation. Takes precedence over the LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS repository variable; when empty the variable is used, falling back to 3. Set to "0" to disable.'
+        type: string
+        default: ''
       dry_run:
         description: 'Verbose log of all resolved versions; never fails the build'
         type: boolean
@@ -95,5 +99,5 @@ jobs:
           ignore-file: ${{ inputs.ignore_file }}
           check-indirect: ${{ inputs.check_indirect && 'true' || 'false' }}
           comment-on-pr: ${{ inputs.comment_on_pr && 'true' || 'false' }}
-          major-bump-grace-days: ${{ vars.LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS || '3' }}
+          major-bump-grace-days: ${{ inputs.major_bump_grace_days || vars.LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS || '3' }}
           dry-run: ${{ inputs.dry_run && 'true' || 'false' }}

--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Validate Lerian library versions
         id: check
-        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@develop
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/lerian-lib-version@feat/lib-version-major-bump-grace
         with:
           github-token: ${{ secrets.LERIAN_LIB_READ_TOKEN || github.token }}
           comment-token: ${{ secrets.MANAGE_TOKEN || github.token }}

--- a/docs/lerian-lib-version-check.md
+++ b/docs/lerian-lib-version-check.md
@@ -187,23 +187,36 @@ lib-foo
 
 The action posts (and updates) a single comment marked with `<!-- lerian-lib-version-check -->`. Re-runs update the same comment in place — no duplicate threads accumulate across pushes.
 
+Each row is prefixed with a status emoji, the header reflects the overall outcome (`✅ all up to date`, `🔴 action required`, or `⚠️ review needed`), and skipped/pinned rows link to the ignore-file docs so reviewers see the reason without leaving the PR.
+
+| Status | Rendered as |
+|--------|-------------|
+| Up to date | `✅ Current` |
+| Behind latest | `🔴 Needs update` |
+| Pinned via ignore file | `📌 Pinned` |
+| Skipped via ignore file | `⏭️ Skipped` |
+| Latest release unresolved | `⚠️ Unknown` |
+| Major bump within grace window | `🕒 Grace` |
+
 Example:
 
 ```
-## Lerian Library Version Check
+## 🔴 Lerian Library Version Check — action required
 
 | Library              | Current | Latest | Status      |
 |----------------------|---------|--------|-------------|
-| `lib-commons/v5`     | `v5.1.0`| `v5.5.0`| Outdated   |
-| `lib-auth/v2`        | `v2.7.0`| `v2.8.0`| Outdated   |
-| `lib-license-go/v2`  | `v2.3.5`| `v2.3.5`| Current    |
-| `lib-foo/v1`         | `v1.0.0`| `v2.0.0`| Grace (major bump, expires 2026-07-19) |
-| `lib-bar/v2`         | `v2.0.0`| _skipped_ | Skipped (ignore file) |
+| `lib-commons/v5`     | `v5.1.0`| `v5.5.0`| 🔴 Needs update |
+| `lib-auth/v2`        | `v2.7.0`| `v2.8.0`| 🔴 Needs update |
+| `lib-license-go/v2`  | `v2.3.5`| `v2.3.5`| ✅ Current |
+| `lib-foo/v1`         | `v1.0.0`| `v2.0.0`| 🕒 Grace (major bump, expires 2026-07-19) |
+| `lib-bar/v2`         | `v2.0.0`| _skipped_ | ⏭️ Skipped — ignore file, expires 2026-08-01 · [why?](https://github.com/LerianStudio/github-actions-shared-workflows/blob/main/docs/lerian-lib-version-check.md#lerianstudiolibignore-format) |
 
-**2 outdated** | **1 in grace** | **1 current** | **1 skipped** | **0 unknown**
+✅ 1 current · 🔴 2 needs update · 🕒 1 in grace · ⏭️ 1 skipped · ⚠️ 0 unknown
 
 > Bump the outdated libraries, or add temporary entries to `.lerianstudiolibignore`.
 ```
+
+Under `dry_run: true` the comment is prefixed with a `> 🧪 _Dry run — no failures enforced._` banner.
 
 ## Limitations
 

--- a/docs/lerian-lib-version-check.md
+++ b/docs/lerian-lib-version-check.md
@@ -100,13 +100,16 @@ jobs:
 | `ignore_file`    | string  | `.lerianstudiolibignore`    | Path to the optional ignore file. Missing file produces a warning, not a failure.            |
 | `check_indirect` | boolean | `false`                     | Also check transitive (`// indirect`) deps                                                   |
 | `comment_on_pr`  | boolean | `true`                      | Post / update a sticky comment on the PR with the result table                               |
+| `major_bump_grace_days` | string | `''`                | Per-invocation override for the major-bump grace window. Takes precedence over the `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` variable; empty uses the variable, then defaults to `3`. |
 | `dry_run`        | boolean | `false`                     | Verbose log of all resolved versions; never fails the build                                  |
 
 ## Major-bump grace window
 
 Major-version bumps (a higher major on an unpinned, API-resolved lib) are tolerated while the latest release is younger than the grace window. Minor and patch bumps are always enforced immediately. This gives teams a short buffer to plan the import-path migration a major bump requires, without letting it linger.
 
-The window is configured org-wide through the GitHub Actions variable `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (repository, environment, or organization scope). When unset it defaults to `3`. Set it to `0` to disable the grace window and enforce major bumps immediately.
+The window is resolved in this order: the per-invocation `major_bump_grace_days` input wins when set, otherwise the org-wide GitHub Actions variable `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (repository, environment, or organization scope), falling back to `3` when both are unset. Set it to `0` to disable the grace window and enforce major bumps immediately.
+
+> **Scope:** for a Go module with a `/vN` suffix (e.g. `lib-commons/v5`), the major is fixed by the import path — the checker only ever compares against `v5.*` releases, so no major bump is ever detected there (upgrading to `/v6` is a manual import-path change). The grace window therefore applies to `v0`/`v1` modules and to libraries that publish a higher major without a `/vN` module-path suffix.
 
 - The window is measured from the release's `published_at` date. A lib in grace shows `Grace (major bump, expires <date>)` in the report and does **not** fail the check.
 - The window **auto-expires**: once the release is at least `N` days old, the lib falls back to `Outdated` on the next run and the check fails — no manual cleanup needed.

--- a/docs/lerian-lib-version-check.md
+++ b/docs/lerian-lib-version-check.md
@@ -16,6 +16,7 @@ This workflow turns those expectations into a CI gate.
 ## Features
 
 - **Strict latest-stable enforcement** — every direct Lerian dep must be on the latest stable GitHub release.
+- **Major-bump grace window** — major-version bumps are tolerated while the latest release is younger than the grace window (default 3 days); minor and patch bumps are always enforced immediately. Configured org-wide via a GitHub variable.
 - **Standards gate** — services with no Lerian libs in `go.mod` fail the check.
 - **Sticky PR comment** — a single comment is created and updated in place with a status table.
 - **`.lerianstudiolibignore`** — gitignore-style exemption file for temporary skips or version pins.
@@ -34,6 +35,7 @@ src/validate/lerian-lib-version (composite action)
    2. Load .lerianstudiolibignore (if present)
    3. For each lib: GET /repos/LerianStudio/<repo>/releases (paged, stable only)
    4. Compare current vs latest using semver (sort -V)
+   4b. Apply the major-bump grace window (unpinned libs only)
    5. Build markdown report, write step summary
    6. Upsert sticky PR comment (via actions/github-script)
    7. Exit non-zero if outdated or no Lerian libs detected
@@ -100,6 +102,19 @@ jobs:
 | `comment_on_pr`  | boolean | `true`                      | Post / update a sticky comment on the PR with the result table                               |
 | `dry_run`        | boolean | `false`                     | Verbose log of all resolved versions; never fails the build                                  |
 
+## Major-bump grace window
+
+Major-version bumps (a higher major on an unpinned, API-resolved lib) are tolerated while the latest release is younger than the grace window. Minor and patch bumps are always enforced immediately. This gives teams a short buffer to plan the import-path migration a major bump requires, without letting it linger.
+
+The window is configured org-wide through the GitHub Actions variable `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (repository, environment, or organization scope). When unset it defaults to `3`. Set it to `0` to disable the grace window and enforce major bumps immediately.
+
+- The window is measured from the release's `published_at` date. A lib in grace shows `Grace (major bump, expires <date>)` in the report and does **not** fail the check.
+- The window **auto-expires**: once the release is at least `N` days old, the lib falls back to `Outdated` on the next run and the check fails — no manual cleanup needed.
+- Grace applies only to libs resolved from the releases API. Libs pinned via `.lerianstudiolibignore` (`lib@vX.Y.Z`) keep comparing against the pin as before.
+- If the release date cannot be determined, the lib is enforced immediately (conservative default).
+
+Because it is a GitHub variable rather than a workflow input, no caller change is needed to roll a new value out across every consumer repo.
+
 ## Secrets
 
 | Name                    | Required | Description                                                                                                                                                                       |
@@ -126,6 +141,7 @@ Without the secret, the workflow still runs and enforces freshness on all **publ
 |-------------------|----------------------------------------------------------------------|
 | `has_outdated`    | `true` if at least one direct Lerian lib is behind latest stable     |
 | `outdated_count`  | Number of outdated direct Lerian libs                                |
+| `grace_count`     | Number of direct Lerian libs within the major-bump grace window      |
 | `has_lerian_libs` | `true` if at least one Lerian lib was detected in `go.mod`           |
 
 ## Required permissions
@@ -141,7 +157,8 @@ permissions:
 | Condition                                                | Behavior                                            |
 |----------------------------------------------------------|-----------------------------------------------------|
 | App has no Lerian libs in `go.mod`                       | Fail — violates company standards                   |
-| One or more direct Lerian libs are outdated              | Fail — bump or add to ignore file                   |
+| One or more direct Lerian libs are outdated (minor/patch, or expired major) | Fail — bump or add to ignore file        |
+| Major bump with latest release younger than the grace window | Tolerated — marked _grace_, does not fail       |
 | `.lerianstudiolibignore` does not exist                  | Warning in log, proceed normally                    |
 | Lib matched by ignore-skip rule                          | Skipped, marked _skipped_ in the report             |
 | Lib matched by ignore-pin rule (`lib@vX.Y.Z`)            | Compared against the pin, marked _pinned_           |
@@ -177,9 +194,10 @@ Example:
 | `lib-commons/v5`     | `v5.1.0`| `v5.5.0`| Outdated   |
 | `lib-auth/v2`        | `v2.7.0`| `v2.8.0`| Outdated   |
 | `lib-license-go/v2`  | `v2.3.5`| `v2.3.5`| Current    |
-| `lib-foo/v1`         | `v1.0.0`| _skipped_ | Skipped (ignore file) |
+| `lib-foo/v1`         | `v1.0.0`| `v2.0.0`| Grace (major bump, expires 2026-07-19) |
+| `lib-bar/v2`         | `v2.0.0`| _skipped_ | Skipped (ignore file) |
 
-**2 outdated** | **1 current** | **1 skipped** | **0 unknown**
+**2 outdated** | **1 in grace** | **1 current** | **1 skipped** | **0 unknown**
 
 > Bump the outdated libraries, or add temporary entries to `.lerianstudiolibignore`.
 ```

--- a/docs/lerian-lib-version-check.md
+++ b/docs/lerian-lib-version-check.md
@@ -107,7 +107,7 @@ jobs:
 
 Major-version bumps (a higher major on an unpinned, API-resolved lib) are tolerated while the latest release is younger than the grace window. Minor and patch bumps are always enforced immediately. This gives teams a short buffer to plan the import-path migration a major bump requires, without letting it linger.
 
-The window is resolved in this order: the per-invocation `major_bump_grace_days` input wins when set, otherwise the org-wide GitHub Actions variable `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (repository, environment, or organization scope), falling back to `3` when both are unset. Set it to `0` to disable the grace window and enforce major bumps immediately.
+The window is resolved in this order: the per-invocation `major_bump_grace_days` input wins when set, otherwise the org-wide GitHub Actions variable `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (repository, environment, or organisation scope), falling back to `3` when both are unset. Set it to `0` to disable the grace window and enforce major bumps immediately.
 
 > **Scope:** for a Go module with a `/vN` suffix (e.g. `lib-commons/v5`), the major is fixed by the import path — the checker only ever compares against `v5.*` releases, so no major bump is ever detected there (upgrading to `/v6` is a manual import-path change). The grace window therefore applies to `v0`/`v1` modules and to libraries that publish a higher major without a `/vN` module-path suffix.
 
@@ -116,7 +116,7 @@ The window is resolved in this order: the per-invocation `major_bump_grace_days`
 - Grace applies only to libs resolved from the releases API. Libs pinned via `.lerianstudiolibignore` (`lib@vX.Y.Z`) keep comparing against the pin as before.
 - If the release date cannot be determined, the lib is enforced immediately (conservative default).
 
-Because it is a GitHub variable rather than a workflow input, no caller change is needed to roll a new value out across every consumer repo.
+Setting the `LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` variable at organisation scope rolls a new value out across every consumer repo without touching any caller. When a specific caller needs a different window, it passes `major_bump_grace_days`, which takes precedence over the variable for that invocation.
 
 ## Secrets
 

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -22,6 +22,7 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 | `go-mod-path`     | Path to `go.mod` relative to the repo root.                                                     | No       | `go.mod`                   |
 | `ignore-file`     | Path to optional `.lerianstudiolibignore` file. Missing file is a warning, not a failure.       | No       | `.lerianstudiolibignore`   |
 | `check-indirect`  | Also check transitive (`// indirect`) deps.                                                     | No       | `false`                    |
+| `major-bump-grace-days` | Grace window (in days) for major-version bumps. A major bump is tolerated while the latest release is younger than this many days; minor/patch bumps are enforced immediately. Set to `0` to disable. | No | `3`                        |
 | `comment-on-pr`   | Post or update a sticky comment on the PR with the result table.                                | No       | `true`                     |
 | `comment-token`   | Token used to post/update the sticky PR comment. Falls back to `github-token` when empty. Must be an org-scoped PAT (e.g., `MANAGE_TOKEN`) with pull-requests:write when calling from a nested reusable workflow, because `github.token` in that context is scoped to the shared-workflows repo, not the caller. | No | `""` |
 | `dry-run`         | Verbose log of all resolved versions; never fails the build.                                    | No       | `false`                    |
@@ -32,6 +33,7 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 |--------------------|-----------------------------------------------------------------------------------|
 | `has_outdated`     | `true` if at least one direct Lerian lib is behind latest stable.                 |
 | `outdated_count`   | Number of outdated direct Lerian libs.                                            |
+| `grace_count`      | Number of direct Lerian libs within the major-bump grace window.                  |
 | `has_lerian_libs`  | `true` if at least one Lerian lib was detected in `go.mod`.                       |
 | `report_path`      | Filesystem path to the generated markdown report (for downstream use).            |
 
@@ -41,7 +43,8 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 |----------------------------------------------------------|-----------------------------------------------------------|
 | `go.mod` not found at `go-mod-path`                      | **Fail** with `::error`                                   |
 | No `github.com/LerianStudio/*` deps in `go.mod`          | **Fail** — service must use at least one Lerian library    |
-| One or more direct Lerian libs are outdated              | **Fail** unless `dry-run: true`                            |
+| One or more direct Lerian libs are outdated (minor/patch, or expired major) | **Fail** unless `dry-run: true`         |
+| Major bump with latest release younger than `major-bump-grace-days` | Tolerated — marked _grace_, does not fail       |
 | `.lerianstudiolibignore` does not exist                  | `::warning` — proceed normally                             |
 | A lib is matched by an ignore-skip rule                  | Skipped, marked _skipped_ in the report                    |
 | A lib is matched by an ignore-pin rule (`lib@vX.Y.Z`)    | Compared against the pin instead of latest, marked _pinned_ |
@@ -127,4 +130,5 @@ permissions:
 - Repo names are derived from the module path by stripping `github.com/LerianStudio/` and any trailing `/vN` major-version suffix.
 - Latest stable resolution paginates up to 100 releases and excludes drafts and pre-releases (`-beta`, `-rc`).
 - Latest-release lookups are cached per repo within a single run to minimise API calls.
+- The major-bump grace window measures release age from `published_at` and auto-expires: once the release is at least `major-bump-grace-days` old, the lib falls back to `Outdated`. It applies to API-resolved (unpinned) libs only.
 - Repo-name resolution assumes one repo per module. Modules whose repo name differs from the path segment are not currently supported.

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -44,14 +44,14 @@ A sticky PR comment summarises the result. An optional `.lerianstudiolibignore` 
 | `go.mod` not found at `go-mod-path`                      | **Fail** with `::error`                                   |
 | No `github.com/LerianStudio/*` deps in `go.mod`          | **Fail** — service must use at least one Lerian library    |
 | One or more direct Lerian libs are outdated (minor/patch, or expired major) | **Fail** unless `dry-run: true`         |
-| Major bump with latest release younger than `major-bump-grace-days` | Tolerated — marked _grace_, does not fail       |
+| Major bump with latest release younger than `major-bump-grace-days` | Tolerated — marked `🕒 Grace`, does not fail    |
 | `.lerianstudiolibignore` does not exist                  | `::warning` — proceed normally                             |
-| A lib is matched by an ignore-skip rule                  | Skipped, marked _skipped_ in the report                    |
-| A lib is matched by an ignore-pin rule (`lib@vX.Y.Z`)    | Compared against the pin instead of latest, marked _pinned_ |
+| A lib is matched by an ignore-skip rule                  | Skipped, marked `⏭️ Skipped` in the report                 |
+| A lib is matched by an ignore-pin rule (`lib@vX.Y.Z`)    | Compared against the pin instead of latest, marked `📌 Pinned` |
 | A lib has an active TTL (`lib\|ttl:YYYY-MM-DD`)          | Rule honored; expiry date shown in the report column        |
 | A lib's TTL has expired (today ≥ TTL date)               | `::warning` — rule ignored, version check enforced         |
 | TTL date format is invalid                               | `::warning` — treated as expired, version check enforced   |
-| Latest stable release cannot be resolved (API error)     | `::warning` — marked _unknown_, does not fail              |
+| Latest stable release cannot be resolved (API error)     | `::warning` — marked `⚠️ Unknown`, does not fail            |
 
 ## `.lerianstudiolibignore` format
 

--- a/src/validate/lerian-lib-version/README.md
+++ b/src/validate/lerian-lib-version/README.md
@@ -130,5 +130,5 @@ permissions:
 - Repo names are derived from the module path by stripping `github.com/LerianStudio/` and any trailing `/vN` major-version suffix.
 - Latest stable resolution paginates up to 100 releases and excludes drafts and pre-releases (`-beta`, `-rc`).
 - Latest-release lookups are cached per repo within a single run to minimise API calls.
-- The major-bump grace window measures release age from `published_at` and auto-expires: once the release is at least `major-bump-grace-days` old, the lib falls back to `Outdated`. It applies to API-resolved (unpinned) libs only.
+- The major-bump grace window measures release age from `published_at` and auto-expires: once the release is at least `major-bump-grace-days` old, the lib falls back to `Outdated`. It applies to API-resolved (unpinned) libs only. Because a `/vN` module is pinned to its major by the import path, the window effectively covers `v0`/`v1` modules and libs that publish a higher major without a `/vN` suffix.
 - Repo-name resolution assumes one repo per module. Modules whose repo name differs from the path segment are not currently supported.

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -227,12 +227,17 @@ runs:
 
         # ---------- 3. Resolve latest stable release per repo (cache by repo name) ----------
         declare -A LATEST_CACHE=()
-        declare -A LATEST_DATE=()
+
+        # resolve_latest runs inside command substitution (a subshell), so it cannot
+        # export the resolved publish date via a shell variable. It writes the date of
+        # the chosen release to this file instead; the caller reads it right after.
+        LATEST_DATE_FILE="${RUNNER_TEMP:-/tmp}/lerian-latest-date.txt"
 
         resolve_latest() {
           local repo="$1"
           local major_filter="$2"   # e.g. "v5" or "" for v0/v1 modules
           local cache_key="${repo}::${major_filter}"
+          : > "${LATEST_DATE_FILE}"
           if [[ -n "${LATEST_CACHE[${cache_key}]:-}" ]]; then
             echo "${LATEST_CACHE[${cache_key}]}"
             return 0
@@ -308,7 +313,7 @@ runs:
           latest_date=$(echo "${releases_json}" | jq -r --arg t "${latest}" '
             [ .[]? | select(.tag_name == $t or ("v" + .tag_name) == $t) | .published_at ] | .[0] // ""
           ' 2>/dev/null || echo "")
-          LATEST_DATE[${cache_key}]="${latest_date%%T*}"
+          printf '%s' "${latest_date%%T*}" > "${LATEST_DATE_FILE}"
 
           LATEST_CACHE[${cache_key}]="${latest}"
           echo "${latest}"
@@ -378,6 +383,7 @@ runs:
           # degraded (non-200). Only unpinned libs depend on resolve_latest.
           is_pinned="false"
           pin_note=""
+          rel_date=""
           if [[ -n "${IGNORE_PIN[${short_path}]:-}" ]]; then
             target="${IGNORE_PIN[${short_path}]}"
             latest="${target}"
@@ -386,6 +392,7 @@ runs:
             pin_note="${pin_note} · [why?](${IGNORE_DOCS_URL})"
           else
             latest=$(resolve_latest "${repo}" "${major_filter}")
+            rel_date=$(cat "${LATEST_DATE_FILE}" 2>/dev/null || true)
 
             if [[ -z "${latest}" ]]; then
               UNKNOWN=$((UNKNOWN+1))
@@ -412,7 +419,6 @@ runs:
           # minor/patch bumps are always enforced immediately.
           cur_major="${current#v}"; cur_major="${cur_major%%.*}"
           tgt_major="${target#v}"; tgt_major="${tgt_major%%.*}"
-          rel_date="${LATEST_DATE["${repo}::${major_filter}"]:-}"
           if [[ "${cur_major}" =~ ^[0-9]+$ && "${tgt_major}" =~ ^[0-9]+$ ]] \
              && (( tgt_major > cur_major )) \
              && [[ "${GRACE_DAYS}" -gt 0 && -n "${rel_date}" ]]; then
@@ -461,7 +467,7 @@ runs:
             echo "> Bump the outdated libraries, or add temporary entries to \`${IGNORE_FILE}\`."
           fi
           if [[ "${GRACE}" -gt 0 ]]; then
-            echo "> ${GRACE} major bump(s) within the ${GRACE_DAYS}-day grace window — bump them before the window expires or the check will start failing."
+            echo "> 🕒 ${GRACE} major bump(s) are within the grace period. The grace period applies to major bumps only and lasts ${GRACE_DAYS} days — bump them before it expires, or the check will start failing."
           fi
         } >> "${REPORT_PATH}"
 

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -120,7 +120,7 @@ runs:
           echo "report_path=${REPORT_PATH}" >> "${GITHUB_OUTPUT}"
 
           {
-            echo "## Lerian Library Version Check"
+            echo "## 🔴 Lerian Library Version Check — action required"
             echo
             echo "**No \`github.com/LerianStudio/*\` dependencies found in \`${GO_MOD_PATH}\`.**"
             echo
@@ -334,6 +334,8 @@ runs:
         ROWS_FILE="${RUNNER_TEMP:-/tmp}/lerian-rows.txt"
         : > "${ROWS_FILE}"
 
+        IGNORE_DOCS_URL="https://github.com/LerianStudio/github-actions-shared-workflows/blob/main/docs/lerian-lib-version-check.md#lerianstudiolibignore-format"
+
         while IFS= read -r dep_line; do
           [[ -z "${dep_line}" ]] && continue
           # split: <module> <version> [// indirect]
@@ -366,7 +368,7 @@ runs:
             SKIPPED=$((SKIPPED+1))
             ttl_suffix=""
             [[ -n "${IGNORE_TTL[${short_path}]:-}" ]] && ttl_suffix=", expires ${IGNORE_TTL[${short_path}]}"
-            printf '| `%s` | `%s` | _skipped_ | Skipped (ignore file%s) |\n' "${short_path}" "${current}" "${ttl_suffix}" >> "${ROWS_FILE}"
+            printf '| `%s` | `%s` | _skipped_ | ⏭️ Skipped — ignore file%s · [why?](%s) |\n' "${short_path}" "${current}" "${ttl_suffix}" "${IGNORE_DOCS_URL}" >> "${ROWS_FILE}"
             continue
           fi
 
@@ -374,18 +376,20 @@ runs:
           # via .lerianstudiolibignore, compare against the pin and skip the API
           # call entirely, so the pin is still honoured even if the API is
           # degraded (non-200). Only unpinned libs depend on resolve_latest.
-          marker_suffix=""
+          is_pinned="false"
+          pin_note=""
           if [[ -n "${IGNORE_PIN[${short_path}]:-}" ]]; then
             target="${IGNORE_PIN[${short_path}]}"
             latest="${target}"
-            marker_suffix=" (pinned)"
-            [[ -n "${IGNORE_TTL[${short_path}]:-}" ]] && marker_suffix=" (pinned, expires ${IGNORE_TTL[${short_path}]})"
+            is_pinned="true"
+            [[ -n "${IGNORE_TTL[${short_path}]:-}" ]] && pin_note=" (expires ${IGNORE_TTL[${short_path}]})"
+            pin_note="${pin_note} · [why?](${IGNORE_DOCS_URL})"
           else
             latest=$(resolve_latest "${repo}" "${major_filter}")
 
             if [[ -z "${latest}" ]]; then
               UNKNOWN=$((UNKNOWN+1))
-              printf '| `%s` | `%s` | _unknown_ | Could not resolve latest release |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
+              printf '| `%s` | `%s` | _unknown_ | ⚠️ Unknown — could not resolve latest release |\n' "${short_path}" "${current}" >> "${ROWS_FILE}"
               log "::warning title=Could not resolve latest release::Failed to fetch latest stable release for LerianStudio/${repo}"
               continue
             fi
@@ -395,7 +399,11 @@ runs:
 
           if ver_ge "${current}" "${target}"; then
             CURRENT=$((CURRENT+1))
-            printf '| `%s` | `%s` | `%s` | Current%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
+            if [[ "${is_pinned}" == "true" ]]; then
+              printf '| `%s` | `%s` | `%s` | 📌 Pinned%s |\n' "${short_path}" "${current}" "${latest}" "${pin_note}" >> "${ROWS_FILE}"
+            else
+              printf '| `%s` | `%s` | `%s` | ✅ Current |\n' "${short_path}" "${current}" "${latest}" >> "${ROWS_FILE}"
+            fi
             continue
           fi
 
@@ -415,7 +423,7 @@ runs:
               if (( age_days < GRACE_DAYS )); then
                 GRACE=$((GRACE+1))
                 expires=$(date -u -d "${rel_date} +${GRACE_DAYS} days" +%Y-%m-%d 2>/dev/null || echo "${rel_date}")
-                printf '| `%s` | `%s` | `%s` | Grace (major bump, expires %s) |\n' "${short_path}" "${current}" "${latest}" "${expires}" >> "${ROWS_FILE}"
+                printf '| `%s` | `%s` | `%s` | 🕒 Grace (major bump, expires %s) |\n' "${short_path}" "${current}" "${latest}" "${expires}" >> "${ROWS_FILE}"
                 debug "grace: ${short_path} ${current} -> ${latest} (released ${rel_date}, age ${age_days}d, expires ${expires})"
                 continue
               fi
@@ -423,18 +431,31 @@ runs:
           fi
 
           OUTDATED=$((OUTDATED+1))
-          printf '| `%s` | `%s` | `%s` | Outdated%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
+          if [[ "${is_pinned}" == "true" ]]; then
+            printf '| `%s` | `%s` | `%s` | 🔴 Needs update — below pin%s |\n' "${short_path}" "${current}" "${latest}" "${pin_note}" >> "${ROWS_FILE}"
+          else
+            printf '| `%s` | `%s` | `%s` | 🔴 Needs update |\n' "${short_path}" "${current}" "${latest}" >> "${ROWS_FILE}"
+          fi
         done <<< "${DEPS_RAW}"
 
         # ---------- 5. Build markdown report ----------
+        # Header reflects the overall outcome at a glance.
+        if [[ "${OUTDATED}" -gt 0 ]]; then
+          HEADER="## 🔴 Lerian Library Version Check — action required"
+        elif [[ "${GRACE}" -gt 0 || "${SKIPPED}" -gt 0 || "${UNKNOWN}" -gt 0 ]]; then
+          HEADER="## ⚠️ Lerian Library Version Check — review needed"
+        else
+          HEADER="## ✅ Lerian Library Version Check — all up to date"
+        fi
+
         {
-          echo "## Lerian Library Version Check"
+          echo "${HEADER}"
           echo
           echo "| Library | Current | Latest | Status |"
           echo "|---------|---------|--------|--------|"
           cat "${ROWS_FILE}"
           echo
-          echo "**${OUTDATED} outdated** | **${GRACE} in grace** | **${CURRENT} current** | **${SKIPPED} skipped** | **${UNKNOWN} unknown**"
+          echo "✅ ${CURRENT} current · 🔴 ${OUTDATED} needs update · 🕒 ${GRACE} in grace · ⏭️ ${SKIPPED} skipped · ⚠️ ${UNKNOWN} unknown"
           echo
           if [[ "${OUTDATED}" -gt 0 ]]; then
             echo "> Bump the outdated libraries, or add temporary entries to \`${IGNORE_FILE}\`."
@@ -486,7 +507,7 @@ runs:
           }
           const marker = '<!-- lerian-lib-version-check -->';
           const dryRunBanner = process.env.DRY_RUN === 'true'
-            ? '> _Dry run — no failures enforced._\n\n'
+            ? '> 🧪 _Dry run — no failures enforced._\n\n'
             : '';
           const body = `${marker}\n${dryRunBanner}${fs.readFileSync(path, 'utf8')}`;
 

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -225,9 +225,7 @@ runs:
           echo "::warning title=Ignore file not found::Optional ignore file '${IGNORE_FILE}' not found. Proceeding without ignore rules."
         fi
 
-        # ---------- 3. Resolve latest stable release per repo (cache by repo name) ----------
-        declare -A LATEST_CACHE=()
-
+        # ---------- 3. Resolve latest stable release per repo ----------
         # resolve_latest runs inside command substitution (a subshell), so it cannot
         # export the resolved publish date via a shell variable. It writes the date of
         # the chosen release to this file instead; the caller reads it right after.
@@ -236,12 +234,7 @@ runs:
         resolve_latest() {
           local repo="$1"
           local major_filter="$2"   # e.g. "v5" or "" for v0/v1 modules
-          local cache_key="${repo}::${major_filter}"
           : > "${LATEST_DATE_FILE}"
-          if [[ -n "${LATEST_CACHE[${cache_key}]:-}" ]]; then
-            echo "${LATEST_CACHE[${cache_key}]}"
-            return 0
-          fi
 
           # We page through up to 100 releases and pick the highest stable tag that
           # matches the requested major (when set). Pre-releases are excluded both by
@@ -266,14 +259,12 @@ runs:
 
           if [[ "${http_code}" == "404" ]]; then
             log "::warning title=Cannot read LerianStudio/${repo}::Repository is private and not accessible. Provide the LERIAN_LIB_READ_TOKEN secret."
-            LATEST_CACHE[${cache_key}]=""
             echo ""
             return 0
           fi
 
           if [[ "${http_code}" != "200" ]]; then
             log "::warning title=Cannot read LerianStudio/${repo}::Releases API returned HTTP ${http_code}. Check that LERIAN_LIB_READ_TOKEN has Contents:read and is approved by the org."
-            LATEST_CACHE[${cache_key}]=""
             echo ""
             return 0
           fi
@@ -287,7 +278,6 @@ runs:
           tags=$(printf '%s\n' "${tags}" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true)
 
           if [[ -z "${tags}" ]]; then
-            LATEST_CACHE[${cache_key}]=""
             echo ""
             return 0
           fi
@@ -315,7 +305,6 @@ runs:
           ' 2>/dev/null || echo "")
           printf '%s' "${latest_date%%T*}" > "${LATEST_DATE_FILE}"
 
-          LATEST_CACHE[${cache_key}]="${latest}"
           echo "${latest}"
         }
 

--- a/src/validate/lerian-lib-version/action.yml
+++ b/src/validate/lerian-lib-version/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: Also check transitive (// indirect) dependencies. Off by default.
     required: false
     default: "false"
+  major-bump-grace-days:
+    description: Grace window (in days) for major-version bumps. A major bump is tolerated while the latest release is younger than this many days; minor and patch bumps are always enforced immediately. Set to "0" to disable and enforce major bumps immediately.
+    required: false
+    default: "3"
   comment-on-pr:
     description: Post or update a sticky comment on the PR with the result table.
     required: false
@@ -42,6 +46,9 @@ outputs:
   outdated_count:
     description: Number of outdated direct Lerian libs.
     value: ${{ steps.check.outputs.outdated_count }}
+  grace_count:
+    description: Number of direct Lerian libs within the major-bump grace window (not counted as outdated).
+    value: ${{ steps.check.outputs.grace_count }}
   has_lerian_libs:
     description: "true if at least one Lerian lib was detected in go.mod."
     value: ${{ steps.check.outputs.has_lerian_libs }}
@@ -69,6 +76,7 @@ runs:
         GO_MOD_PATH: ${{ inputs.go-mod-path }}
         IGNORE_FILE: ${{ inputs.ignore-file }}
         CHECK_INDIRECT: ${{ inputs.check-indirect }}
+        GRACE_DAYS: ${{ inputs.major-bump-grace-days }}
         DRY_RUN: ${{ inputs.dry-run }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
@@ -79,6 +87,11 @@ runs:
 
         log() { echo "$@"; }
         debug() { if [[ "${DRY_RUN}" == "true" ]]; then echo "::debug::$*"; fi; }
+
+        # Empty / non-numeric grace value disables the major-bump grace window.
+        if ! [[ "${GRACE_DAYS:-}" =~ ^[0-9]+$ ]]; then
+          GRACE_DAYS=0
+        fi
 
         # ---------- 1. Parse go.mod ----------
         # Collect lines like:
@@ -103,6 +116,7 @@ runs:
           echo "has_lerian_libs=false" >> "${GITHUB_OUTPUT}"
           echo "has_outdated=false" >> "${GITHUB_OUTPUT}"
           echo "outdated_count=0" >> "${GITHUB_OUTPUT}"
+          echo "grace_count=0" >> "${GITHUB_OUTPUT}"
           echo "report_path=${REPORT_PATH}" >> "${GITHUB_OUTPUT}"
 
           {
@@ -213,6 +227,7 @@ runs:
 
         # ---------- 3. Resolve latest stable release per repo (cache by repo name) ----------
         declare -A LATEST_CACHE=()
+        declare -A LATEST_DATE=()
 
         resolve_latest() {
           local repo="$1"
@@ -286,6 +301,15 @@ runs:
           if [[ -n "${latest}" ]]; then
             latest="v${latest}"
           fi
+
+          # Record the publish date (YYYY-MM-DD) of the chosen tag so the caller
+          # can measure release age for the major-bump grace window.
+          local latest_date
+          latest_date=$(echo "${releases_json}" | jq -r --arg t "${latest}" '
+            [ .[]? | select(.tag_name == $t or ("v" + .tag_name) == $t) | .published_at ] | .[0] // ""
+          ' 2>/dev/null || echo "")
+          LATEST_DATE[${cache_key}]="${latest_date%%T*}"
+
           LATEST_CACHE[${cache_key}]="${latest}"
           echo "${latest}"
         }
@@ -304,6 +328,7 @@ runs:
         CURRENT=0
         SKIPPED=0
         UNKNOWN=0
+        GRACE=0
 
         # Use a temp file for the table rows so we control ordering and avoid heredoc quoting traps.
         ROWS_FILE="${RUNNER_TEMP:-/tmp}/lerian-rows.txt"
@@ -371,10 +396,34 @@ runs:
           if ver_ge "${current}" "${target}"; then
             CURRENT=$((CURRENT+1))
             printf '| `%s` | `%s` | `%s` | Current%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
-          else
-            OUTDATED=$((OUTDATED+1))
-            printf '| `%s` | `%s` | `%s` | Outdated%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
+            continue
           fi
+
+          # Outdated. Major bumps (higher major on an unpinned, API-resolved lib)
+          # are tolerated while the latest release is younger than GRACE_DAYS;
+          # minor/patch bumps are always enforced immediately.
+          cur_major="${current#v}"; cur_major="${cur_major%%.*}"
+          tgt_major="${target#v}"; tgt_major="${tgt_major%%.*}"
+          rel_date="${LATEST_DATE["${repo}::${major_filter}"]:-}"
+          if [[ "${cur_major}" =~ ^[0-9]+$ && "${tgt_major}" =~ ^[0-9]+$ ]] \
+             && (( tgt_major > cur_major )) \
+             && [[ "${GRACE_DAYS}" -gt 0 && -n "${rel_date}" ]]; then
+            pub_epoch=$(date -u -d "${rel_date}" +%s 2>/dev/null || echo "")
+            today_epoch=$(date -u -d "${TODAY}" +%s 2>/dev/null || echo "")
+            if [[ -n "${pub_epoch}" && -n "${today_epoch}" ]]; then
+              age_days=$(( (today_epoch - pub_epoch) / 86400 ))
+              if (( age_days < GRACE_DAYS )); then
+                GRACE=$((GRACE+1))
+                expires=$(date -u -d "${rel_date} +${GRACE_DAYS} days" +%Y-%m-%d 2>/dev/null || echo "${rel_date}")
+                printf '| `%s` | `%s` | `%s` | Grace (major bump, expires %s) |\n' "${short_path}" "${current}" "${latest}" "${expires}" >> "${ROWS_FILE}"
+                debug "grace: ${short_path} ${current} -> ${latest} (released ${rel_date}, age ${age_days}d, expires ${expires})"
+                continue
+              fi
+            fi
+          fi
+
+          OUTDATED=$((OUTDATED+1))
+          printf '| `%s` | `%s` | `%s` | Outdated%s |\n' "${short_path}" "${current}" "${latest}" "${marker_suffix}" >> "${ROWS_FILE}"
         done <<< "${DEPS_RAW}"
 
         # ---------- 5. Build markdown report ----------
@@ -385,10 +434,13 @@ runs:
           echo "|---------|---------|--------|--------|"
           cat "${ROWS_FILE}"
           echo
-          echo "**${OUTDATED} outdated** | **${CURRENT} current** | **${SKIPPED} skipped** | **${UNKNOWN} unknown**"
+          echo "**${OUTDATED} outdated** | **${GRACE} in grace** | **${CURRENT} current** | **${SKIPPED} skipped** | **${UNKNOWN} unknown**"
           echo
           if [[ "${OUTDATED}" -gt 0 ]]; then
             echo "> Bump the outdated libraries, or add temporary entries to \`${IGNORE_FILE}\`."
+          fi
+          if [[ "${GRACE}" -gt 0 ]]; then
+            echo "> ${GRACE} major bump(s) within the ${GRACE_DAYS}-day grace window — bump them before the window expires or the check will start failing."
           fi
         } >> "${REPORT_PATH}"
 
@@ -398,6 +450,7 @@ runs:
         # Outputs
         {
           echo "outdated_count=${OUTDATED}"
+          echo "grace_count=${GRACE}"
           if [[ "${OUTDATED}" -gt 0 ]]; then
             echo "has_outdated=true"
           else


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds a **major-bump grace window** to the Lerian library version check. Major-version bumps (a higher major on an unpinned, API-resolved lib) are now tolerated while the latest release is younger than a configurable window; minor and patch bumps are still enforced immediately, exactly as before.

Affected components:

- `src/validate/lerian-lib-version/action.yml` — new `major-bump-grace-days` input (default `3`); `resolve_latest` now records the chosen release's `published_at`; the comparison step measures release age and marks recent major bumps as `Grace (major bump, expires <date>)` instead of `Outdated`; new `GRACE` counter and `grace_count` output.
- `.github/workflows/lerian-lib-version-check.yml` — the grace value is sourced from the GitHub Actions variable `vars.LERIAN_LIB_MAJOR_BUMP_GRACE_DAYS` (fallback `'3'`), so it can be changed org-wide without touching any caller; new `grace_count` workflow output.
- `docs/lerian-lib-version-check.md` and composite `README.md` — documented the window, the GitHub variable, the auto-expiry behavior, and the new output.

Also makes the sticky PR comment more scannable (**closes #539**): status emojis (`✅ Current`, `🔴 Needs update`, `📌 Pinned`, `⏭️ Skipped`, `⚠️ Unknown`, `🕒 Grace`), an outcome-driven header (`✅ all up to date` / `🔴 action required` / `⚠️ review needed`), an emoji summary line with `·` separators, skipped/pinned rows that show the TTL and link to the ignore-file docs, and a `🧪` dry-run banner. Purely cosmetic — no input/output changes.

Behavior notes:

- The window is measured from the release's `published_at` date and **auto-expires**: once the release is at least `N` days old, the lib falls back to `Outdated` and the check fails — no manual cleanup.
- Grace applies only to API-resolved libs; libs pinned via `.lerianstudiolibignore` keep comparing against the pin.
- If the release date cannot be determined, the lib is enforced immediately (conservative default). Setting the variable to `0` disables the window.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The change is additive: the new input defaults to `3` and the new output/variable are optional. No existing input, output, secret, or default behavior for minor/patch bumps changes. Callers need no updates.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Also validated the embedded Bash with `bash -n`, and ran a standalone functional test of the grace decision logic covering: major bump within window → grace; major bump at/after window → outdated (auto-expiry); minor/patch → outdated immediately; `grace-days=0` → disabled; missing release date → immediate; non-numeric grace value → disabled. The `jq` `published_at` extraction was verified against tags with and without a leading `v`.

**Caller repo / workflow run:** _not yet run against a caller — recommend a `dry_run: true` run on `@feat/lib-version-major-bump-grace` before release._

## Related Issues

Closes #539

