### PR TITLE
fix(deployment-matrix): stop redirecting caradhras beta tags into stg-mt

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -158,12 +158,6 @@ clusters:
       lerian-map: cross
       rosiehr: cross
       tenant-manager: cross
-      # Caradhras is the pre-promotion test instance of the plugin-access-manager
-      # auth-backend and exists only at stg-mt (its values.yaml is the one whose
-      # .auth.backend.image.repository already points at ghcr.io/lerianstudio/caradhras,
-      # unlike the primary plugin-access-manager, which still runs ghcr.io/lerianstudio/casdoor).
-      # Without this override a beta tag would resolve dev-st / dev-mt and find no values.yaml.
-      plugin-access-manager-caradhras: stg-mt
     apps:
       - midaz
       - fetcher


### PR DESCRIPTION
## Description

Removes the `clusters.benedita.app_helmfile_env.plugin-access-manager-caradhras: stg-mt` override added in #618. Six lines deleted, nothing added.

### What went wrong

`app_helmfile_env` is a static redirect applied inside the env loop, on **every** tag type — not just the one whose env the override names. So a beta tag expanded to `dev-st` / `dev-mt`, both were redirected to `stg-mt`, and the run overwrote the rc pin sitting there:

```
LerianStudio/lerian-internal-gitops@2264b35
  ci(plugin-access-manager-caradhras): update image tags (beta/dev)
  -  tag: "1.2.0-rc.1"      +  tag: "1.2.0-beta.7"    # auth.backend.image
```

A stable tag would have done the same thing.

### Why plain expansion is correct

`plugin-access-manager-caradhras` exists **only** at `stg-mt`, and benedita's `env_suffixes: ["-st", "-mt"]` already produce exactly the intended selectivity — no override needed:

| Tag type | Expanded envs | Outcome |
|---|---|---|
| beta | `dev-st`, `dev-mt` | neither directory exists → warning, skipped |
| **rc** | `stg-st`, `stg-mt` | `stg-st` absent (skipped), **`stg-mt` written** |
| stable | `prd-st`, `prd-mt` | neither exists → warning, skipped |

Only rc reaches `stg-mt`, which is the intent for a pre-promotion test instance. The cost is a cosmetic "values file not found" warning for the absent sibling envs.

The registry entry and the `clusters.benedita.apps` entry from #618 are unchanged — only the override is dropped.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None for other callers. The seven pre-existing `cross` overrides are untouched; this removes one entry added earlier today.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Parsed the edited manifest and asserted: the app still resolves to `['benedita']`, `app_helmfile_env` no longer has an entry for it, the other seven `cross` overrides are intact, and the per-tag-type expansion produces `dev-st/dev-mt`, `stg-st/stg-mt`, `prd-st/prd-mt` respectively — so `stg-mt` is reachable only from an rc tag.

Separately, the clobbered pin in `lerian-internal-gitops` needs restoring; that is a live-environment change and is not part of this PR.

## Related Issues

Follow-up to #618.