### PR TITLE
fix(deployment-matrix): register caradhras on benedita

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -155,6 +155,12 @@ clusters:
       lerian-map: cross
       rosiehr: cross
       tenant-manager: cross
+      # Caradhras is the pre-promotion test instance of the plugin-access-manager
+      # auth-backend and exists only at stg-mt (its values.yaml is the one whose
+      # .auth.backend.image.repository already points at ghcr.io/lerianstudio/caradhras,
+      # unlike the primary plugin-access-manager, which still runs ghcr.io/lerianstudio/casdoor).
+      # Without this override a beta tag would resolve dev-st / dev-mt and find no values.yaml.
+      caradhras: stg-mt
     apps:
       - midaz
       - fetcher

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -73,6 +73,7 @@ apps:
 
     # Plugins
     - plugin-access-manager       # caller repo may push as plugin-identity / plugin-auth / casdoor
+    - caradhras                   # Lerian's hard fork of Casdoor (IAM/SSO); pushed by LerianStudio/caradhras. Distinct from plugin-access-manager: its own app dir, own values.yaml, three images (caradhras, caradhras-postgres-migrations, caradhras-ui)
     - plugin-fees
     - plugin-br-pix-indirect-btg
     - plugin-br-pix-switch
@@ -163,6 +164,7 @@ clusters:
       - tracer
       - product-console
       - plugin-access-manager
+      - caradhras
       - plugin-fees
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -73,7 +73,7 @@ apps:
 
     # Plugins
     - plugin-access-manager       # caller repo may push as plugin-identity / plugin-auth / casdoor
-    - caradhras                   # Lerian's hard fork of Casdoor (IAM/SSO); pushed by LerianStudio/caradhras. Distinct from plugin-access-manager: its own app dir, own values.yaml, three images (caradhras, caradhras-postgres-migrations, caradhras-ui)
+    - plugin-access-manager-caradhras  # pre-promotion test instance of the plugin-access-manager auth-backend, running the caradhras image; pushed by LerianStudio/caradhras via gitops_app_name (its image is ghcr.io/lerianstudio/caradhras, so the repo name alone does not match this app dir)
     - plugin-fees
     - plugin-br-pix-indirect-btg
     - plugin-br-pix-switch
@@ -160,7 +160,7 @@ clusters:
       # .auth.backend.image.repository already points at ghcr.io/lerianstudio/caradhras,
       # unlike the primary plugin-access-manager, which still runs ghcr.io/lerianstudio/casdoor).
       # Without this override a beta tag would resolve dev-st / dev-mt and find no values.yaml.
-      caradhras: stg-mt
+      plugin-access-manager-caradhras: stg-mt
     apps:
       - midaz
       - fetcher
@@ -170,7 +170,7 @@ clusters:
       - tracer
       - product-console
       - plugin-access-manager
-      - caradhras
+      - plugin-access-manager-caradhras
       - plugin-fees
       - plugin-br-pix-indirect-btg
       - plugin-br-pix-switch


### PR DESCRIPTION
## Description

Registers the caradhras deployment in `config/deployment-matrix.yml`:

- `plugin-access-manager-caradhras` added to `apps.registry`
- `plugin-access-manager-caradhras` added to `clusters.benedita.apps`
- `clusters.benedita.app_helmfile_env.plugin-access-manager-caradhras: stg-mt`

Affects `gitops-update.yml`, which reads this manifest at `deployment_matrix_ref` (default `main` — hence the hotfix straight to `main` rather than via `develop`).

### Why

The caradhras release pipeline reaches `update_gitops` on every tag push (`enable_gitops_update` defaults to `true`), and the resolver currently emits a "not registered in any cluster" warning.

The target is the **pre-promotion test instance** of the plugin-access-manager auth-backend. It is the only app whose `.auth.backend.image.repository` already points at `ghcr.io/lerianstudio/caradhras`; the primary `plugin-access-manager` still runs `ghcr.io/lerianstudio/casdoor` (+ `casdoor-migrations`) in all five envs, on its own 3.x series published by a different repo. Pointing caradhras tag bumps at the primary app would write a caradhras version into a key whose `repository` says `casdoor` — a nonexistent image, and ImagePullBackOff in prd-st and sandbox included.

The app is registered under its gitops directory name, `plugin-access-manager-caradhras`, which does not match the caller's repository name (`caradhras`). The caller reaches it with the new `gitops_app_name` input from #620 — `app_name` cannot serve that purpose, because `go-release.yml` forwards the same input to `build.yml`, where it also renames the published image.

`app_helmfile_env` is required because that instance exists only at `stg-mt`, while benedita's `env_suffixes` would expand a beta tag to `dev-st` / `dev-mt`. Its ArgoCD app name (`benedita-plugin-access-manager-caradhras-stg-mt`) follows the `{server}-{app}-{env}` pattern the override requires.

Benedita only. Anacleto declares `env_contexts: ["chaos", "fuzzing"]` alongside `env_suffixes`, which would process the same `values.yaml` four times per run — out of scope here.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. Purely additive — a registry entry, one cluster list entry, one `app_helmfile_env` entry. No existing app's resolution changes.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Ran the manifest loader's own resolution logic against the edited file: `plugin-access-manager-caradhras` is in `apps.registry`, resolves to exactly `['benedita']`, and picks up `app_helmfile_env` -> `stg-mt`.

Merge order does not matter — this entry is inert until a caller passes `gitops_app_name: "plugin-access-manager-caradhras"`, and until then caradhras keeps logging the same "not registered" warning it logs today (a warning, not a failure).

### Related

- #620 — adds the `gitops_app_name` input the caller needs
- LerianStudio/caradhras#30 — supplies `enable_gitops_artifacts` and the `gitops_yaml_key_mappings` that pair with this entry

## Related Issues

_None._