### PR TITLE
feat(matrix): register lender for gitops auto-bump

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -80,6 +80,7 @@ apps:
     - plugin-br-payments
     - plugin-bc-correios
     - underwriter
+    - lender                      # credit journey engine (Underwriter family); UI console pin (lenderConsole.image.tag) is bumped manually, not by this workflow
     - br-sta
     - br-slc
     - br-ccs
@@ -125,6 +126,7 @@ clusters:
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch
       - br-sisbajud
+      - lender
       - ungoliant-controller
 
   benedita:
@@ -168,6 +170,7 @@ clusters:
       - plugin-br-payments
       - plugin-bc-correios
       - underwriter
+      - lender
       - br-sta
       - br-slc
       - br-ccs


### PR DESCRIPTION
## Problem

`lender` was never registered in `config/deployment-matrix.yml`, so `gitops-update.yml` resolves **zero clusters** for it. Releases publish images to GHCR fine (latest: `lender:1.0.0-beta.51` + `lender-ui:1.0.0-beta.51`), but the gitops dispatch never bumps the repo pins — dev-st is still pinned to `1.0.0-beta.49`.

## Fix

Register `lender` in three places:
- `apps.registry` (adjacent to `underwriter` — same credit family)
- `clusters.benedita.apps` — live tiers: `dev-st`/`stg-st`/`prd-st`/`sandbox`; the `-mt` suffix expansion hits paths that don't exist and warn-and-skips (same as several existing apps)
- `clusters.anacleto.apps` — the chaos/fuzzing parity dirs exist for lender (`{chaos,fuzzing}/{dev-st,dev-mt}`). Registering benedita-only would have the bot push bumps straight to `main` for benedita while anacleto drifts stale (the same drift class we hit with lerian-map).

The caller side is already configured: lender `release.yml` has `enable_gitops_artifacts: true` + `gitops_yaml_key_mappings: '{"lender.tag": ".lender.image.tag"}'`. The `lenderConsole` UI pin remains manually bumped (fleet convention) — this registers only the API image.

Matrix is read at `main` → takes effect on the next release with no caller re-pin. The `beta.51` catch-up bump will be done by hand in gitops (this PR only fixes the automation going forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcf1au1N6J3MMDxLnjC7Da