### PR TITLE
fix(deployment-matrix): register br-sisbajud (benedita + anacleto)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -83,6 +83,7 @@ apps:
     - br-sta
     - br-slc
     - br-ccs
+    - br-sisbajud
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -123,6 +124,7 @@ clusters:
       - plugin-fees
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch
+      - br-sisbajud
       - ungoliant-controller
 
   benedita:
@@ -169,6 +171,7 @@ clusters:
       - br-sta
       - br-slc
       - br-ccs
+      - br-sisbajud
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
## Description

br-sisbajud releases fail in `gitops-update` with:

> App 'br-sisbajud' is not registered in any cluster of the deployment matrix.

and produce an empty ArgoCD-sync target matrix (the sync job is skipped with an un-interpolated name). The app is deployed but never synced.

`br-sisbajud` deploys on:
- **benedita** — `dev-st`, `stg-st`, `prd-st`, `stg-mt`, `sandbox`
- **anacleto** — `fuzzing` and `chaos`, `dev-st` / `dev-mt`

This registers it in `apps.registry` and both clusters' `apps` lists.

## Why a hotfix to main

`gitops-update` reads the deployment matrix from `main` (`deployment_matrix_ref` defaults to `main`), so consumers pinned to older `go-release` tags (e.g. br-sisbajud on `@v1.40.3`) pick this up immediately once merged — no consumer bump needed.

## Type of Change
- [x] `fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)