### PR TITLE
fix(release): default enable_dockerhub to true and drop js/ts tag aliases

### DIFF
--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -78,7 +78,7 @@ on:
       enable_dockerhub:
         description: 'Enable pushing to DockerHub'
         type: boolean
-        default: false
+        default: true
       enable_ghcr:
         description: 'Enable pushing to GitHub Container Registry'
         type: boolean

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -51,7 +51,7 @@ on:
       enable_dockerhub:
         description: 'Enable pushing to DockerHub'
         type: boolean
-        default: false
+        default: true
       enable_ghcr:
         description: 'Enable pushing to GitHub Container Registry'
         type: boolean


### PR DESCRIPTION
## Description

Two related fixes for JS/TS release builds, found while validating a `product-console` release run:

1. `js-release.yml` and `typescript-build.yml` had `enable_dockerhub` defaulting to `false`, unlike the Go equivalents (`go-release.yml`, `build.yml`), which already default to `true`. Aligned the default to `true` (matching `enable_ghcr`, already `true`).
2. Enabling DockerHub by default surfaced a real bug: `docker-build-ts/action.yml` generated `{{major}}.{{minor}}` and `{{major}}` tag aliases (e.g. `1.10`, `1`) in addition to the full version tag. Those aliases get overwritten on every release, which fails against DockerHub's tag immutability settings (confirmed failure: https://github.com/LerianStudio/product-console/actions/runs/29610036488/job/88460375913). Go's `build.yml` never generated these aliases — only the full semver tag — so removed the aliases and the now-unused `is-release` input from `docker-build-ts` to match Go's behavior.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

- Callers of `js-release.yml`/`typescript-build.yml` that do not explicitly set `enable_dockerhub` will now also push images to DockerHub, not just GHCR. Repos that should NOT publish to DockerHub must set `enable_dockerhub: false` explicitly.
- Images built via `docker-build-ts` no longer get `{{major}}.{{minor}}` or `{{major}}` tag aliases (e.g. `1.10`, `1`) — only the full version tag (e.g. `1.10.0`), matching Go's tagging behavior. Any consumer relying on those alias tags must switch to the full version tag.

## Testing

- [x] YAML syntax validated locally
- [x] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** https://github.com/LerianStudio/product-console/actions/runs/29610036488 (failure that led to fix #2)

## Related Issues

Closes #