### PR TITLE
feat(go-release,js-release): add gitops_app_name override

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -165,6 +165,10 @@ on:
         description: 'Space-separated environments updated by a stable release (main branch). Default "prd" so a hotfix does not overwrite features still in dev/stg. Set to "dev stg prd" to refresh lower environments too. Sandbox is controlled separately by update_sandbox.'
         type: string
         default: 'prd'
+      gitops_app_name:
+        description: 'App name used ONLY for the gitops-update job (deployment-matrix lookup + the helmfile applications/{env}/{app}/values.yaml path). Empty = keep the existing resolution (app_name, then app_name_prefix, then the repository name). Set this when the gitops app directory is named differently from the published image: `app_name` cannot be used for that, because it is the same input that renames the built image in build.yml.'
+        type: string
+        default: ''
       gitops_artifact_pattern:
         description: 'Pattern to download GitOps artifacts (defaults to "gitops-tags-<repo-name>*")'
         type: string
@@ -667,7 +671,10 @@ jobs:
       beta_environments: ${{ inputs.beta_environments }}
       rc_environments: ${{ inputs.rc_environments }}
       stable_environments: ${{ inputs.stable_environments }}
-      app_name: ${{ inputs.app_name || inputs.app_name_prefix }}
+      # gitops_app_name first, then the pre-existing chain unchanged, so a caller
+      # that does not set it resolves exactly as before (and gitops-update still
+      # falls back to the repository name when all three are empty).
+      app_name: ${{ inputs.gitops_app_name || inputs.app_name || inputs.app_name_prefix }}
       artifact_pattern: ${{ inputs.gitops_artifact_pattern || format('gitops-tags-{0}*', github.event.repository.name) }}
       yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
       deployment_matrix_ref: ${{ inputs.deployment_matrix_ref }}

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -145,6 +145,10 @@ on:
         description: 'Space-separated environments updated by a stable release (main branch). Default "prd" so a hotfix does not overwrite features still in dev/stg. Set to "dev stg prd" to refresh lower environments too. Sandbox is controlled separately by update_sandbox.'
         type: string
         default: 'prd'
+      gitops_app_name:
+        description: 'App name used ONLY for the gitops-update job (deployment-matrix lookup + the helmfile applications/{env}/{app}/values.yaml path). Empty = keep the existing resolution (app_name_prefix, then the repository name). Set this when the gitops app directory is named differently from the published image.'
+        type: string
+        default: ''
       gitops_artifact_pattern:
         description: 'Pattern to download GitOps artifacts (defaults to "gitops-tags-<repo-name>*")'
         type: string
@@ -428,7 +432,10 @@ jobs:
       beta_environments: ${{ inputs.beta_environments }}
       rc_environments: ${{ inputs.rc_environments }}
       stable_environments: ${{ inputs.stable_environments }}
-      app_name: ${{ inputs.app_name_prefix }}
+      # gitops_app_name first, then the pre-existing value unchanged, so a caller
+      # that does not set it resolves exactly as before (and gitops-update still
+      # falls back to the repository name when both are empty).
+      app_name: ${{ inputs.gitops_app_name || inputs.app_name_prefix }}
       artifact_pattern: ${{ inputs.gitops_artifact_pattern || format('gitops-tags-{0}*', github.event.repository.name) }}
       yaml_key_mappings: ${{ inputs.gitops_yaml_key_mappings }}
       deployment_matrix_ref: ${{ inputs.deployment_matrix_ref }}

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -56,6 +56,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `beta_environments` | Space-separated environments updated by a beta release (`develop` branch) | string | `dev` |
 | `rc_environments` | Space-separated environments updated by an rc release (`release-candidate` branch) | string | `stg` |
 | `stable_environments` | Space-separated environments updated by a stable release (`main` branch). Default `prd` so a hotfix does not overwrite features still in dev/stg. Set to `dev stg prd` to refresh lower environments too. Sandbox is controlled separately by `update_sandbox` | string | `prd` |
+| `gitops_app_name` | App name used **only** by `update_gitops` (deployment-matrix lookup + the `applications/{env}/{app}/values.yaml` path). Empty → the existing chain (`app_name`, then `app_name_prefix`, then the repo name) | string | `''` |
 | `gitops_artifact_pattern` | Pattern to download GitOps artifacts. Empty → `gitops-tags-<repo-name>*` | string | `''` |
 | `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
 | `gitops_runner_type` | Runner for the gitops-update (deploy) job (needs cluster access) | string | `eveo-lxc-runners` |
@@ -88,6 +89,8 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `release_single_app` | Force single-app mode for the release job even when `filter_paths` is set (one version tag, many images) | boolean | `false` |
 
 > **Derived gitops defaults** — to slim down gitops/helm plugin callers, three gitops-update inputs derive from `app_name_prefix` / the repo name when left unset: `commit_message_prefix` → `app_name_prefix`; the gitops deploy `app_name` → `app_name_prefix`; `gitops_artifact_pattern` → `gitops-tags-<repo-name>*`. Set any of them explicitly to override (e.g. a repo whose deploy app name differs from its `app_name_prefix`, or a monorepo needing a different artifact suffix). All derivations fall back to the repository name when `app_name_prefix` is also empty, preserving the previous behavior.
+>
+> **Decoupling the gitops app name from the image name** — `app_name` is a single input shared by `build.yml` and `update_gitops`, so using it to fix a gitops path also renames the published image (`build.yml` resolves `APP_NAME="${app_name:-$REPO_NAME}"`). When the gitops app directory is named differently from the image, set `gitops_app_name` instead: it takes precedence for the deploy job only and leaves the image name untouched. Empty (the default) keeps the chain above exactly as it was.
 
 ## Secrets
 

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -51,6 +51,7 @@ Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services �
 | `beta_environments` | Space-separated environments updated by a beta release (`develop` branch) | string | `dev` |
 | `rc_environments` | Space-separated environments updated by an rc release (`release-candidate` branch) | string | `stg` |
 | `stable_environments` | Space-separated environments updated by a stable release (`main` branch). Default `prd` so a hotfix does not overwrite features still in dev/stg. Set to `dev stg prd` to refresh lower environments too. Sandbox is controlled separately by `update_sandbox` | string | `prd` |
+| `gitops_app_name` | App name used **only** by `update_gitops` (deployment-matrix lookup + the `applications/{env}/{app}/values.yaml` path). Empty → the existing chain (`app_name_prefix`, then the repo name) | string | `''` |
 | `gitops_artifact_pattern` | Pattern to download GitOps artifacts. Empty → `gitops-tags-<repo-name>*` | string | `''` |
 | `gitops_yaml_key_mappings` | JSON mapping of artifact names to YAML keys | string | `''` |
 | `deployment_matrix_ref` | Git ref of shared-workflows to read the deployment matrix from | string | `main` |


### PR DESCRIPTION
## Description

Adds an optional `gitops_app_name` input to `go-release.yml` and `js-release.yml` that sets the app name for the `update_gitops` job **only** — the deployment-matrix lookup and the `applications/{env}/{app}/values.yaml` path — without touching the published image name.

```yaml
# go-release.yml
app_name: ${{ inputs.gitops_app_name || inputs.app_name || inputs.app_name_prefix }}

# js-release.yml
app_name: ${{ inputs.gitops_app_name || inputs.app_name_prefix }}
```

### Why

`app_name` is a single input shared by two consumers. `go-release.yml` forwards it to `build.yml`, where it renames the published image:

```bash
# build.yml
APP_NAME="${APP_NAME_INPUT:-$REPO_NAME}"
```

and to `update_gitops`, where it selects the deployment-matrix entry and the values.yaml path. So a repo whose gitops app directory is named differently from its image has no way to fix the gitops path — setting `app_name` renames the image too.

Concrete case: `LerianStudio/caradhras` publishes `ghcr.io/lerianstudio/caradhras`, but its gitops app directory is `plugin-access-manager-caradhras` (it is the pre-promotion test instance of the plugin-access-manager auth-backend). Today the only workarounds are renaming the gitops directory or renaming the image — both worse than an input.

### Additive, not a substitute

The new input defaults to `''` and sits at the **front** of the existing fallback chain, which is otherwise untouched:

- A caller that does not set it resolves exactly as before — same expression, same precedence.
- `gitops-update.yml` still falls back to the repository name when the whole chain is empty (`app_name` there remains `required: false`).
- No existing input changed type, default, or meaning; nothing was removed or renamed.
- `build.yml` is not touched at all, so no image name can change as a result of this PR.

Applied symmetrically to both release umbrellas that call `gitops-update.yml`. `go-lambda-release.yml` and `typescript-release.yml` do not call it, so they are unaffected.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None. Purely additive and backward compatible — an unset `gitops_app_name` reproduces the previous resolution byte for byte.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Parsed both workflows and asserted the new input is `type: string`, `default: ''`, and that the forwarded `app_name` expression keeps the prior chain intact behind it.

Docs updated: the input tables in `docs/go-release-workflow.md` and `docs/js-release.md`, plus a note under "Derived gitops defaults" explaining why `app_name` cannot serve this purpose.

The first consumer will be `LerianStudio/caradhras` (see caradhras#30), which needs this released before it can point at its `plugin-access-manager-caradhras` gitops directory.

## Related Issues

_None._