### PR TITLE
fix(go-pr-validation): run the change detector on edited PRs

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -217,9 +217,13 @@ jobs:
     secrets: inherit
 
   # ----------------- Change Detection (gate) -----------------
+  # `edited` must stay in this list. When this job is skipped, the *-gate
+  # aggregators still run (if: always()) and receive result == 'skipped', which
+  # result-gate treats as a pass — so a run that evaluated nothing reports the
+  # required checks green. Matches js-pr-validation.yml, which already includes it.
   changes:
     name: Detect non-doc changes
-    if: contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)
+    if: contains(fromJSON('["opened","edited","synchronize","reopened","ready_for_review"]'), github.event.action)
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     permissions:
       contents: read

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -15,6 +15,8 @@ Umbrella reusable workflow for Go service repositories. A caller references this
 
 The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing — so broken change detection cannot let the required checks go green.
 
+> The aggregators run with `if: always()`, so they report on every run of this workflow. `result-gate` treats `skipped` as a pass, which is correct for the docs-only case (the detector ran and found nothing to analyse) but **not** for a run where the detector never ran at all — that would report the required checks green having evaluated nothing. The `changes` job must therefore stay reachable on every `pull_request` action type the caller listens to, `edited` included. A caller that adds an action type to its own `types:` list without it being covered here reintroduces the hole.
+
 ## Inputs
 
 | Input | Description | Type | Default |


### PR DESCRIPTION
## Description

Adds `edited` to the action-type list on the `changes` job of `go-pr-validation.yml`, matching `js-pr-validation.yml`, which already includes it.

```diff
-    if: contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)
+    if: contains(fromJSON('["opened","edited","synchronize","reopened","ready_for_review"]'), github.event.action)
```

## The bug: required checks go green having evaluated nothing

Callers list `edited` in their own `types:` (it is in the documented usage snippet in `docs/go-pr-validation.md`, so that a corrected PR title re-validates). On an `edited` event today:

1. `changes` is skipped — `edited` is not in its list.
2. `go-analysis` / `security` / `lib-version` need `needs.changes.outputs.code == 'true'`; `code` is empty, so all three are skipped. The whole `go-pr-analysis` pipeline — including its own `Detect Changes` — never even gets created.
3. The `*-gate` aggregators run anyway (`if: always()`) and receive `needs.changes.result == 'skipped'`, since `${{ needs.changes.result != 'success' && needs.changes.result || ... }}` yields `'skipped'`.
4. `src/validate/result-gate` does `if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then exit 0`.

Result: **`Go Analysis`, `Security` and `Lib Version` all report success on a run where no analysis ran.** Those are precisely the three checks this repo's own docs tell consumers to make required for branch protection.

### Observed

`LerianStudio/caradhras` PR #34, both runs on the same commit `11498104`:

| Run | Event | `Detect non-doc changes` | `Coverage (caradhras)` | `validate / Go Analysis` |
|---|---|---|---|---|
| 30299075075 | `synchronize` | ran | **failure** — `Coverage 42.0% is below threshold 80%` | **failure** |
| 30299123860 | `edited` (description edit) | skipped | job does not exist | **success** |

That PR changes `Makefile`, which is in its `shared_paths`, so every component *should* go through analysis — and does, on the `synchronize` run. The `edited` run skipped it for a reason unrelated to paths: the detector never ran. The failure only stayed visible on the PR because both runs happened to coexist on the same commit; had the `edited` run been the latest to produce those contexts on its own, branch protection would have seen three green required checks over a real coverage failure.

### Why this fix

`result-gate` treating `skipped` as a pass is correct for the case it was written for — a docs-only PR, where the detector *did* run and correctly found nothing to analyse. It cannot distinguish that from "the detector never ran", because all it receives is the string `skipped`.

Rather than teach the gate a new distinction, this keeps the detector reachable on every action type a caller listens to, which is what `js-pr-validation.yml` already does. Then `skipped` always means what `result-gate` assumes it means.

The trade-off is explicit: on an `edited` event the pipelines now run, so editing a PR description re-runs lint/tests/coverage/security. The diff is unchanged by a description edit, so `changes` yields the same `code` and the analysis is a repeat. That cost is already what the JS umbrella pays today. The alternative — gating the three `*-gate` jobs on the same action-type condition, so an `edited` run produces no contexts at all and the previous run's results stand — avoids the re-run but introduces a pattern with no precedent in this repo. Happy to switch if maintainers prefer it.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None to inputs or outputs. Behavioural change: `edited` events now run the analysis and security pipelines instead of skipping them, so those runs take longer and report real results rather than vacuous green.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Parsed both umbrellas and asserted the `changes` job's `if` expression is now byte-identical between `go-pr-validation.yml` and `js-pr-validation.yml`, and that the three `*-gate` jobs keep `if: always()` with unchanged `needs`.

The bug itself is reproducible without this branch: edit any PR's description on a repo using this umbrella and compare the resulting run's `validate / Go Analysis` against the previous `synchronize` run, as tabulated above.

Docs updated: `docs/go-pr-validation.md` now states why `skipped` is only a safe pass when the detector actually ran, and warns that a caller adding an action type not covered here reintroduces the hole.

## Related Issues

_None._