### PR TITLE
fix(go-pr-analysis): warn when custom_checks is enabled but empty

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -921,7 +921,11 @@ jobs:
   custom-checks:
     name: Custom Checks (${{ matrix.app.name }})
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks && inputs.custom_checks != ''
+    # Deliberately NOT also gated on `custom_checks != ''`. A caller that enables
+    # the gate but leaves the list empty is misconfigured, and skipping the job
+    # silently would report coverage that never happened — the run step warns
+    # instead.
+    if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     # This is the only job that runs caller-supplied commands, so it is the one
     # place an unbounded hang is plausible. Caps the 6h GitHub default while
@@ -984,6 +988,10 @@ jobs:
         env:
           CUSTOM_CHECKS: ${{ inputs.custom_checks }}
         run: |
+          if [ -z "${CUSTOM_CHECKS//[[:space:]]/}" ]; then
+            echo "::warning::enable_custom_checks is true but custom_checks is empty — no checks ran"
+            exit 0
+          fi
           set +e
           failures=0
           while IFS= read -r target; do

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -276,8 +276,12 @@ jobs:
       fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
       go_private_modules: ${{ inputs.go_private_modules }}
       enable_integration_tests: ${{ inputs.enable_integration_tests }}
-      # Empty falls through to go-pr-analysis's own default (`make test-integration`),
-      # so an unset caller keeps the previous behaviour.
+      # Intentional duplicate of go-pr-analysis's own default — KEEP IN SYNC.
+      # A reusable-workflow default applies only when the input is omitted, and a
+      # `with:` mapping cannot conditionally omit a key: passing the empty string
+      # through would reach go-pr-analysis as '' and produce an empty `run:` in its
+      # integration-tests job, which is a workflow validation error. So the literal
+      # has to be repeated here rather than deferred to.
       integration_test_command: ${{ inputs.integration_test_command || 'make test-integration' }}
       enable_test_determinism: ${{ inputs.enable_test_determinism }}
       test_determinism_runs: ${{ inputs.test_determinism_runs }}


### PR DESCRIPTION
## Description

Two follow-ups from the CodeRabbit review on #625 (the `develop` → `main` promotion carrying #623 and #624).

### 1. `custom_checks` enabled but empty no longer skips silently

The job was gated on `inputs.custom_checks != ''`, so a caller that set `enable_custom_checks: true` and forgot the list got a silently absent job — a gate reporting coverage it never provided. Dropped that clause from the `if:` and added an early guard in the run step:

```bash
if [ -z "${CUSTOM_CHECKS//[[:space:]]/}" ]; then
  echo "::warning::enable_custom_checks is true but custom_checks is empty — no checks ran"
  exit 0
fi
```

Whitespace-stripped, so a list containing only newlines warns too. Costs a runner spin-up on a misconfigured repo; that seemed clearly better than a gate that quietly claims to have run.

### 2. Corrected a misleading comment on the `integration_test_command` fallback

The comment claimed empty "falls through to go-pr-analysis's own default". It does not — the umbrella substitutes the same literal. The code is correct and load-bearing; only the comment was wrong.

The reviewer's proposed fix was to drop the fallback and pass the input through as-is. That would break callers: a reusable-workflow `default` applies only when the input is **omitted**, and a `with:` mapping cannot conditionally omit a key. An empty string therefore arrives at `go-pr-analysis` as `''`, and its integration-tests job does `run: ${{ inputs.integration_test_command }}` — an empty `run:` is a workflow validation error. Every umbrella caller with `enable_integration_tests: true` and no explicit command would fail.

So the literal has to be repeated. The comment now says that, and says why, and flags it as a keep-in-sync duplicate.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None. Change 1 only affects a configuration that was previously a silent no-op — it now emits a warning and still exits 0, so no currently-passing PR starts failing. Change 2 is comment-only.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Parsed both workflows and asserted the `custom-checks` `if:` no longer references `custom_checks`, that the guard is the first thing in the run step, and that the forwarded `integration_test_command` expression is unchanged. Ran the guard's bash condition against three inputs — empty, newlines-only, and a real target list — confirming the first two warn and exit 0 while the third proceeds.

The happy path was already exercised end to end on `LerianStudio/caradhras` PR #34, where `Custom Checks (caradhras)` ran `check-migrations`, `check-goroutines` and `check-e2e-vet` and agreed with the bespoke jobs kept as a control on the same commit.

## Related Issues

Follow-up to #623 / #624, reviewed on #625.