### PR TITLE
feat(deploy): register br-consignado-gw on benedita

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -86,6 +86,7 @@ apps:
     - br-slc
     - br-ccs
     - br-sisbajud
+    - br-consignado-gw
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -187,6 +188,7 @@ clusters:
       - br-slc
       - br-ccs
       - br-sisbajud
+      - br-consignado-gw
       - mock-btg-server
       - backoffice-console
       - cs-platform


### PR DESCRIPTION
Registers `br-consignado-gw` in the shared deployment matrix for Benedita only.

This lets the corrected gateway release pipeline resolve the internal GitOps app once its Helm values exist. Anacleto remains explicitly out of scope.

Validation: YAML parsed; registry and Benedita membership are unique; no Anacleto registration.