### PR TITLE
chore(config): bump Mattraks/delete-workflow-runs to v2.1

### DIFF
--- a/src/config/workflow-runs-cleanup/action.yml
+++ b/src/config/workflow-runs-cleanup/action.yml
@@ -41,7 +41,7 @@ runs:
   using: composite
   steps:
     - name: Delete old workflow runs
-      uses: Mattraks/delete-workflow-runs@39f0bbed25d76b34de5594dceab824811479e5de # v2.0.6
+      uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2.1
       with:
         token: ${{ inputs.github-token }}
         repository: ${{ github.repository }}


### PR DESCRIPTION
## Description

Bumps the pinned `Mattraks/delete-workflow-runs` action in `src/config/workflow-runs-cleanup/action.yml` from `v2.0.6` (SHA `39f0bbed25d76b34de5594dceab824811479e5de`) to `v2.1` (SHA `b3018382ca039b53d238908238bd35d1fb14f8ee`).

`v2.0.6` targets Node.js 20, which GitHub deprecated on Actions runners and is now forcing to run on Node.js 24, generating a warning on every `Delete old workflow runs` job run. `v2.1` declares `runs.using: node24` natively, resolving the warning. Verified the action's inputs (`token`, `repository`, `retain_days`, `keep_minimum_runs`, `delete_workflow_pattern`, `delete_run_by_conclusion_pattern`, `delete_workflow_by_state_pattern`, `dry_run`) are unchanged between the two versions, so no other changes are needed.

## Type of Change

- [x] `chore`: Dependency bumps, config updates, maintenance

## Breaking Changes

None. Inputs used by the composite wrapper are identical between v2.0.6 and v2.1.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

## Related Issues

Closes #522