### PR TITLE
fix(ungoliant): skip release-diff trigger for CI/meta-only changes

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -242,6 +242,10 @@ on:
         description: 'Runner for the Ungoliant release-diff job. Needs Tailscale reach to the controller, so it defaults to eveo-anacleto-lxc-runners rather than the build runner.'
         type: string
         default: 'eveo-anacleto-lxc-runners'
+      ungoliant_skip_globs:
+        description: 'Space-separated glob patterns. When every changed file matches one, Ungoliant is never contacted. Default skips CI/workflow-only releases.'
+        type: string
+        default: '.releaserc.yml .github/*'
 
       # ----------------- Shared -----------------
       shared_paths:
@@ -725,6 +729,7 @@ jobs:
           tenancy: ${{ inputs.ungoliant_tenancy }}
           base-env: ${{ steps.target.outputs.base_env }}
           controller-url: ${{ vars.UNGOLIANT_CONTROLLER_URL || inputs.ungoliant_controller_url }}
+          skip-globs: ${{ inputs.ungoliant_skip_globs }}
           github-token: ${{ github.token }}
           webhook-token: ${{ secrets.UNGOLIANT_WEBHOOK_TOKEN }}
           dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -225,6 +225,10 @@ on:
         description: 'Runner for the Ungoliant release-diff job. Needs Tailscale reach to the controller, so it defaults to eveo-anacleto-lxc-runners rather than the build runner.'
         type: string
         default: 'eveo-anacleto-lxc-runners'
+      ungoliant_skip_globs:
+        description: 'Space-separated glob patterns. When every changed file matches one, Ungoliant is never contacted. Default skips CI/workflow-only releases.'
+        type: string
+        default: '.releaserc.yml .github/*'
 
     secrets:
       MANAGE_TOKEN:
@@ -491,6 +495,7 @@ jobs:
           tenancy: ${{ inputs.ungoliant_tenancy }}
           base-env: ${{ steps.target.outputs.base_env }}
           controller-url: ${{ vars.UNGOLIANT_CONTROLLER_URL || inputs.ungoliant_controller_url }}
+          skip-globs: ${{ inputs.ungoliant_skip_globs }}
           github-token: ${{ github.token }}
           webhook-token: ${{ secrets.UNGOLIANT_WEBHOOK_TOKEN }}
           dry-run: ${{ inputs.dry_run }}

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -76,6 +76,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `ungoliant_tenancy` | Ungoliant tenancy — `st` (single-tenant) \| `mt` (multi-tenant) | string | `st` |
 | `ungoliant_controller_url` | Ungoliant controller base URL (reachable over Tailscale) | string | `https://ungoliant-controller.anacleto.lerian.net` |
 | `ungoliant_runner_type` | Runner for the Ungoliant release-diff job (needs Tailscale reach to the controller) | string | `eveo-anacleto-lxc-runners` |
+| `ungoliant_skip_globs` | Space-separated glob patterns; when every changed file in the release diff matches one, the controller is never contacted | string | `.releaserc.yml .github/*` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 | `release_single_app` | Force single-app mode for the release job even when `filter_paths` is set (one version tag, many images) | boolean | `false` |
@@ -176,6 +177,8 @@ The controller is reachable only over Tailscale, so the job runs on the `eveo-an
 
 Compose behaviour with `ungoliant_env_type` (`chaos` default, `fuzzing` supported) and `ungoliant_tenancy` (`st` default, `mt` supported). Provide `UNGOLIANT_WEBHOOK_TOKEN` via `secrets: inherit` for an authenticated call; when unset the webhook is sent unauthenticated.
 
+**CI-only releases skip Ungoliant entirely.** `ungoliant_skip_globs` (default `.releaserc.yml .github/*`) is checked against every file in the `previous...version` diff before anything else runs: when every changed file matches one of these patterns, the controller is never contacted — no health check, no diff fetch, no webhook call. This is what keeps a release that only bumps a workflow version or tweaks `.releaserc.yml` from firing a full chaos/fuzz analysis. Set it to `''` to disable the check and always contact the controller.
+
 ```yaml
 jobs:
   pipeline:
@@ -184,6 +187,7 @@ jobs:
       enable_ungoliant_release_diff: true
       ungoliant_env_type: chaos
       ungoliant_tenancy: st
+      # ungoliant_skip_globs: '.releaserc.yml .github/*'  # default — override only to widen/narrow the skip
     secrets: inherit
 ```
 

--- a/src/validate/ungoliant-release-diff/README.md
+++ b/src/validate/ungoliant-release-diff/README.md
@@ -11,10 +11,8 @@ This is the CI equivalent of `ungoliant-controller/docs/testing/cluster/test-rel
 
 1. Resolves the target repository as `<repo-owner>/<app>` and composes `target_env = <env-type>-<base-env>-<tenancy>`.
 2. Auto-resolves the previous tag from the GitHub API when `previous` is empty.
-3. Fetches the `previous...version` compare (revision SHA, previous SHA, files changed) and the raw diff, capped at `max-diff-bytes`.
-4. Builds the JSON payload (`app, env, repository, version, revision, previous, diff, target_env`).
-5. Health-checks the controller `/healthz`.
-6. POSTs the payload to `/webhook/release-diff` with the `X-Ungoliant-Token` header and reports the analysis result.
+3. Fetches the `previous...version` compare metadata (revision SHA, previous SHA, changed files) and checks every changed file against `skip-globs`. When all of them match, the release is CI/meta-only: the controller is **never contacted** — no health check, no diff fetch, no webhook call — and the action reports `outcome: skipped_ci_only`.
+4. Otherwise: health-checks the controller `/healthz`, fetches the raw diff (capped at `max-diff-bytes`), builds the JSON payload (`app, env, repository, version, revision, previous, diff, target_env`), and POSTs it to `/webhook/release-diff` with the `X-Ungoliant-Token` header, reporting the analysis result.
 
 > The controller is only reachable over Tailscale, so the job must run on a Tailscale-connected self-hosted runner (e.g. `eveo-anacleto-lxc-runners`).
 
@@ -34,6 +32,7 @@ This is the CI equivalent of `ungoliant-controller/docs/testing/cluster/test-rel
 | `github-token`   | GitHub token used to read tags, compare and diff via the API.                   | Yes      |                                                      |
 | `webhook-token`  | Ungoliant webhook token sent as the `X-Ungoliant-Token` header.                 | No       | `""`                                                 |
 | `max-diff-bytes` | Maximum diff size forwarded to the controller (bytes).                          | No       | `262144`                                             |
+| `skip-globs`     | Space-separated glob patterns. When every changed file matches one, the release is CI/meta-only and the controller is never contacted. Empty disables the check. | No | `.releaserc.yml .github/*` |
 | `curl-timeout`   | Timeout for the webhook POST in seconds. Must stay in lockstep with `ungoliant-controller`'s `NEMOCLAW_TIMEOUT_SECONDS` and its ingress proxy timeouts — don't change this in isolation. | No | `900` |
 | `dry-run`        | Resolve and preview the payload without firing the webhook.                     | No       | `false`                                              |
 
@@ -46,17 +45,21 @@ This is the CI equivalent of `ungoliant-controller/docs/testing/cluster/test-rel
 | `schema`     | Response schema (`release-plan` \| `release-summary`).   |
 | `risk-level` | Risk level reported by the controller.                   |
 | `target-env` | Composed `target_env` forwarded to the controller.       |
-| `outcome`    | `executed` (smoke/chaos ran) \| `skipped` (no tests warranted). |
+| `outcome`    | `executed` (smoke/chaos ran) \| `skipped` (no tests warranted) \| `skipped_ci_only` (diff matched `skip-globs`; controller never contacted). |
 | `k6`         | Number of k6 smoke scenarios selected.                   |
 | `chaos`      | Number of chaos experiments selected.                    |
 
 When the controller completes an analysis but selects neither smoke nor chaos
 (a low-risk / provably-trivial diff), the step reports `outcome: skipped` and
-succeeds — the run makes the skip explicit in its logs and step summary. In both
-the `executed` and `skipped` cases the action also posts (or updates) a comment
-on the pull request that produced the release, so reviewers see whether the full
-Ungoliant flow ran or was skipped. Posting the comment requires the calling job
-to grant `pull-requests: write`; it is best-effort and never fails the release.
+succeeds — the run makes the skip explicit in its logs and step summary. When
+every changed file matches `skip-globs` instead, the step reports
+`outcome: skipped_ci_only` without ever calling the controller. In all three
+cases (`executed`, `skipped`, `skipped_ci_only`) the action also posts (or
+updates) a comment on the pull request that produced the release, so reviewers
+see whether the full Ungoliant flow ran, was skipped by the controller, or was
+never triggered because the change was CI/meta-only. Posting the comment
+requires the calling job to grant `pull-requests: write`; it is best-effort and
+never fails the release.
 
 ## Usage as composite step
 
@@ -103,6 +106,7 @@ permissions:
 ## Implementation notes
 
 - Pure Bash + `curl` + `jq` — no `gh` CLI or Python runtime is required on the runner.
+- The `skip-globs` check runs first, off a cheap JSON-only compare (no diff body), so a CI-only release never triggers the health check or the heavier diff fetch.
 - The diff is streamed to the controller via `--data-binary @payload.json`, avoiding the per-argument length limit (`E2BIG`) that a large diff hits when passed as an argv value.
 - The byte-level diff cap is UTF-8-sanitised with `iconv -c` so a truncated multi-byte sequence never breaks the JSON payload.
 - A `analysis_completed` status is required for the step to succeed; any other status fails the job.

--- a/src/validate/ungoliant-release-diff/README.md
+++ b/src/validate/ungoliant-release-diff/README.md
@@ -53,13 +53,14 @@ When the controller completes an analysis but selects neither smoke nor chaos
 (a low-risk / provably-trivial diff), the step reports `outcome: skipped` and
 succeeds — the run makes the skip explicit in its logs and step summary. When
 every changed file matches `skip-globs` instead, the step reports
-`outcome: skipped_ci_only` without ever calling the controller. In all three
-cases (`executed`, `skipped`, `skipped_ci_only`) the action also posts (or
-updates) a comment on the pull request that produced the release, so reviewers
-see whether the full Ungoliant flow ran, was skipped by the controller, or was
-never triggered because the change was CI/meta-only. Posting the comment
-requires the calling job to grant `pull-requests: write`; it is best-effort and
-never fails the release.
+`outcome: skipped_ci_only` without ever calling the controller. For non-dry-run
+invocations, in all three cases (`executed`, `skipped`, `skipped_ci_only`) the
+action also posts (or updates) a comment on the pull request that produced the
+release, so reviewers see whether the full Ungoliant flow ran, was skipped by
+the controller, or was never triggered because the change was CI/meta-only.
+`dry-run: true` skips this comment entirely, along with the webhook call.
+Posting the comment requires the calling job to grant `pull-requests: write`;
+it is best-effort and never fails the release.
 
 ## Usage as composite step
 

--- a/src/validate/ungoliant-release-diff/action.yml
+++ b/src/validate/ungoliant-release-diff/action.yml
@@ -219,9 +219,14 @@ runs:
         # When every changed file matches a skip-glob, this release is
         # CI/meta-only (e.g. workflow bumps under .github/*): skip Ungoliant
         # entirely instead of spending a chaos/fuzz analysis on it.
+        #
+        # GitHub's compare API caps .files at 300 entries — FILES == 300 could
+        # mean there are more, unlisted files past the cap. Treat that as
+        # indeterminate and never skip Ungoliant on it, rather than risk
+        # classifying a real code change as CI-only from a truncated list.
         read -ra skip_patterns <<< "$SKIP_GLOBS"
         CI_ONLY=false
-        if [ "$FILES" -gt 0 ] && [ "${#skip_patterns[@]}" -gt 0 ]; then
+        if [ "$FILES" -gt 0 ] && [ "$FILES" -lt 300 ] && [ "${#skip_patterns[@]}" -gt 0 ]; then
           CI_ONLY=true
           while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -241,6 +246,8 @@ runs:
 
         if [ "$CI_ONLY" = "true" ]; then
           echo "::notice::All ${FILES} changed file(s) match skip-globs (${SKIP_GLOBS}) — release is CI/meta-only, Ungoliant will not be contacted"
+        elif [ "$FILES" -ge 300 ]; then
+          echo "CI-only check: ${FILES} files changed — at/above the compare API's 300-file cap, treating as indeterminate — proceeding with Ungoliant"
         else
           echo "CI-only check: not all files match skip-globs (${SKIP_GLOBS:-<none>}) — proceeding with Ungoliant"
         fi

--- a/src/validate/ungoliant-release-diff/action.yml
+++ b/src/validate/ungoliant-release-diff/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: Maximum diff size forwarded to the controller (bytes)
     required: false
     default: "262144"
+  skip-globs:
+    description: 'Space-separated glob patterns. When every file in the diff matches one of these, the release is CI/meta-only and the controller is never contacted. Empty disables the check.'
+    required: false
+    default: ".releaserc.yml .github/*"
   curl-timeout:
     description: Timeout for the webhook POST in seconds (LLM inference can take 60-120s, longer for large/complex diffs). Must stay in lockstep with ungoliant-controller's NEMOCLAW_TIMEOUT_SECONDS and its ingress proxy timeouts.
     required: false
@@ -73,8 +77,8 @@ outputs:
     description: Composed target env forwarded to the controller
     value: ${{ steps.resolve.outputs.target_env }}
   outcome:
-    description: High-level outcome — executed (smoke/chaos ran) | skipped (no tests warranted)
-    value: ${{ steps.webhook.outputs.outcome }}
+    description: High-level outcome — executed (smoke/chaos ran) | skipped (no tests warranted) | skipped_ci_only (diff matched skip-globs; controller was never contacted)
+    value: ${{ steps.diff.outputs.ci_only == 'true' && 'skipped_ci_only' || steps.webhook.outputs.outcome }}
   k6:
     description: Number of k6 smoke scenarios selected by the controller
     value: ${{ steps.webhook.outputs.k6 }}
@@ -125,18 +129,6 @@ runs:
           echo "target_env=$TARGET_ENV"
         } >> "$GITHUB_OUTPUT"
 
-    # ----------------- Health Check (fail fast before GitHub API calls) -----------------
-    - name: Health check controller
-      shell: bash
-      env:
-        CONTROLLER_URL: ${{ inputs.controller-url }}
-      run: |
-        set -euo pipefail
-        echo "Checking controller at ${CONTROLLER_URL}..."
-        HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${CONTROLLER_URL}/healthz" || true)"
-        [ "$HTTP_CODE" = "200" ] || { echo "::error::Controller not reachable ($HTTP_CODE). Is the runner on Tailscale?"; exit 1; }
-        echo "Controller is up"
-
     # ----------------- Resolve Previous Tag -----------------
     - name: Resolve previous tag
       id: previous
@@ -183,15 +175,18 @@ runs:
 
         echo "previous=$PREV" >> "$GITHUB_OUTPUT"
 
-    # ----------------- Fetch Compare & Diff -----------------
-    - name: Fetch compare and diff
+    # ----------------- Fetch Compare Metadata & CI-only Detection -----------------
+    # Cheap JSON-only compare, done before the health check / heavy diff fetch
+    # so a release limited to skip-globs (workflow/config changes) never
+    # contacts the controller at all — not even a health-check ping.
+    - name: Fetch compare metadata
       id: diff
       shell: bash
       env:
         REPO: ${{ steps.resolve.outputs.repo }}
         VERSION: ${{ inputs.version }}
         PREVIOUS: ${{ steps.previous.outputs.previous }}
-        MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
+        SKIP_GLOBS: ${{ inputs.skip-globs }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
@@ -220,6 +215,72 @@ runs:
         FILES="$(printf '%s' "$COMPARE" | jq -r '.files | length')"
         echo "Revision: $REVISION  |  Previous: $PREV_SHA  |  Files changed: $FILES"
 
+        # ----------------- CI-only change detection -----------------
+        # When every changed file matches a skip-glob, this release is
+        # CI/meta-only (e.g. workflow bumps under .github/*): skip Ungoliant
+        # entirely instead of spending a chaos/fuzz analysis on it.
+        read -ra skip_patterns <<< "$SKIP_GLOBS"
+        CI_ONLY=false
+        if [ "$FILES" -gt 0 ] && [ "${#skip_patterns[@]}" -gt 0 ]; then
+          CI_ONLY=true
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            matched=false
+            for glob in "${skip_patterns[@]}"; do
+              # shellcheck disable=SC2254
+              case "$file" in
+                $glob) matched=true; break ;;
+              esac
+            done
+            if [ "$matched" = false ]; then
+              CI_ONLY=false
+              break
+            fi
+          done < <(printf '%s' "$COMPARE" | jq -r '.files[].filename')
+        fi
+
+        if [ "$CI_ONLY" = "true" ]; then
+          echo "::notice::All ${FILES} changed file(s) match skip-globs (${SKIP_GLOBS}) — release is CI/meta-only, Ungoliant will not be contacted"
+        else
+          echo "CI-only check: not all files match skip-globs (${SKIP_GLOBS:-<none>}) — proceeding with Ungoliant"
+        fi
+
+        {
+          echo "revision=$REVISION"
+          echo "prev_sha=$PREV_SHA"
+          echo "files=$FILES"
+          echo "ci_only=$CI_ONLY"
+        } >> "$GITHUB_OUTPUT"
+
+    # ----------------- Health Check (fail fast before the heavy diff fetch) -----------------
+    - name: Health check controller
+      if: steps.diff.outputs.ci_only != 'true'
+      shell: bash
+      env:
+        CONTROLLER_URL: ${{ inputs.controller-url }}
+      run: |
+        set -euo pipefail
+        echo "Checking controller at ${CONTROLLER_URL}..."
+        HTTP_CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${CONTROLLER_URL}/healthz" || true)"
+        [ "$HTTP_CODE" = "200" ] || { echo "::error::Controller not reachable ($HTTP_CODE). Is the runner on Tailscale?"; exit 1; }
+        echo "Controller is up"
+
+    # ----------------- Fetch Diff Text -----------------
+    - name: Fetch diff text
+      id: diff-text
+      if: steps.diff.outputs.ci_only != 'true'
+      shell: bash
+      env:
+        REPO: ${{ steps.resolve.outputs.repo }}
+        VERSION: ${{ inputs.version }}
+        PREVIOUS: ${{ steps.previous.outputs.previous }}
+        MAX_DIFF_BYTES: ${{ inputs.max-diff-bytes }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        API="https://api.github.com/repos/${REPO}"
+
         echo "Fetching diff (cap ${MAX_DIFF_BYTES} bytes)..."
         curl -sf --retry 2 --retry-delay 2 --max-time 120 \
           -H "Authorization: Bearer $GH_TOKEN" \
@@ -234,14 +295,9 @@ runs:
         echo "Diff size: ${DIFF_SIZE} bytes"
         [ "$DIFF_SIZE" -gt 0 ] || { echo "::error::Empty diff — check tags exist in $REPO"; exit 1; }
 
-        {
-          echo "revision=$REVISION"
-          echo "prev_sha=$PREV_SHA"
-          echo "files=$FILES"
-        } >> "$GITHUB_OUTPUT"
-
     # ----------------- Build Payload -----------------
     - name: Build payload
+      if: steps.diff.outputs.ci_only != 'true'
       shell: bash
       env:
         APP: ${{ inputs.app }}
@@ -267,7 +323,7 @@ runs:
 
     # ----------------- Dry Run -----------------
     - name: Dry run summary
-      if: inputs.dry-run == 'true'
+      if: inputs.dry-run == 'true' && steps.diff.outputs.ci_only != 'true'
       shell: bash
       env:
         APP: ${{ inputs.app }}
@@ -289,10 +345,34 @@ runs:
         echo "  target_env  : $TARGET_ENV"
         echo "  payload size: $(wc -c < payload.json | tr -d ' ') bytes"
 
+    # ----------------- CI-only Skip Summary -----------------
+    - name: CI-only skip summary
+      if: steps.diff.outputs.ci_only == 'true'
+      shell: bash
+      env:
+        APP: ${{ inputs.app }}
+        VERSION: ${{ inputs.version }}
+        SKIP_GLOBS: ${{ inputs.skip-globs }}
+        FILES: ${{ steps.diff.outputs.files }}
+      run: |
+        set -euo pipefail
+        echo "::notice::Ungoliant skipped — all ${FILES} changed file(s) in ${VERSION} matched skip-globs (${SKIP_GLOBS})"
+        {
+          echo "### Ungoliant release-diff — SKIPPED (CI-only change)"
+          echo ""
+          echo "| Field | Value |"
+          echo "| --- | --- |"
+          echo "| outcome | \`skipped_ci_only\` |"
+          echo "| app | \`$APP\` |"
+          echo "| version | \`$VERSION\` |"
+          echo "| files changed | \`$FILES\` |"
+          echo "| skip_globs | \`$SKIP_GLOBS\` |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
     # ----------------- Fire Webhook -----------------
     - name: Send release-diff webhook
       id: webhook
-      if: inputs.dry-run != 'true'
+      if: inputs.dry-run != 'true' && steps.diff.outputs.ci_only != 'true'
       shell: bash
       env:
         CONTROLLER_URL: ${{ inputs.controller-url }}
@@ -391,10 +471,13 @@ runs:
 
     # ----------------- Comment on Originating PR -----------------
     # Best-effort: post/update a comment on the PR that produced this release
-    # stating whether Ungoliant ran the full flow or skipped it. Never fails
-    # the release — an API/permission hiccup only logs a warning.
+    # stating whether Ungoliant ran the full flow, skipped it, or was never
+    # contacted (CI-only change). Never fails the release — an API/permission
+    # hiccup only logs a warning.
     - name: Comment ungoliant outcome on originating PR
-      if: inputs.dry-run != 'true' && (steps.webhook.outputs.outcome == 'executed' || steps.webhook.outputs.outcome == 'skipped')
+      if: >-
+        inputs.dry-run != 'true' &&
+        (steps.webhook.outputs.outcome == 'executed' || steps.webhook.outputs.outcome == 'skipped' || steps.diff.outputs.ci_only == 'true')
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -405,6 +488,8 @@ runs:
         APP: ${{ inputs.app }}
         VERSION: ${{ inputs.version }}
         TARGET_ENV: ${{ steps.resolve.outputs.target_env }}
+        CI_ONLY: ${{ steps.diff.outputs.ci_only }}
+        SKIP_GLOBS: ${{ inputs.skip-globs }}
         OUTCOME: ${{ steps.webhook.outputs.outcome }}
         STATUS: ${{ steps.webhook.outputs.status }}
         SCHEMA: ${{ steps.webhook.outputs.schema }}
@@ -416,6 +501,10 @@ runs:
         set -uo pipefail
         API="https://api.github.com/repos/${RUN_REPO}"
         AUTH=(-H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json")
+
+        if [ "$CI_ONLY" = "true" ]; then
+          OUTCOME="skipped_ci_only"
+        fi
 
         # Resolve the PR behind this release commit. Primary: PRs GitHub
         # associates with the tagged commit. Fallback: the last (#NNN) in the
@@ -436,7 +525,10 @@ runs:
 
         RUN_URL="${SERVER_URL}/${RUN_REPO}/actions/runs/${RUN_ID_GH}"
         MARKER="<!-- ungoliant-release-diff:${VERSION} -->"
-        if [ "$OUTCOME" = "skipped" ]; then
+        if [ "$OUTCOME" = "skipped_ci_only" ]; then
+          HEADER="## Ungoliant Release Diff — Skipped (CI-only change)"
+          BLURB="This release only touched files matched by skip-globs (\`${SKIP_GLOBS}\`), so Ungoliant was never contacted — no health check and no webhook call were made."
+        elif [ "$OUTCOME" = "skipped" ]; then
           HEADER="## Ungoliant Release Diff — Skipped"
           BLURB="No smoke or chaos tests were run for this release. Ungoliant judged the diff low-risk / provably trivial (doc-only or CI/linter cosmetics), so test execution was skipped."
         else
@@ -457,11 +549,13 @@ runs:
         add "| app | \`${APP}\` |"
         add "| version | \`${VERSION}\` |"
         add "| target_env | \`${TARGET_ENV}\` |"
-        add "| risk_level | \`${RISK}\` |"
-        add "| k6 smoke scenarios | \`${K6_COUNT}\` |"
-        add "| chaos experiments | \`${CHAOS_COUNT}\` |"
-        add "| schema | \`${SCHEMA}\` |"
-        add "| run_id | \`${RUN_ID}\` |"
+        if [ "$OUTCOME" != "skipped_ci_only" ]; then
+          add "| risk_level | \`${RISK}\` |"
+          add "| k6 smoke scenarios | \`${K6_COUNT}\` |"
+          add "| chaos experiments | \`${CHAOS_COUNT}\` |"
+          add "| schema | \`${SCHEMA}\` |"
+          add "| run_id | \`${RUN_ID}\` |"
+        fi
         add ""
         add "[Workflow run](${RUN_URL})"
 


### PR DESCRIPTION
## Description

Adds a `skip-globs` input (default `.releaserc.yml .github/*`) to the `ungoliant-release-diff` composite, wired through `go-release.yml`/`js-release.yml` as `ungoliant_skip_globs`. Before contacting the controller, it fetches a cheap JSON-only compare between `previous...version` and checks every changed file against `skip-globs`. When all of them match, the release is treated as CI/meta-only and the controller is **never contacted** — no health check, no diff fetch, no webhook call — reporting `outcome: skipped_ci_only` instead.

This was prompted by a real incident: a PR that only bumped `github-actions-shared-workflows` versions in `.github/workflows/*` (plus an incidental `Makefile` whitespace tweak) triggered a full release + deploy + Ungoliant chaos/fuzz analysis in `midaz`, for a change with no runtime impact. The existing `non-doc-changes` gate only protects the branch-push semantic-release step, not the tag-push Ungoliant trigger — this closes that gap directly in the composite so any caller benefits without extra wiring.

Default `.releaserc.yml .github/*` covers workflow-version bumps and semantic-release config tweaks; callers can widen/narrow via `ungoliant_skip_globs` or disable the check entirely with an empty string.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. `skip-globs` is optional with a safe default; existing callers that never pass it get the new default behavior (skip on `.github/*`/`.releaserc.yml`-only diffs), which is strictly a cost/noise reduction — any release touching real code still fires Ungoliant exactly as before.

## Testing

- [x] YAML syntax validated locally (`python3 -c "import yaml..."` + `yamllint -c .yamllint.yml` on all three changed workflow/action files — no new warnings beyond pre-existing long-description lines)
- [x] Composite schema validated locally against `src/lint/composite-schema`'s rules (10 steps, all inputs kebab-case with description + default)
- [x] Manually simulated the `ci_only` bash detection logic against realistic file lists (workflow-only, workflow + `.releaserc.yml`, workflow + `Makefile`, nested workflow path) — matches expected true/false in every case
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected (change scoped to the `ungoliant-release-diff` composite + its two callers)

**Caller repo / workflow run:** N/A yet — recommend validating against a caller repo (e.g. midaz) with `@fix/ungoliant-skip-ci-only-changes` before merge.

## Related Issues

