### PR TITLE
fix(deployment-matrix): register lender (benedita + anacleto)

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -80,6 +80,7 @@ apps:
     - plugin-br-payments
     - plugin-bc-correios
     - underwriter
+    - lender                      # credit journey engine (Underwriter family); UI console pin (lenderConsole.image.tag) is bumped manually, not by this workflow
     - br-sta
     - br-slc
     - br-ccs
@@ -125,6 +126,7 @@ clusters:
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch
       - br-sisbajud
+      - lender
       - ungoliant-controller
 
   benedita:
@@ -168,6 +170,7 @@ clusters:
       - plugin-br-payments
       - plugin-bc-correios
       - underwriter
+      - lender
       - br-sta
       - br-slc
       - br-ccs


### PR DESCRIPTION
## Problem

`lender` was never registered in `config/deployment-matrix.yml`, so `gitops-update.yml` resolves **zero clusters** for it. Releases publish images fine (latest `lender:1.0.0-beta.51` + `lender-ui:1.0.0-beta.51` on GHCR), but the gitops pins never move — evidence from the `v1.0.0-beta.51` tag run: `update_gitops` completed with an **empty target matrix** (`ArgoCD Sync (${{ matrix.target.server }}/…)` skipped, unexpanded), dev-st still pinned to `1.0.0-beta.49`.

## Fix (mirrors #593 br-sisbajud / #585 br-slc)

Register `lender` in:
- `apps.registry` (adjacent to `underwriter` — same credit family)
- `clusters.benedita.apps` — live tiers `dev-st/stg-st/prd-st/sandbox`; the `-mt` suffix expansion warn-and-skips on missing paths (same as several existing apps)
- `clusters.anacleto.apps` — the `{chaos,fuzzing}/{dev-st,dev-mt}` lender dirs exist; benedita-only registration would have the bot bump benedita straight to `main` while anacleto drifts stale (the lerian-map drift class)

Caller side already configured: lender `release.yml` has `enable_gitops_artifacts: true` + `gitops_yaml_key_mappings: '{"lender.tag": ".lender.image.tag"}'`. The `lenderConsole` UI pin remains manually bumped (fleet convention).

Matrix is read at `main` (`deployment_matrix_ref` default) → effective on the next lender release, no caller re-pin. The `beta.51` catch-up will be a manual gitops bump.

Note: chart `appVersion` staying at beta is expected — `Dispatch Helm Update` only fires on stable releases unless `helm_dispatch_on_beta` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcf1au1N6J3MMDxLnjC7Da