### PR TITLE
feat: standardize runners via vars.RUNNER_LABEL

### DIFF
--- a/.github/workflows/api-dog-e2e-tests.yml
+++ b/.github/workflows/api-dog-e2e-tests.yml
@@ -49,7 +49,7 @@ on:
 
 jobs:
   api-dog-e2e-tests:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   # ----------------- Expand Rules -----------------
   expand:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     outputs:
       matrix: ${{ steps.expand.outputs.matrix }}
       has_pairs: ${{ steps.expand.outputs.has_pairs }}
@@ -137,7 +137,7 @@ jobs:
   sync:
     needs: expand
     if: needs.expand.outputs.has_pairs == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.expand.outputs.matrix) }}

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   cleanup:
     name: Clean up branches
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Run branch cleanup
         uses: LerianStudio/github-actions-shared-workflows/src/config/branch-cleanup@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_builds: ${{ steps.set-matrix.outputs.has_builds }}
@@ -273,7 +273,7 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.has_builds == 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     name: Build ${{ matrix.app.name }}
     permissions:
       contents: read

--- a/.github/workflows/dispatch-helm.yml
+++ b/.github/workflows/dispatch-helm.yml
@@ -97,7 +97,7 @@ on:
 jobs:
   prepare-and-dispatch:
     name: Prepare and Dispatch
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -75,7 +75,7 @@ permissions:
 jobs:
   end-to-end-tests:
     name: End-to-End Tests
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -196,7 +196,7 @@ jobs:
   # ============================================
   detect-changes:
     name: Detect Changes
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
       has_changes: ${{ steps.changed-paths.outputs.has_changes }}
@@ -220,7 +220,7 @@ jobs:
     name: Lint (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_lint
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -273,7 +273,7 @@ jobs:
     name: Type Check (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_typecheck
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -319,7 +319,7 @@ jobs:
     name: Security (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_security
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -373,7 +373,7 @@ jobs:
     name: Tests (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_tests
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -449,7 +449,7 @@ jobs:
     name: Coverage (${{ matrix.app.name }})
     needs: [detect-changes, tests]
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_coverage
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -585,7 +585,7 @@ jobs:
     name: Build (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_build
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -638,7 +638,7 @@ jobs:
     name: i18n Check (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_i18n_check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -720,7 +720,7 @@ jobs:
     name: Accessibility (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_accessibility
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -774,7 +774,7 @@ jobs:
     name: Custom Checks (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -853,7 +853,7 @@ jobs:
     name: Bundle Budget (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_bundle_budget
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -907,7 +907,7 @@ jobs:
     name: Performance Budget (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_performance_budget
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -972,7 +972,7 @@ jobs:
     name: Visual Regression (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_visual_regression
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -1048,7 +1048,7 @@ jobs:
     name: Docker Smoke Test (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_docker_smoke
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -1195,7 +1195,7 @@ jobs:
     name: No Frontend Changes
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes != 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Skip
         run: |

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -109,7 +109,7 @@ jobs:
 
   coverage-report:
     name: Coverage Report
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: test
     if: inputs.enable_coverage_comment && github.event_name == 'pull_request'
     permissions:
@@ -133,7 +133,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
 
     steps:
       - name: Checkout code
@@ -153,7 +153,7 @@ jobs:
 
   build:
     name: Build Binary
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: [test, lint]
     if: inputs.enable_cross_platform_build
 
@@ -203,7 +203,7 @@ jobs:
 
   verify-module:
     name: Verify Module
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.check_module_tidy
 
     steps:
@@ -223,7 +223,7 @@ jobs:
 
   check-format:
     name: Check Formatting
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
 
     steps:
       - name: Checkout code
@@ -248,7 +248,7 @@ jobs:
 
   check-docs:
     name: Check Documentation
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.check_docs
 
     steps:

--- a/.github/workflows/go-fuzz.yml
+++ b/.github/workflows/go-fuzz.yml
@@ -72,7 +72,7 @@ permissions:
 jobs:
   fuzz:
     name: Fuzz Tests
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:

--- a/.github/workflows/go-lambda-release.yml
+++ b/.github/workflows/go-lambda-release.yml
@@ -70,7 +70,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       id-token: write # AWS OIDC to assume the upload role
       contents: read

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -107,7 +107,7 @@ jobs:
   # ============================================
   detect-changes:
     name: Detect Changes
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
       has_changes: ${{ steps.changed-paths.outputs.has_changes }}
@@ -130,7 +130,7 @@ jobs:
     name: Lint (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_lint
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +226,7 @@ jobs:
     name: Security (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_security
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -322,7 +322,7 @@ jobs:
     name: Tests (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_tests
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -476,7 +476,7 @@ jobs:
     name: Coverage (${{ matrix.app.name }})
     needs: [detect-changes, tests]
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_coverage
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -757,7 +757,7 @@ jobs:
     name: Build (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_build
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -837,7 +837,7 @@ jobs:
     name: Integration Tests (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_integration_tests
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -889,7 +889,7 @@ jobs:
     name: Test Determinism (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_test_determinism
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -959,7 +959,7 @@ jobs:
     name: No Go Changes
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes != 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Skip
         run: |

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -220,7 +220,7 @@ jobs:
   changes:
     name: Detect non-doc changes
     if: contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
       pull-requests: read
@@ -260,7 +260,7 @@ jobs:
     name: Go Analysis
     needs: [changes, go-analysis]
     if: always()
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Aggregate Go Analysis result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -293,7 +293,7 @@ jobs:
     name: Security
     needs: [changes, security]
     if: always()
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Aggregate security result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -319,7 +319,7 @@ jobs:
     name: Lib Version
     needs: [changes, lib-version]
     if: always()
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Aggregate Lib Version result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -71,7 +71,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: github.event_name == 'pull_request' && inputs.enable_dependency_review
 
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   gosec:
     name: Gosec Security Scan
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_gosec
 
     steps:
@@ -112,7 +112,7 @@ jobs:
 
   govulncheck:
     name: Go Vulnerability Check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_govulncheck
 
     steps:
@@ -133,7 +133,7 @@ jobs:
 
   nancy:
     name: Nancy Dependency Check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_nancy
 
     steps:
@@ -157,7 +157,7 @@ jobs:
 
   trivy:
     name: Trivy Security Scan
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_trivy
 
     steps:
@@ -182,7 +182,7 @@ jobs:
 
   secret-scan:
     name: Secret Scanning
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_secret_scan
 
     steps:
@@ -201,7 +201,7 @@ jobs:
 
   license-check:
     name: License Check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_license_check
 
     steps:
@@ -235,7 +235,7 @@ jobs:
 
   sbom:
     name: Generate SBOM
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_sbom
 
     steps:
@@ -263,7 +263,7 @@ jobs:
 
   security-summary:
     name: Security Summary
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: [gosec, govulncheck, nancy, trivy, secret-scan, license-check, sbom]
     if: always()
 

--- a/.github/workflows/gptchangelog.yml
+++ b/.github/workflows/gptchangelog.yml
@@ -55,7 +55,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
@@ -245,7 +245,7 @@ jobs:
   generate_changelog:
     needs: prepare
     if: needs.prepare.outputs.has_changes == 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     name: Generate Consolidated Changelog
 
     steps:

--- a/.github/workflows/helm-alpha-cleanup.yml
+++ b/.github/workflows/helm-alpha-cleanup.yml
@@ -71,7 +71,7 @@ concurrency:
 jobs:
   cleanup:
     name: Prune alpha packages past TTL
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       packages: write # delete alpha package versions from GHCR
     steps:

--- a/.github/workflows/helm-alpha-release.yml
+++ b/.github/workflows/helm-alpha-release.yml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   alpha:
     name: "Publish alpha • ${{ inputs.chart }}"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read # checkout the chart source
       packages: write # push the packaged chart to GHCR

--- a/.github/workflows/helm-release-notification.yml
+++ b/.github/workflows/helm-release-notification.yml
@@ -82,7 +82,7 @@ permissions:
 jobs:
   notify:
     name: Send Slack Notification
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -99,7 +99,7 @@ permissions:
 jobs:
   update-chart:
     name: Update Chart
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Validate base_branch
         env:

--- a/.github/workflows/helm-upgrade-doc.yml
+++ b/.github/workflows/helm-upgrade-doc.yml
@@ -69,7 +69,7 @@ permissions:
 jobs:
   upgrade-doc:
     name: Generate Helm Upgrade Doc
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -308,7 +308,7 @@ jobs:
   changes:
     name: Detect non-doc changes
     if: contains(fromJSON('["opened","edited","synchronize","reopened","ready_for_review"]'), github.event.action)
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
       pull-requests: read
@@ -376,7 +376,7 @@ jobs:
     name: Frontend Analysis
     needs: [changes, frontend-analysis]
     if: always()
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
     steps:
@@ -407,7 +407,7 @@ jobs:
     name: Security
     needs: [changes, security]
     if: always()
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
     steps:
@@ -426,7 +426,7 @@ jobs:
   go-analysis-gate:
     name: Go Analysis
     if: ${{ github.event_name == 'none' }}
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
     steps:
@@ -435,7 +435,7 @@ jobs:
   lib-version-gate:
     name: Lib Version
     if: ${{ github.event_name == 'none' }}
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   sync:
     name: Sync labels to repository
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Sync labels
         uses: LerianStudio/github-actions-shared-workflows/src/config/labels-sync@v1

--- a/.github/workflows/lerian-lib-version-check.yml
+++ b/.github/workflows/lerian-lib-version-check.yml
@@ -77,7 +77,7 @@ permissions:
 jobs:
   check:
     name: Lerian Library Version Check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       has_outdated: ${{ steps.check.outputs.has_outdated }}
       outdated_count: ${{ steps.check.outputs.outdated_count }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -127,7 +127,7 @@ permissions:
 
 jobs:
   prepare_matrix:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.changed-paths.outputs.matrix }}
     steps:
@@ -161,7 +161,7 @@ jobs:
   security_scan:
     needs: prepare_matrix
     if: needs.prepare_matrix.outputs.matrix != '[]'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -291,7 +291,7 @@ jobs:
   codeql_scan:
     needs: prepare_matrix
     if: inputs.enable_codeql && inputs.codeql_languages != '' && needs.prepare_matrix.outputs.matrix != '[]'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       # ----------------- Setup -----------------
       - name: Checkout Repository
@@ -353,7 +353,7 @@ jobs:
     name: Notify
     needs: [prepare_matrix, security_scan, codeql_scan]
     if: always() && needs.prepare_matrix.outputs.matrix != '[]'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Slack Notification
         uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -76,7 +76,7 @@ jobs:
   # ----------------- Tier 1: Blocking Checks (no checkout, fail-fast) -----------------
   blocking-checks:
     name: Blocking Checks
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: github.event.pull_request.draft != true
     outputs:
       source-branch-result: ${{ steps.collect.outputs.source_branch }}
@@ -122,7 +122,7 @@ jobs:
   # ----------------- Tier 2: Advisory Checks (shared checkout, depends on Tier 1) -----------------
   advisory-checks:
     name: Advisory Checks
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: [blocking-checks]
     if: always() && needs.blocking-checks.result == 'success' && github.event.pull_request.draft != true
     outputs:
@@ -174,7 +174,7 @@ jobs:
   # ----------------- PR Checks Summary -----------------
   pr-checks-summary:
     name: PR Checks Summary
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: [blocking-checks, advisory-checks]
     if: always()
 
@@ -193,7 +193,7 @@ jobs:
   # ----------------- PR Validation Summary Comment -----------------
   pr-validation-report:
     name: PR Validation Report
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: [blocking-checks, advisory-checks]
     if: always() && github.event.pull_request.draft != true
 

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -111,7 +111,7 @@ permissions:
 jobs:
   notify:
     name: Release Notification
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
@@ -168,7 +168,7 @@ jobs:
   publish_release:
     needs: prepare
     if: needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     environment:
       name: create_release
     name: Release ${{ matrix.app.name }}
@@ -410,7 +410,7 @@ jobs:
     name: Aggregate Publish Status
     needs: publish_release
     if: always() && needs.publish_release.result != 'cancelled'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       release_published: ${{ steps.aggregate.outputs.published }}
       release_version: ${{ steps.aggregate.outputs.version }}
@@ -471,7 +471,7 @@ jobs:
       inputs.enable_changelog &&
       needs.publish_release_status.outputs.release_published == 'true' &&
       (needs.update_major_tag.result == 'success' || needs.update_major_tag.result == 'skipped')
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     environment:
       name: create_release
     steps:
@@ -501,7 +501,7 @@ jobs:
     name: Update Major Tag
     needs: [publish_release, publish_release_status]
     if: inputs.enable_major_tag && needs.publish_release_status.outputs.release_published == 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     environment:
       name: create_release
     permissions:
@@ -537,7 +537,7 @@ jobs:
     name: Enforce Latest Release
     needs: [publish_release, publish_release_status]
     if: always() && needs.publish_release_status.outputs.release_published == 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/s3-upload.yml
+++ b/.github/workflows/s3-upload.yml
@@ -124,7 +124,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - uses: actions/checkout@v6.0.3
 

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -36,7 +36,7 @@ jobs:
   # ----------------- Changed Files Detection -----------------
   changed-files:
     name: Detect Changed Files
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       pull-requests: read
@@ -60,7 +60,7 @@ jobs:
   # ----------------- YAML Lint -----------------
   yamllint:
     name: YAML Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.yaml_files != ''
     steps:
@@ -75,7 +75,7 @@ jobs:
   # ----------------- Action Lint -----------------
   actionlint:
     name: Action Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.workflow_files != ''
     steps:
@@ -90,7 +90,7 @@ jobs:
   # ----------------- Pinned Actions Check -----------------
   pinned-actions:
     name: Pinned Actions Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.action_files != ''
     steps:
@@ -105,7 +105,7 @@ jobs:
   # ----------------- Markdown Link Check -----------------
   markdown-link-check:
     name: Markdown Link Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.markdown_files != ''
     steps:
@@ -122,7 +122,7 @@ jobs:
     name: Spelling Check
     needs: changed-files
     if: needs.changed-files.outputs.all_files != ''
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -135,7 +135,7 @@ jobs:
   # ----------------- Shell Check -----------------
   shellcheck:
     name: Shell Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.action_files != ''
     steps:
@@ -150,7 +150,7 @@ jobs:
   # ----------------- README Check -----------------
   readme-check:
     name: README Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.action_files != ''
     steps:
@@ -165,7 +165,7 @@ jobs:
   # ----------------- Composite Schema Lint -----------------
   composite-schema:
     name: Composite Schema Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.composite_files != ''
     steps:
@@ -180,7 +180,7 @@ jobs:
   # ----------------- Deployment Matrix Lint -----------------
   deployment-matrix:
     name: Deployment Matrix Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: contains(needs.changed-files.outputs.all_files, 'config/deployment-matrix.yml')
     steps:
@@ -195,7 +195,7 @@ jobs:
   # ----------------- CodeQL Analysis -----------------
   codeql:
     name: CodeQL Analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changed-files
     if: needs.changed-files.outputs.action_files != ''
     permissions:
@@ -237,7 +237,7 @@ jobs:
   # ----------------- Lint Report -----------------
   lint-report:
     name: Lint Report
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   notify:
     name: Send Notification
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     steps:
       - name: Check if Slack webhook is configured
         id: check_webhook

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   stale-issue:
     name: Flag and close stale issues
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Run stale issue scan
         uses: LerianStudio/github-actions-shared-workflows/src/config/stale@v1

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   stale-pr:
     name: Flag and close stale PRs
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Run stale PR scan
         uses: LerianStudio/github-actions-shared-workflows/src/config/stale@v1

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -159,7 +159,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_builds: ${{ steps.set-matrix.outputs.has_builds }}
@@ -256,7 +256,7 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.has_builds == 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     name: Build ${{ matrix.app.name }}
     permissions:
       contents: read

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -76,7 +76,7 @@ permissions:
 jobs:
   lint-and-typecheck:
     name: Lint & Type Check
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -110,7 +110,7 @@ jobs:
 
   build-and-test:
     name: Build & Test (Node ${{ matrix.node }})
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     needs: lint-and-typecheck
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
 
   security-audit:
     name: Security Audit
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_security_audit
     defaults:
       run:
@@ -215,7 +215,7 @@ jobs:
 
   docs:
     name: Generate Documentation
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     if: inputs.enable_docs
     needs: build-and-test
     defaults:

--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
@@ -98,7 +98,7 @@ jobs:
   publish_release:
     needs: prepare
     if: needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ vars.RUNNER_LABEL || inputs.runner_type }}
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PAT_FOR_PACKAGES }}
     environment:

--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -53,7 +53,7 @@ permissions:
 jobs:
   propagate:
     name: Propagate ${{ inputs.new_tag || 'latest stable' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       # ----------------- Source Checkout -----------------
       # Pin to the immutable workflow-file SHA that originated this run.

--- a/.github/workflows/workflow-runs-cleanup.yml
+++ b/.github/workflows/workflow-runs-cleanup.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   cleanup:
     name: Delete old workflow runs
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - name: Delete old workflow runs
         uses: LerianStudio/github-actions-shared-workflows/src/config/workflow-runs-cleanup@v1

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -80,6 +80,7 @@ apps:
     - plugin-br-payments
     - plugin-bc-correios
     - underwriter
+    - lender                      # credit journey engine (Underwriter family); UI console pin (lenderConsole.image.tag) is bumped manually, not by this workflow
     - br-sta
     - br-slc
     - br-ccs
@@ -125,6 +126,7 @@ clusters:
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch
       - br-sisbajud
+      - lender
       - ungoliant-controller
 
   benedita:
@@ -168,6 +170,7 @@ clusters:
       - plugin-br-payments
       - plugin-bc-correios
       - underwriter
+      - lender
       - br-sta
       - br-slc
       - br-ccs

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -83,6 +83,7 @@ apps:
     - br-sta
     - br-slc
     - br-ccs
+    - br-sisbajud
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -123,6 +124,7 @@ clusters:
       - plugin-fees
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch
+      - br-sisbajud
       - ungoliant-controller
 
   benedita:
@@ -169,6 +171,7 @@ clusters:
       - br-sta
       - br-slc
       - br-ccs
+      - br-sisbajud
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
Requested by: Bedatty — Padronizar runners via vars.RUNNER_LABEL para todos os workflows shared (exceto gitops e ungoliant que já têm lógica própria)