### PR TITLE
chore(config): register billing-api in the deployment matrix

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -106,6 +106,7 @@ apps:
     # Benedita-exclusive
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
+    - billing-api                 # Lago-backed billing gateway (benedita only); values at dev-st/stg-st. The Lago install it fronts lives at cross/, the gateway itself does not
 
 clusters:
   anacleto:
@@ -190,3 +191,4 @@ clusters:
       - go-boilerplate-ddd
       - severino-bot
       - streaming-hub
+      - billing-api


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Registers **`billing-api`** in `config/deployment-matrix.yml` — two lines: `apps.registry` and `clusters.benedita.apps`.

`billing-api` (the Lago-backed billing gateway) is deployed to benedita `dev-st` and `stg-st`. Without an entry here `gitops-update` resolves no cluster for it, so its release workflow has been running with `enable_gitops_update: false` and every image bump has been a hand-written PR in `lerian-internal-gitops` — three of them so far, chasing the `beta.1 → beta.2 → beta.3` boot fixes.

**Targeted at `main` directly as a hotfix.** That is not a shortcut around `develop`: `gitops-update.yml` reads the manifest from `deployment_matrix_ref`, whose **default is `main`**, not from the tag the caller pins. So the entry only takes effect once it is on `main`, and it takes effect immediately for every caller regardless of the shared-workflows version they pin.

### Placement

Registered under **Benedita-exclusive** — the app runs on that cluster only.

Worth stating explicitly because it is easy to get wrong: the values live at `dev-st`/`stg-st`, **not** `cross`. The Lago install the gateway fronts is the cross one (`lago-api-svc.lago-cross`), but the gateway itself is per-environment — it talks to the per-environment `plugin-access-manager` and Redpanda broker. So it needs **no** `app_helmfile_env` override, unlike `rosiehr`/`forge`/`lerian-map`.

`dev-mt` and `prd-st` have no `values.yaml` yet. `gitops-update` logs missing files as *skipped* rather than failing (verified in the `Apply tags to values.yaml` step — `MISSING_FILES` is only reported, never fatal), so a beta tag updates `dev-st` alone and nothing breaks as the other environments come online later.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [x] `chore`: Configuration / manifest change (deployment matrix registration)

## Breaking Changes

None. Adding an app to the manifest cannot affect resolution for any other app — each caller looks up only its own `app_name`.

## Testing

- [x] YAML syntax validated locally (parsed with `yaml.safe_load`)
- [x] Integrity checked: every app listed in both cluster blocks resolves to an entry in `apps.registry`, and `billing-api` appears in the registry and in `benedita` exactly once
- [ ] Triggered a real workflow run on a caller repository — not yet: the caller side (`enable_gitops_artifacts` + `gitops_yaml_key_mappings` in `LerianStudio/billing-api`) is a separate PR that has to land after this one, and the end-to-end proof is its next beta tag
- [x] Verified all existing inputs still work with default values — no input or workflow logic touched
- [x] Confirmed no secrets or tokens are printed in logs — manifest data only
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** follows in the `billing-api` release run once its workflow PR merges.

## Related Issues

None.
