### PR TITLE
fix(gitops-update): install kustomize without sudo, mirroring the yq pattern

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -255,7 +255,10 @@ jobs:
           URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz"
           curl -fsSL "$URL" -o /tmp/kustomize.tar.gz
           tar -xzf /tmp/kustomize.tar.gz -C /tmp
-          sudo install -m 755 /tmp/kustomize /usr/local/bin/kustomize
+          mkdir -p ~/.local/bin
+          install -m 755 /tmp/kustomize ~/.local/bin/kustomize
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
           kustomize version
 
       - name: Validate kustomize inputs


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The `Install kustomize` step in `gitops-update.yml` used `sudo install -m 755 /tmp/kustomize /usr/local/bin/kustomize`, which assumes `sudo` is available on the runner. The `update_gitops` job runs on `${{ vars.GITOPS_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}`, and the organization's self-hosted pool has no `sudo` — the step fails with `sudo: command not found`.

This caused a real production failure: in `LerianStudio/ungoliant-controller`, the `v2.1.0-beta.10` release ([run 30110283556](https://github.com/LerianStudio/ungoliant-controller/actions/runs/30110283556/job/89538599855)) built and pushed the image successfully, but `update_gitops` failed at this step, cascading into a cancelled ArgoCD Sync — the image was never reconciled into the cluster.

The fix mirrors the pattern already used by the two other binary installers in the same file (`Install yq`, lines 224-240, and the `argocd` CLI install, line ~913): install into a user-writable directory and export it via `$GITHUB_PATH`, so no elevated privileges and no write to `/usr/local/bin` are needed.

```diff
  tar -xzf /tmp/kustomize.tar.gz -C /tmp
- sudo install -m 755 /tmp/kustomize /usr/local/bin/kustomize
+ mkdir -p ~/.local/bin
+ install -m 755 /tmp/kustomize ~/.local/bin/kustomize
+ echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+ export PATH="$HOME/.local/bin:$PATH"
  kustomize version
```

The existing comment explaining the `kustomize/vX.Y.Z` tag URL-encoding (a separate historical bug) is preserved untouched.

**Repo-wide `sudo` audit** — the remaining `sudo` usages were reviewed and intentionally left as-is:

| Location | Usage | Verdict |
|---|---|---|
| `gitops-update.yml:258` | `sudo install ... /usr/local/bin/kustomize` | **fixed in this PR** |
| `go-pr-analysis.yml` (6 occurrences) | `sudo apt-get install` of `inputs.system_packages` | out of scope — runs on the separate `GENERAL_RUNNERS` pool, and arbitrary apt packages have no `~/.local/bin` equivalent |
| `src/lint/{shellcheck,composite-schema,deployment-matrix}` | `sudo apt-get install` (shellcheck, python3-yaml) | out of scope — only consumed by `self-*` workflows in this repo, on blacksmith runners |

`gitops-update.yml` now contains zero `sudo` invocations.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. No input, output, or secret changed. Only the installation path of the `kustomize` binary changed — it is exported via `$GITHUB_PATH`, so all subsequent steps resolve it identically. The new path also works on GitHub-hosted and blacksmith runners, so no caller sees a behavior difference.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Notes on what was and was not verified:

- YAML parsed successfully; the step body is unchanged apart from the four lines above.
- The step is gated by `if: inputs.gitops_layout == 'kustomize'`, unchanged — `helmfile` callers are unaffected.
- **Not yet validated on a caller.** This step only fails on the `sudo`-less self-hosted pool, which cannot be reached from a branch-pinned test without a released tag. End-to-end confirmation requires merge + a new tag, then bumping `ungoliant-controller`'s pin in `.github/workflows/release.yml` from `@v1.47.4` to the new tag and re-triggering the `v2.1.0-beta.10` release to confirm `update_gitops` and the ArgoCD Sync both complete.

**Caller repo / workflow run:** [ungoliant-controller run 30110283556](https://github.com/LerianStudio/ungoliant-controller/actions/runs/30110283556/job/89538599855) — this is the **failing** run that surfaced the bug, not a validation of the fix.

## Related Issues

None.
