### PR TITLE
feat(go-pr-validation,go-pr-analysis): add custom_checks gate

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -923,6 +923,10 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks && inputs.custom_checks != ''
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    # This is the only job that runs caller-supplied commands, so it is the one
+    # place an unbounded hang is plausible. Caps the 6h GitHub default while
+    # staying generous enough for a heavy guard.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -930,6 +934,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          # Caller-supplied make targets run in this workspace; do not leave a
+          # usable git credential behind for them. Private-module access comes
+          # from the explicit git config step below, not from checkout.
+          persist-credentials: false
 
       - name: Install system dependencies
         if: inputs.system_packages != ''
@@ -956,12 +965,16 @@ jobs:
           go-version: ${{ inputs.go_version }}
           cache: true
 
+      # MANAGE_TOKEN goes through env rather than being interpolated into the
+      # script text: an interpolated secret is not masked if the shell traces the
+      # command, and it is what CodeQL/zizmor flag as template-injection.
       - name: Configure private Go modules
         if: inputs.go_private_modules != ''
         run: |
-          git config --global url."https://${{ secrets.MANAGE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${MANAGE_TOKEN}@github.com/".insteadOf "https://github.com/"
         env:
           GOPRIVATE: ${{ inputs.go_private_modules }}
+          MANAGE_TOKEN: ${{ secrets.MANAGE_TOKEN }}
 
       # Every target runs even if an earlier one fails, so one PR surfaces every
       # broken guard instead of only the first. CUSTOM_CHECKS is passed via env

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -89,6 +89,14 @@ on:
         description: 'Number of times to run tests for determinism check'
         type: number
         default: 3
+      enable_custom_checks:
+        description: 'Enable arbitrary caller-owned checks beyond the named gates above (runs each target in custom_checks). Mirrors the same input in frontend-pr-analysis.yml.'
+        type: boolean
+        default: false
+      custom_checks:
+        description: 'Newline-separated Makefile targets to run as additional checks (e.g. repo-specific static guards). Each runs independently via `make <target>`; a non-zero exit on any of them fails the job. Use for gates the named jobs do not cover, so a repo does not need its own parallel workflow file.'
+        type: string
+        default: ''
       system_packages:
         description: 'Space-separated list of apt packages to install before running Go commands (e.g., "libxml2-dev pkg-config"). Required for CGO repositories that depend on native system libraries.'
         type: string
@@ -908,6 +916,85 @@ jobs:
         run: ${{ inputs.integration_test_command }}
 
   # ============================================
+  # CUSTOM CHECKS
+  # ============================================
+  custom-checks:
+    name: Custom Checks (${{ matrix.app.name }})
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks && inputs.custom_checks != ''
+    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    strategy:
+      fail-fast: false
+      matrix:
+        app: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Install system dependencies
+        if: inputs.system_packages != ''
+        env:
+          SYSTEM_PACKAGES: ${{ inputs.system_packages }}
+        run: |
+          mapfile -t PACKAGES < <(printf '%s' "$SYSTEM_PACKAGES" | tr -s '[:space:]' '\n' | grep -v '^[[:space:]]*$')
+          if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+            echo "::notice::No valid package names in system_packages; skipping."
+            exit 0
+          fi
+          for pkg in "${PACKAGES[@]}"; do
+            if [[ "$pkg" == -* ]] || [[ ! "$pkg" =~ ^[A-Za-z0-9][A-Za-z0-9.+:-]*$ ]]; then
+              echo "::error::Invalid apt package token: '$pkg'"
+              exit 1
+            fi
+          done
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${PACKAGES[@]}"
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        with:
+          go-version: ${{ inputs.go_version }}
+          cache: true
+
+      - name: Configure private Go modules
+        if: inputs.go_private_modules != ''
+        run: |
+          git config --global url."https://${{ secrets.MANAGE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        env:
+          GOPRIVATE: ${{ inputs.go_private_modules }}
+
+      # Every target runs even if an earlier one fails, so one PR surfaces every
+      # broken guard instead of only the first. CUSTOM_CHECKS is passed via env
+      # (not interpolated into the script) to avoid code injection from inputs.
+      - name: Run custom checks
+        working-directory: ${{ matrix.app.working_dir }}
+        env:
+          CUSTOM_CHECKS: ${{ inputs.custom_checks }}
+        run: |
+          set +e
+          failures=0
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            if [[ ! "$target" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+              echo "::error::Invalid Makefile target name: '$target'"
+              failures=$((failures + 1))
+              continue
+            fi
+            echo "::group::make $target"
+            make "$target"
+            status=$?
+            echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              echo "::error::Custom check '$target' failed (exit $status)"
+              failures=$((failures + 1))
+            fi
+          done <<< "$CUSTOM_CHECKS"
+          if [ "$failures" -ne 0 ]; then
+            echo "::error::$failures custom check(s) failed"
+            exit 1
+          fi
+
+  # ============================================
   # TEST DETERMINISM
   # ============================================
   test-determinism:
@@ -996,12 +1083,12 @@ jobs:
   # ============================================
   notify:
     name: Notify
-    needs: [detect-changes, lint, security, tests, build, integration-tests, test-determinism]
+    needs: [detect-changes, lint, security, tests, build, integration-tests, custom-checks, test-determinism]
     if: always() && needs.detect-changes.outputs.has_changes == 'true'
     uses: ./.github/workflows/slack-notify.yml
     with:
-      status: ${{ (needs.lint.result == 'failure' || needs.security.result == 'failure' || needs.tests.result == 'failure' || needs.build.result == 'failure' || needs.integration-tests.result == 'failure' || needs.test-determinism.result == 'failure') && 'failure' || 'success' }}
+      status: ${{ (needs.lint.result == 'failure' || needs.security.result == 'failure' || needs.tests.result == 'failure' || needs.build.result == 'failure' || needs.integration-tests.result == 'failure' || needs.custom-checks.result == 'failure' || needs.test-determinism.result == 'failure') && 'failure' || 'success' }}
       workflow_name: "Go PR Analysis"
-      failed_jobs: ${{ needs.lint.result == 'failure' && 'Lint, ' || '' }}${{ needs.security.result == 'failure' && 'Security, ' || '' }}${{ needs.tests.result == 'failure' && 'Tests, ' || '' }}${{ needs.build.result == 'failure' && 'Build, ' || '' }}${{ needs.integration-tests.result == 'failure' && 'Integration Tests, ' || '' }}${{ needs.test-determinism.result == 'failure' && 'Test Determinism' || '' }}
+      failed_jobs: ${{ needs.lint.result == 'failure' && 'Lint, ' || '' }}${{ needs.security.result == 'failure' && 'Security, ' || '' }}${{ needs.tests.result == 'failure' && 'Tests, ' || '' }}${{ needs.build.result == 'failure' && 'Build, ' || '' }}${{ needs.integration-tests.result == 'failure' && 'Integration Tests, ' || '' }}${{ needs.custom-checks.result == 'failure' && 'Custom Checks, ' || '' }}${{ needs.test-determinism.result == 'failure' && 'Test Determinism' || '' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -124,6 +124,26 @@ on:
         description: 'Enable integration tests (requires make test-integration target)'
         type: boolean
         default: false
+      integration_test_command:
+        description: 'Command to run integration tests. Empty = go-pr-analysis default (`make test-integration`).'
+        type: string
+        default: ''
+      enable_test_determinism:
+        description: 'Enable the test determinism check (runs tests multiple times with shuffle)'
+        type: boolean
+        default: false
+      test_determinism_runs:
+        description: 'Number of times to run tests for the determinism check'
+        type: number
+        default: 3
+      enable_custom_checks:
+        description: 'Enable arbitrary caller-owned checks beyond the named gates (runs each target in custom_checks)'
+        type: boolean
+        default: false
+      custom_checks:
+        description: 'Newline-separated Makefile targets to run as additional checks. Each runs via `make <target>`; a non-zero exit on any of them fails the job. Use for repo-specific guards the named jobs do not cover.'
+        type: string
+        default: ''
       system_packages:
         description: 'Space-separated apt packages to install before Go commands (CGO repos)'
         type: string
@@ -252,6 +272,13 @@ jobs:
       fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
       go_private_modules: ${{ inputs.go_private_modules }}
       enable_integration_tests: ${{ inputs.enable_integration_tests }}
+      # Empty falls through to go-pr-analysis's own default (`make test-integration`),
+      # so an unset caller keeps the previous behaviour.
+      integration_test_command: ${{ inputs.integration_test_command || 'make test-integration' }}
+      enable_test_determinism: ${{ inputs.enable_test_determinism }}
+      test_determinism_runs: ${{ inputs.test_determinism_runs }}
+      enable_custom_checks: ${{ inputs.enable_custom_checks }}
+      custom_checks: ${{ inputs.custom_checks }}
       system_packages: ${{ inputs.system_packages }}
       shared_paths: ${{ inputs.shared_paths }}
     secrets: inherit

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -46,6 +46,11 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `true` |
 | `go_private_modules` | GOPRIVATE pattern for private modules | string | `''` |
 | `enable_integration_tests` | Enable integration tests | boolean | `false` |
+| `integration_test_command` | Command for the integration lane. Empty → `make test-integration` | string | `''` |
+| `enable_test_determinism` | Enable the test determinism check (repeat runs with shuffle) | boolean | `false` |
+| `test_determinism_runs` | Number of repeat runs for the determinism check | number | `3` |
+| `enable_custom_checks` | Run arbitrary caller-owned Makefile targets as an extra gate | boolean | `false` |
+| `custom_checks` | Newline-separated Makefile targets; each runs via `make <target>`, any non-zero exit fails the job | string | `''` |
 | `system_packages` | apt packages to install for CGO repos | string | `''` |
 | `ignore_file` | Path to Trivy ignore file | string | `''` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a root Dockerfile (monorepos with Dockerfiles under `components/`/`cmd/`) | boolean | `true` |


### PR DESCRIPTION
## Description

Adds a `custom-checks` job to `go-pr-analysis.yml`, driven by two new inputs exposed and forwarded by `go-pr-validation.yml`:

- `enable_custom_checks` (boolean, default `false`)
- `custom_checks` (string, default `''`) — newline-separated Makefile targets, each run via `make <target>`

Mirrors the `enable_custom_checks` / `custom_checks` contract that `frontend-pr-analysis.yml` already offers, so the Go side reaches feature parity.

### Why

The Go side has exactly one hook for a repo-specific gate: the `check-api-spec` target probed by the `tests` job. Once a repo uses that for its OpenAPI drift gate, any *other* static guard has nowhere to go, so the repo keeps a parallel hand-rolled workflow file alongside the shared one — duplicating checkout, Go setup, private-module config and runner selection.

Concrete driver: `LerianStudio/caradhras` maintains a `build.yml` whose only remaining non-e2e jobs are `make check-migrations` (migration pairing/naming/sequence) and `make check-goroutines` (no naked `go func`, everything through the `SafeGo` seam). Neither maps to a named shared job. With this input that file can shrink to just the two e2e lanes.

### Also fixes three forwarding gaps

`go-pr-validation.yml` did not expose or forward inputs that `go-pr-analysis.yml` already accepted, so callers of the umbrella could not reach them at all:

- `integration_test_command` — forwarded as `${{ inputs.integration_test_command || 'make test-integration' }}` so an unset caller keeps the previous default
- `enable_test_determinism`
- `test_determinism_runs`

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None. Every new input defaults to off/empty, the new job is gated on `inputs.enable_custom_checks && inputs.custom_checks != ''`, and the three newly-forwarded inputs reproduce the previous effective values when unset. No existing input changed type, default or meaning.

## Implementation notes

- The job reuses the `integration-tests` job's setup verbatim (checkout, `system_packages`, `setup-go` with cache, private-module git config), so CGO repos and private `GOPRIVATE` deps work the same way.
- All targets run even if an earlier one fails (`set +e`, failure counter), so one PR surfaces every broken guard instead of only the first — matching the frontend job's behaviour.
- `custom_checks` is passed through step `env`, never interpolated into the script body, and each target is validated against `^[A-Za-z0-9][A-Za-z0-9._-]*$` before use. Both guards exist to keep a caller-controlled string out of shell evaluation.
- Wired into `notify` (`needs` plus the `status` and `failed_jobs` expressions) so a custom-check failure is reported as such rather than silently omitted from the Slack summary.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Parsed both workflows and asserted: `custom-checks` is present in `go-pr-analysis`'s job list, both new inputs carry the intended types and off-by-default values, `notify.needs` includes `custom-checks` and its `status` expression references it, and all five inputs are forwarded by the umbrella with `integration_test_command` falling back to `make test-integration`.

Docs updated: the input table in `docs/go-pr-validation.md` now covers all five.

First consumer will be `LerianStudio/caradhras`, which needs this released before it can drop the two static-guard jobs from its own workflow file.

## Related Issues

_None._