### PR TITLE
fix(go-pr-analysis): expose normalize_to_filter for component path collapsing

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -25,6 +25,10 @@ on:
         description: 'Directory depth level to extract app name'
         type: number
         default: 2
+      normalize_to_filter:
+        description: 'Collapse every changed file under a filter_paths entry into that one component (working_dir = the filter itself), instead of the path_level-trimmed directory. Default true: without it, a change deeper than path_level segments inside a filtered component (e.g. "apps/dict/components/hub/api/services/command/x.go" under the filter "apps/dict/components/hub/api") spawns a bogus matrix entry rooted at that subdirectory, where no Makefile and no testable package exist — so no coverage.txt is produced, the upload finds no file, and the coverage job fails with "Artifact not found". Mirrors the same input in frontend-pr-analysis.yml.'
+        type: boolean
+        default: true
       app_name_prefix:
         description: 'Prefix for app names in matrix output'
         type: string
@@ -129,6 +133,7 @@ jobs:
           path-level: ${{ inputs.path_level }}
           get-app-name: 'true'
           app-name-prefix: ${{ inputs.app_name_prefix }}
+          normalize-to-filter: ${{ inputs.normalize_to_filter }}
           fallback-app-name: ${{ inputs.app_name_prefix != '' && inputs.app_name_prefix || 'app' }}
 
   # ============================================

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -108,6 +108,10 @@ on:
         description: 'Directory depth level to extract the component name from filter_paths'
         type: number
         default: 2
+      normalize_to_filter:
+        description: 'Collapse every changed file under a filter_paths entry into that one component (working_dir = the filter itself) instead of the path_level-trimmed directory. Forwarded to go-pr-analysis; see that workflow for why the default is true.'
+        type: boolean
+        default: true
       coverage_threshold:
         description: 'Minimum coverage percentage required (0-100)'
         type: number
@@ -272,6 +276,7 @@ jobs:
       app_name_prefix: ${{ inputs.app_name_prefix }}
       filter_paths: ${{ inputs.filter_paths }}
       path_level: ${{ inputs.path_level }}
+      normalize_to_filter: ${{ inputs.normalize_to_filter }}
       coverage_threshold: ${{ inputs.coverage_threshold }}
       fail_on_coverage_threshold: ${{ inputs.fail_on_coverage_threshold }}
       go_private_modules: ${{ inputs.go_private_modules }}

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -97,6 +97,7 @@ jobs:
 | `runner_type` | GitHub runner type | No | `firmino-lxc-runners` |
 | `filter_paths` | JSON array of paths to monitor for changes. If empty, treats repo as single-app. | No | `''` |
 | `path_level` | Directory depth level to extract app name | No | `2` |
+| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one component (`working_dir` = the filter itself) instead of the `path_level`-trimmed directory. With `false`, a change deeper than `path_level` segments inside a filtered component spawns a bogus matrix entry rooted at that subdirectory — no testable package, so no `coverage.txt`, and the coverage job fails with "Artifact not found". | No | `true` |
 | `app_name_prefix` | Prefix for app names in matrix output | No | `''` |
 | `go_version` | Go version to use | No | `1.23` |
 | `golangci_lint_version` | GolangCI-Lint version | No | `v1.62.2` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -44,6 +44,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
 | `filter_paths` | Newline-separated component path prefixes for monorepo per-component analysis (lint/tests/coverage) **and** security scanning; empty = single-app root run. When using it for security, leave `dockerfile_path` empty so each component Dockerfile is discovered | string | `''` |
 | `path_level` | Directory depth level to extract the component name from `filter_paths` | number | `2` |
+| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one component instead of the `path_level`-trimmed directory; forwarded to `go-pr-analysis` | boolean | `true` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `true` |
 | `go_private_modules` | GOPRIVATE pattern for private modules | string | `''` |


### PR DESCRIPTION
## Description

`go-pr-analysis.yml` calls the `changed-paths` composite, which already supports `normalize-to-filter`, but never wired the input up. As a result `matrix.app.working_dir` was always the `path_level`-trimmed directory of each changed file rather than the `filter_paths` entry that owns it.

Consequence: a PR whose changes sit deeper than `path_level` segments inside a filtered component — and that touches no `shared_paths` entry — spawns one matrix entry per changed subdirectory, rooted at that subdirectory. There is no `Makefile` and no testable package there, so:

1. the tests job logs `No packages found after filtering /tests/ and /api/` and writes no `coverage.txt`;
2. `Upload coverage artifact` warns `No files were found with the provided path: <subdir>/coverage.txt`;
3. every `Coverage (<app>)` job then fails with `Unable to download artifact(s): Artifact not found for name: coverage-<app>`.

Real occurrence in `plugin-br-pix-switch` ([failed run](https://github.com/LerianStudio/plugin-br-pix-switch/actions/runs/30358170511/job/90271487333?pr=341)) — the detected matrix was:

```
[{"name":"plugin-br-pix-switch-dict","working_dir":"apps/dict/components/hub/api/bootstrap"},
 {"name":"plugin-br-pix-switch-dict","working_dir":"apps/dict/components/hub/api/docs"},
 {"name":"plugin-br-pix-switch-dict","working_dir":"apps/dict/components/hub/api/services/command"}]
```

instead of the single `apps/dict/components/hub/api` component that is declared in `filter_paths`. Earlier PRs on the same repo were green only because they happened to touch a `shared_paths` entry (`Makefile`), which makes `changed-paths` build the matrix straight from `filter_paths`.

This PR:

- adds the `normalize_to_filter` input to `go-pr-analysis.yml` and forwards it to the composite;
- forwards the same input through the `go-pr-validation.yml` umbrella so callers can opt out;
- documents it in `docs/go-pr-analysis-workflow.md` and `docs/go-pr-validation.md`.

Default is `true`, matching `frontend-pr-analysis.yml`, which already exposes this exact input for this exact failure mode.

### Known adjacent issue, deliberately out of scope

The coverage artifact is keyed as `coverage-${{ matrix.app.name }}`, and several components of the same app share one `matrix.app.name` (it is extracted from the `path_level` segments). Their uploads therefore collide, and each `Coverage` job grades whichever component uploaded last. Keying the artifact per component is *not* part of this PR because it would surface a second latent problem at the same time: components with no unit-testable package produce no `coverage.txt`, which yields `coverage=0` and trips `Check coverage threshold` — today masked by exactly that collision. Fixing it requires deciding whether "no coverage produced" is a skip or a failure, so it belongs in its own PR. A follow-up issue will be opened.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None for callers' configuration — the input is additive and every existing input keeps its default.

Behavior does change for monorepo callers that set `filter_paths`: `working_dir` is now the `filter_paths` entry instead of the deeper trimmed directory, and near-duplicate matrix entries for subdirectories of the same component collapse into one. That is the intended fix. A caller that depends on the previous behavior can restore it with `normalize_to_filter: false`.

## Testing

- [x] YAML syntax validated locally (`yamllint -c .yamllint.yml`, plus a full YAML parse of both workflows — only pre-existing `line-length`/`comments` warnings)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected (`frontend-pr-analysis.yml` already had this input; no other workflow reads the go matrix)

**Caller repo / workflow run:** to be validated on `LerianStudio/plugin-br-pix-switch` PR [#341](https://github.com/LerianStudio/plugin-br-pix-switch/pull/341) once this branch is available as a ref/tag — that PR is the failing case above.

## Related Issues

N/A
