### PR TITLE
feat(gitops): resolve kustomize image per gitops tag artifact

### DIFF
--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -278,16 +278,22 @@ jobs:
             echo "::error::gitops_layout=kustomize requires kustomize_base_path."
             exit 1
           fi
+          # An empty or null mapping value would resolve to nothing and silently
+          # fall back to kustomize_image_name, writing the extra artifact's tag
+          # onto the primary image — the exact failure the mapping exists to
+          # prevent. Reject it instead of resolving it.
+          MAPPED_IMAGES=0
           if [[ -n "$KUSTOMIZE_IMAGE_MAPPINGS" ]]; then
-            if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$KUSTOMIZE_IMAGE_MAPPINGS"; then
-              echo "::error::kustomize_image_mappings must be a JSON object mapping artifact names to image references."
+            if ! jq -e 'type == "object" and all(.[]; type == "string" and length > 0)' >/dev/null 2>&1 <<< "$KUSTOMIZE_IMAGE_MAPPINGS"; then
+              echo "::error::kustomize_image_mappings must be a JSON object whose every value is a non-empty image reference string."
               exit 1
             fi
+            MAPPED_IMAGES=$(jq -r 'length' <<< "$KUSTOMIZE_IMAGE_MAPPINGS")
             echo "kustomize_image_mappings:"
             jq -r 'to_entries[] | "  \(.key) -> \(.value)"' <<< "$KUSTOMIZE_IMAGE_MAPPINGS"
           fi
-          if [[ -z "$KUSTOMIZE_IMAGE_NAME" && -z "$KUSTOMIZE_IMAGE_MAPPINGS" ]]; then
-            echo "::error::gitops_layout=kustomize requires kustomize_image_name or kustomize_image_mappings."
+          if [[ -z "$KUSTOMIZE_IMAGE_NAME" && "$MAPPED_IMAGES" -eq 0 ]]; then
+            echo "::error::gitops_layout=kustomize requires kustomize_image_name or a non-empty kustomize_image_mappings."
             exit 1
           fi
 

--- a/.github/workflows/gitops-update.yml
+++ b/.github/workflows/gitops-update.yml
@@ -77,7 +77,11 @@ on:
         type: string
         default: ''
       kustomize_image_name:
-        description: 'Required when gitops_layout=kustomize. Image reference matched by `kustomize edit set image` (e.g. ghcr.io/lerianstudio/ungoliant-controller).'
+        description: 'Required when gitops_layout=kustomize, unless every image is covered by kustomize_image_mappings. Image reference matched by `kustomize edit set image` (e.g. ghcr.io/lerianstudio/ungoliant-controller). Also the fallback for artifacts absent from kustomize_image_mappings.'
+        type: string
+        default: ''
+      kustomize_image_mappings:
+        description: 'JSON object mapping artifact names to kustomize image references (e.g. {"ungoliant-api":"ghcr.io/lerianstudio/ungoliant-api"}). Use when one release publishes more than one image into the same kustomization.yaml — each downloaded artifact is named after the app that built it. Artifacts not listed fall back to kustomize_image_name. Kustomize layout only.'
         type: string
         default: ''
       kustomize_environments:
@@ -267,14 +271,23 @@ jobs:
         env:
           KUSTOMIZE_BASE_PATH: ${{ inputs.kustomize_base_path }}
           KUSTOMIZE_IMAGE_NAME: ${{ inputs.kustomize_image_name }}
+          KUSTOMIZE_IMAGE_MAPPINGS: ${{ inputs.kustomize_image_mappings }}
         run: |
           set -euo pipefail
           if [[ -z "$KUSTOMIZE_BASE_PATH" ]]; then
             echo "::error::gitops_layout=kustomize requires kustomize_base_path."
             exit 1
           fi
-          if [[ -z "$KUSTOMIZE_IMAGE_NAME" ]]; then
-            echo "::error::gitops_layout=kustomize requires kustomize_image_name."
+          if [[ -n "$KUSTOMIZE_IMAGE_MAPPINGS" ]]; then
+            if ! jq -e 'type == "object"' >/dev/null 2>&1 <<< "$KUSTOMIZE_IMAGE_MAPPINGS"; then
+              echo "::error::kustomize_image_mappings must be a JSON object mapping artifact names to image references."
+              exit 1
+            fi
+            echo "kustomize_image_mappings:"
+            jq -r 'to_entries[] | "  \(.key) -> \(.value)"' <<< "$KUSTOMIZE_IMAGE_MAPPINGS"
+          fi
+          if [[ -z "$KUSTOMIZE_IMAGE_NAME" && -z "$KUSTOMIZE_IMAGE_MAPPINGS" ]]; then
+            echo "::error::gitops_layout=kustomize requires kustomize_image_name or kustomize_image_mappings."
             exit 1
           fi
 
@@ -469,6 +482,7 @@ jobs:
           GITOPS_LAYOUT: ${{ inputs.gitops_layout }}
           KUSTOMIZE_BASE_PATH: ${{ inputs.kustomize_base_path }}
           KUSTOMIZE_IMAGE_NAME: ${{ inputs.kustomize_image_name }}
+          KUSTOMIZE_IMAGE_MAPPINGS: ${{ inputs.kustomize_image_mappings }}
           KUSTOMIZE_ENVIRONMENTS: ${{ inputs.kustomize_environments }}
           MANIFEST_FILE: shared-workflows/${{ inputs.deployment_matrix_file }}
           UPDATE_SANDBOX: ${{ inputs.update_sandbox }}
@@ -677,16 +691,37 @@ jobs:
                 FILE_BEFORE_HASH=$(sha256sum "$KUSTOMIZATION_FILE" | cut -d' ' -f1)
 
                 # Apply each available artifact tag via `kustomize edit set image`.
-                # The artifact value (TAG) is the only thing that varies; we set the
-                # same image_name for every artifact since kustomize layouts typically
-                # have a single image per kustomization.yaml. If an app has multiple
-                # images, callers can extend kustomize_image_name later (out of scope here).
+                # Each artifact file is named after the app that built it
+                # (build.yml writes gitops-tags/<app>.tag), so that basename is the
+                # key used to resolve which image the tag belongs to:
+                #   kustomize_image_mappings[<app>], falling back to
+                #   kustomize_image_name when the app is not listed.
+                # A release publishing more than one image into the same
+                # kustomization.yaml maps every extra app explicitly; single-image
+                # callers leave the mapping empty and every artifact resolves to
+                # kustomize_image_name, exactly as before.
                 for artifact_file in .gitops-tags/*; do
                   [[ -f "$artifact_file" ]] || continue
                   TAG="$(cut -d= -f2 < "$artifact_file" | tr -d '[:space:]')"
                   [[ -n "$TAG" ]] || continue
-                  echo "    kustomize edit set image ${KUSTOMIZE_IMAGE_NAME}=${KUSTOMIZE_IMAGE_NAME}:${TAG}"
-                  ( cd "gitops/${TARGET_DIR}" && kustomize edit set image "${KUSTOMIZE_IMAGE_NAME}=${KUSTOMIZE_IMAGE_NAME}:${TAG}" )
+
+                  ARTIFACT_APP="$(basename "$artifact_file")"
+                  ARTIFACT_APP="${ARTIFACT_APP%.tag}"
+
+                  IMAGE_NAME=""
+                  if [[ -n "$KUSTOMIZE_IMAGE_MAPPINGS" ]]; then
+                    IMAGE_NAME=$(jq -r --arg app "$ARTIFACT_APP" '.[$app] // empty' <<< "$KUSTOMIZE_IMAGE_MAPPINGS")
+                  fi
+                  if [[ -z "$IMAGE_NAME" ]]; then
+                    IMAGE_NAME="$KUSTOMIZE_IMAGE_NAME"
+                  fi
+                  if [[ -z "$IMAGE_NAME" ]]; then
+                    echo "::warning::No kustomize image resolved for artifact '${ARTIFACT_APP}' — not in kustomize_image_mappings and kustomize_image_name is empty. Skipping."
+                    continue
+                  fi
+
+                  echo "    ${ARTIFACT_APP}: kustomize edit set image ${IMAGE_NAME}=${IMAGE_NAME}:${TAG}"
+                  ( cd "gitops/${TARGET_DIR}" && kustomize edit set image "${IMAGE_NAME}=${IMAGE_NAME}:${TAG}" )
                 done
 
                 FILE_AFTER_HASH=$(sha256sum "$KUSTOMIZATION_FILE" | cut -d' ' -f1)

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -221,8 +221,12 @@ on:
         description: 'Required when gitops_layout=kustomize. Path within the gitops repo to the kustomization folder (e.g. environments/anacleto/kustomize/ungoliant-controller). Supports ${SERVER} and ${ENV} placeholders.'
         type: string
         default: ''
+      kustomize_image_mappings:
+        description: 'JSON object mapping artifact names to kustomize image references (e.g. {"ungoliant-api":"ghcr.io/lerianstudio/ungoliant-api"}). Use when extra_builds groups publish additional images into the same kustomization.yaml — artifacts not listed fall back to kustomize_image_name. Requires gitops_artifact_pattern to also match the extra groups (the default only matches the repository name).'
+        type: string
+        default: ''
       kustomize_image_name:
-        description: 'Required when gitops_layout=kustomize. Image reference matched by `kustomize edit set image` (e.g. ghcr.io/lerianstudio/ungoliant-controller).'
+        description: 'Required when gitops_layout=kustomize, unless every image is covered by kustomize_image_mappings. Image reference matched by `kustomize edit set image` (e.g. ghcr.io/lerianstudio/ungoliant-controller).'
         type: string
         default: ''
       kustomize_environments:
@@ -701,6 +705,7 @@ jobs:
       gitops_layout: ${{ inputs.gitops_layout }}
       kustomize_base_path: ${{ inputs.kustomize_base_path }}
       kustomize_image_name: ${{ inputs.kustomize_image_name }}
+      kustomize_image_mappings: ${{ inputs.kustomize_image_mappings }}
       kustomize_environments: ${{ inputs.kustomize_environments }}
       kustomize_version: ${{ inputs.kustomize_version }}
       argocd_app_name_template: ${{ inputs.argocd_app_name_template }}

--- a/docs/gitops-update-workflow.md
+++ b/docs/gitops-update-workflow.md
@@ -92,6 +92,35 @@ Notes:
 - Use `${SERVER}` / `${ENV}` placeholders in `kustomize_base_path` for multi-cluster / multi-env kustomize layouts (e.g. `environments/${SERVER}/kustomize/${ENV}/my-app`).
 - `configmap_updates` is ignored under `gitops_layout=kustomize` (out of scope for v1).
 
+### Kustomize with More Than One Image
+
+When a single release publishes several images into the same `kustomization.yaml` — for example a controller and a slimmer read API built from the same module — map each extra image to the artifact that carries its tag. Every downloaded artifact file is named after the app that built it (`build.yml` writes `gitops-tags/<app>.tag`), and that name is the mapping key.
+
+```yaml
+update_gitops:
+  needs: build
+  if: needs.build.result == 'success'
+  uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gitops-update.yml@v1.0.0
+  with:
+    gitops_repository: LerianStudio/midaz-firmino-gitops
+    gitops_layout: kustomize
+    kustomize_base_path: environments/anacleto/kustomize/ungoliant-controller
+    kustomize_image_name: ghcr.io/lerianstudio/ungoliant-controller
+    kustomize_image_mappings: |
+      {
+        "ungoliant-api": "ghcr.io/lerianstudio/ungoliant-api"
+      }
+    artifact_pattern: 'gitops-tags-*'
+    argocd_app_name_template: '{server}-{app}'
+  secrets: inherit
+```
+
+Notes:
+- Artifacts absent from the mapping fall back to `kustomize_image_name`, so single-image callers need no mapping at all.
+- An artifact that resolves to neither (empty mapping entry and empty `kustomize_image_name`) is skipped with a warning instead of being written under the wrong image name.
+- `artifact_pattern` must match the extra apps too. The default derived from the repository name only matches the primary app, so a second image named after a component needs a broader pattern such as `gitops-tags-*`.
+- All images resolve into the same `kustomization.yaml` (`kustomize_base_path`). A second image living under a different path is not supported yet.
+
 ### Multi-Component Example (Midaz)
 
 ```yaml
@@ -135,7 +164,8 @@ update_gitops:
 | `configmap_updates` | string | - | JSON object mapping artifact names to configmap keys. Helmfile layout only; ignored for kustomize |
 | `gitops_layout` | string | `helmfile` | GitOps layout strategy: `helmfile` (default) or `kustomize` |
 | `kustomize_base_path` | string | - | Required when `gitops_layout=kustomize`. Path within the gitops repo to the kustomization folder. Supports `${SERVER}` / `${ENV}` placeholders |
-| `kustomize_image_name` | string | - | Required when `gitops_layout=kustomize`. Image reference matched by `kustomize edit set image` |
+| `kustomize_image_name` | string | - | Required when `gitops_layout=kustomize`, unless every image is covered by `kustomize_image_mappings`. Image reference matched by `kustomize edit set image`; also the fallback for artifacts absent from the mapping |
+| `kustomize_image_mappings` | string | - | JSON object mapping artifact names to kustomize image references. Use when one release publishes more than one image into the same `kustomization.yaml`. Kustomize layout only |
 | `kustomize_environments` | string | - | Optional space-separated env list overriding the default tag-based env loop when `gitops_layout=kustomize`. Leave empty for layouts without env split |
 | `kustomize_version` | string | `v5.4.3` | Version of kustomize CLI to install (only when `gitops_layout=kustomize`) |
 | `argocd_app_name_template` | string | `{server}-{app}-{env}` | Template for the ArgoCD application name. Supports `{server}`, `{app}`, `{env}`. For kustomize layouts without env split, use e.g. `{server}-{app}` |

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -72,7 +72,8 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `enable_docker_login` | Log in to DockerHub in the gitops-update job | boolean | `false` |
 | `gitops_layout` | GitOps layout strategy: `helmfile` (default, current behavior) or `kustomize` | string | `helmfile` |
 | `kustomize_base_path` | Required when `gitops_layout=kustomize`. Path within the gitops repo to the kustomization folder (supports `${SERVER}`/`${ENV}` placeholders) | string | `''` |
-| `kustomize_image_name` | Required when `gitops_layout=kustomize`. Image reference matched by `kustomize edit set image` | string | `''` |
+| `kustomize_image_name` | Required when `gitops_layout=kustomize`, unless every image is covered by `kustomize_image_mappings`. Image reference matched by `kustomize edit set image`; also the fallback for artifacts absent from the mapping | string | `''` |
+| `kustomize_image_mappings` | JSON object mapping artifact names to kustomize image references, for `extra_builds` groups publishing additional images into the same `kustomization.yaml` (see [Multiple build groups](#multiple-build-groups)) | string | `''` |
 | `kustomize_environments` | Optional space-separated env list overriding the default tag-based env loop when `gitops_layout=kustomize` | string | `''` |
 | `kustomize_version` | Version of kustomize CLI to install (used only when `gitops_layout=kustomize`) | string | `v5.4.3` |
 | `argocd_app_name_template` | Template for the ArgoCD application name. Placeholders `{server}`, `{app}`, `{env}`. For kustomize layouts without env split use e.g. `{server}-{app}` | string | `{server}-{app}-{env}` |
@@ -214,6 +215,26 @@ Extra builds run on tag push (beta/rc, and stable when `build_on_release` is off
 > **Independently-tagged component** — a group with `tag_prefix` set (e.g. `matcher-mcp-v`) only builds when the triggering tag starts with that prefix, letting a component with its own semantic-release line and tag scheme (decoupled from the app's `vX.Y.Z`) share this workflow without building on every unrelated tag push. Set the top-level `tag_prefix` input too (e.g. `v`), so the *primary* build also ignores that component's tags — otherwise a `matcher-mcp-v1.2.3` push would still trigger the primary app build.
 
 > **Important** — `update_gitops` downloads artifacts by `gitops_artifact_pattern` (default `gitops-tags-<repo-name>*`). When an extra build produces an image whose name does **not** start with the repo name (e.g. `mock-btg-server`), set `gitops_artifact_pattern` to a wildcard that captures every image (e.g. `gitops-tags-*`), otherwise that image's tag artifact is skipped.
+
+> **Kustomize layout** — under `gitops_layout: kustomize` the single top-level `kustomize_image_name` used to be applied to *every* downloaded artifact, so an extra build's tag could never reach its own image: both `newTag`s resolved to the primary image name. Map each extra image to the artifact that carries its tag with `kustomize_image_mappings`, keyed by app name (`build.yml` writes `gitops-tags/<app>.tag`). Artifacts not listed still fall back to `kustomize_image_name`, and one that resolves to neither is skipped with a warning rather than written under the wrong image. Set `gitops_artifact_pattern: 'gitops-tags-*'` as well, per the note above — the default pattern only matches the repository name. All images must live in the same `kustomization.yaml`; a second image under a different `kustomize_base_path` is not supported yet.
+>
+> ```yaml
+> kustomize_image_name: ghcr.io/lerianstudio/ungoliant-controller
+> kustomize_image_mappings: |
+>   {
+>     "ungoliant-api": "ghcr.io/lerianstudio/ungoliant-api"
+>   }
+> gitops_artifact_pattern: 'gitops-tags-*'
+> extra_builds: |
+>   [
+>     {
+>       "filter_paths": "components/api",
+>       "app_name_overrides": "components/api:ungoliant-api",
+>       "shared_paths": "go.mod\ngo.sum\ncmd/\ninternal/\ncomponents/api/",
+>       "enable_gitops_artifacts": true
+>     }
+>   ]
+> ```
 
 > **Separate ArgoCD Application** — the wildcard-pattern approach above only works when the extra image is deployed *within the same app's* `values.yaml` (different nested key, same `app_name`/directory). If the extra build's component is its own, independent ArgoCD Application (its own `environments/*/helmfile/applications/<other-app-name>/values.yaml`), the single `update_gitops` job can't target it — `app_name` is one value per job call. Add a second, dedicated job in your caller `release.yml` that calls `gitops-update.yml` directly with that component's own `app_name`, `artifact_pattern`, and `yaml_key_mappings`, independent of the primary `update_gitops`. The primary `update_gitops` job only runs when the primary build actually produced artifacts (`needs.build.outputs.has_builds == 'true'`), so it skips cleanly — instead of failing — on releases where only an `extra_builds` group changed.
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`extra_builds` lets one release publish several images, and each group can opt into gitops artifacts — but under `gitops_layout: kustomize` the tag of an extra image could never reach it. The apply loop used the single top-level `kustomize_image_name` for **every** downloaded artifact:

```bash
# gitops-update.yml, before
for artifact_file in .gitops-tags/*; do
  TAG="$(cut -d= -f2 < "$artifact_file" | tr -d '[:space:]')"
  kustomize edit set image "${KUSTOMIZE_IMAGE_NAME}=${KUSTOMIZE_IMAGE_NAME}:${TAG}"
done
```

So both `newTag` values resolved to the primary image name and the second image had to be pinned by hand in `kustomization.yaml`, where it goes stale silently — a correctness risk, since the workload keeps running old code against a schema or API contract that has moved on.

**How the image is resolved now.** Every artifact file is named after the app that built it (`build.yml` writes `gitops-tags/<app>.tag`), so that basename is the key:

1. `kustomize_image_mappings[<app>]` when present
2. otherwise `kustomize_image_name`
3. neither → `::warning::` and the artifact is skipped, instead of being written under the wrong image name

`kustomize_image_mappings` is a JSON object mapping artifact names to image references — the same shape as `yaml_key_mappings` / `configmap_updates` for the helmfile layout. `go-release.yml` exposes it and forwards it to `update_gitops`.

The `Validate kustomize inputs` step now accepts the mapping as an alternative to `kustomize_image_name`, rejects a mapping that is not a JSON object, and logs the resolved `app -> image` pairs.

**Why not per `extra_builds` group.** The issue proposed `matrix.group.kustomize_image_name || inputs.kustomize_image_name`, but `update_gitops` is a single aggregating job (`go-release.yml:667`) with no matrix — it downloads every group's artifact and applies them together, as the comment above that job already states. There is no `matrix.group` at that point, so the mapping is keyed by app name instead. The result is the same for callers, and it also covers a repository whose extra image comes from a group that did not build in the current run.

Usage for the case in the issue:

```yaml
kustomize_image_name: ghcr.io/lerianstudio/ungoliant-controller
kustomize_image_mappings: |
  {
    "ungoliant-api": "ghcr.io/lerianstudio/ungoliant-api"
  }
gitops_artifact_pattern: 'gitops-tags-*'
extra_builds: |
  [
    {
      "filter_paths": "components/api",
      "app_name_overrides": "components/api:ungoliant-api",
      "shared_paths": "go.mod\ngo.sum\ncmd/\ninternal/\ncomponents/api/",
      "enable_gitops_artifacts": true
    }
  ]
```

`gitops_artifact_pattern` matters here: the default is `gitops-tags-<repo-name>*`, which does not match `gitops-tags-ungoliant-api`, so without a broader pattern that tag artifact is never downloaded in the first place. That was already documented for the helmfile layout and the new kustomize note points at it.

Out of scope, stated explicitly in the docs: a second image living under a different `kustomize_base_path`. All mapped images resolve into the same `kustomization.yaml`, which is what the reported case needs; per-path support would be additive later.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `kustomize_image_mappings` defaults to `''`, in which case every artifact resolves to `kustomize_image_name` exactly as before. The only validation change is a relaxation: `kustomize_image_name` may now be omitted when the mapping covers every image, so no configuration that passes today starts failing.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed: `yaml.safe_load` over both changed workflows; the resolution chain was exercised outside CI with the same `jq` expression — mapped app resolves to its own image, unmapped app falls back to `kustomize_image_name`, and a JSON array is rejected by the `type == "object"` check while the object is accepted. All new values reach bash through `env:`, with no `${{ }}` interpolation added inside any `run:` block. The helmfile path is untouched: the changes are inside the `if [[ "$GITOPS_LAYOUT" == "kustomize" ]]` branch and its validation step.

## Related Issues

Closes #630
