### PR TITLE
feat(go-release): forward kustomize gitops inputs to update_gitops job

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -197,6 +197,30 @@ on:
         description: 'Log in to DockerHub in the gitops-update job (for private image digest reads)'
         type: boolean
         default: false
+      gitops_layout:
+        description: 'GitOps layout strategy: "helmfile" (default, current behavior) or "kustomize".'
+        type: string
+        default: 'helmfile'
+      kustomize_base_path:
+        description: 'Required when gitops_layout=kustomize. Path within the gitops repo to the kustomization folder (e.g. environments/anacleto/kustomize/ungoliant-controller). Supports ${SERVER} and ${ENV} placeholders.'
+        type: string
+        default: ''
+      kustomize_image_name:
+        description: 'Required when gitops_layout=kustomize. Image reference matched by `kustomize edit set image` (e.g. ghcr.io/lerianstudio/ungoliant-controller).'
+        type: string
+        default: ''
+      kustomize_environments:
+        description: 'Optional space-separated env list overriding the default tag-based env loop when gitops_layout=kustomize. Leave empty for layouts without env split.'
+        type: string
+        default: ''
+      kustomize_version:
+        description: 'Version of kustomize CLI to install (used only when gitops_layout=kustomize).'
+        type: string
+        default: 'v5.4.3'
+      argocd_app_name_template:
+        description: 'Template for the ArgoCD application name. Supports placeholders {server}, {app}, {env}. Default {server}-{app}-{env} preserves current behavior. For kustomize layouts without env split, use e.g. {server}-{app}.'
+        type: string
+        default: '{server}-{app}-{env}'
 
       # ----------------- S3 Upload (s3-upload.yml) -----------------
       s3_uploads:
@@ -652,6 +676,12 @@ jobs:
       use_dynamic_mapping: ${{ inputs.use_dynamic_mapping }}
       configmap_updates: ${{ inputs.configmap_updates }}
       enable_docker_login: ${{ inputs.enable_docker_login }}
+      gitops_layout: ${{ inputs.gitops_layout }}
+      kustomize_base_path: ${{ inputs.kustomize_base_path }}
+      kustomize_image_name: ${{ inputs.kustomize_image_name }}
+      kustomize_environments: ${{ inputs.kustomize_environments }}
+      kustomize_version: ${{ inputs.kustomize_version }}
+      argocd_app_name_template: ${{ inputs.argocd_app_name_template }}
       force_env: ${{ github.ref_type == 'branch' && inputs.build_on_release && (contains(needs.release.outputs.new_release_version, '-beta.') && 'development' || contains(needs.release.outputs.new_release_version, '-rc.') && 'staging' || 'production') || '' }}
     secrets: inherit
 

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -66,6 +66,12 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `use_dynamic_mapping` | Use dynamic artifact-to-YAML key mapping | boolean | `false` |
 | `configmap_updates` | JSON mapping of artifact names to configmap keys (helmfile only) | string | `''` |
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
+| `gitops_layout` | GitOps layout strategy: `helmfile` (default, current behavior) or `kustomize` | string | `helmfile` |
+| `kustomize_base_path` | Required when `gitops_layout=kustomize`. Path within the gitops repo to the kustomization folder (supports `${SERVER}`/`${ENV}` placeholders) | string | `''` |
+| `kustomize_image_name` | Required when `gitops_layout=kustomize`. Image reference matched by `kustomize edit set image` | string | `''` |
+| `kustomize_environments` | Optional space-separated env list overriding the default tag-based env loop when `gitops_layout=kustomize` | string | `''` |
+| `kustomize_version` | Version of kustomize CLI to install (used only when `gitops_layout=kustomize`) | string | `v5.4.3` |
+| `argocd_app_name_template` | Template for the ArgoCD application name. Placeholders `{server}`, `{app}`, `{env}`. For kustomize layouts without env split use e.g. `{server}-{app}` | string | `{server}-{app}-{env}` |
 | `s3_uploads` | JSON array of S3 upload entries run after build on tag push (see [S3 migrations upload](#s3-migrations-upload)) | string | `''` |
 | `enable_apidog_e2e` | Run the ApiDog E2E test job on tag push after a successful gitops-update | boolean | `false` |
 | `apidog_runner_type` | Runner for the ApiDog E2E test job (needs reach to the deployed environment) | string | `eveo-lxc-runners` |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `go-release.yml` umbrella's `update_gitops` job only forwarded helmfile-shaped inputs to `gitops-update.yml`, so callers could not select `gitops_layout: kustomize` through the umbrella — even though `gitops-update.yml` fully supports the kustomize layout when called directly. This blocked `ungoliant-controller` and `severino-bot` (both flagged as `gitops_layout=kustomize` in `config/deployment-matrix.yml`) from adopting the umbrella.

This PR wires the kustomize passthrough end to end:

- Adds six inputs to `go-release.yml` in the GitOps Update block, mirroring `gitops-update.yml`'s own shape and defaults:
  - `gitops_layout` (default `helmfile`)
  - `kustomize_base_path`
  - `kustomize_image_name`
  - `kustomize_environments`
  - `kustomize_version` (default `v5.4.3`)
  - `argocd_app_name_template` (default `{server}-{app}-{env}`)
- Forwards all six in the `update_gitops` job's `with:` block.
- Documents the new inputs in `docs/go-release-workflow.md`.

All defaults preserve the current helmfile behavior, so existing callers are unaffected.

**Affected workflow:** `.github/workflows/go-release.yml` (and its doc).

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Every new input has a default that preserves the current helmfile behavior; `gitops_layout` defaults to `helmfile`.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [ ] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** <!-- to be validated by ungoliant-controller adoption -->

## Related Issues

Closes #608
