### PR TITLE
feat(release): develop to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
         description: 'Runner to use for the workflow'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      build_runner_type:
+        description: 'Optional runner override for the Build jobs only (prepare/notify stay on runner_type). Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. If not provided, builds from root.'
         type: string
@@ -277,7 +281,7 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.has_builds == 'true'
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.build_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     name: Build ${{ matrix.app.name }}
     permissions:
       contents: read

--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -11,6 +11,22 @@ on:
         description: 'GitHub runner type'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      lint_runner_type:
+        description: 'Optional runner override for the Lint jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      test_runner_type:
+        description: 'Optional runner override for the Tests jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      coverage_runner_type:
+        description: 'Optional runner override for the Coverage jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      build_runner_type:
+        description: 'Optional runner override for the Build jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       filter_paths:
         description: 'JSON array of paths to monitor for changes (e.g., ["apps/api", "apps/worker"]). If empty, treats repo as single-app and runs against root directory.'
         type: string
@@ -143,7 +159,7 @@ jobs:
     name: Lint (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_lint
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.lint_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -335,7 +351,7 @@ jobs:
     name: Tests (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_tests
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.test_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -514,7 +530,7 @@ jobs:
     name: Coverage (${{ matrix.app.name }})
     needs: [detect-changes, tests]
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_coverage
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.coverage_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -795,7 +811,7 @@ jobs:
     name: Build (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_build
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.build_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -12,6 +12,10 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      gate_runner_type:
+        description: 'Optional runner override for the umbrella utility jobs only (Detect non-doc changes and the Go Analysis / Security / Lib Version result gates). Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       dry_run:
         description: 'Preview metadata validations without posting comments or labels'
         required: false
@@ -82,12 +86,32 @@ on:
         description: 'Target branches that require source branch validation (pipe-separated)'
         type: string
         default: 'main'
+      pr_checks_summary_runner_type:
+        description: 'Optional runner override for the PR Checks Summary job only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
 
       # ----------------- Go analysis (go-pr-analysis.yml) -----------------
       go_version:
         description: 'Go version to use'
         type: string
         default: '1.23'
+      lint_runner_type:
+        description: 'Optional runner override for the Go analysis Lint jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      test_runner_type:
+        description: 'Optional runner override for the Go analysis Tests jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      coverage_runner_type:
+        description: 'Optional runner override for the Go analysis Coverage jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      build_runner_type:
+        description: 'Optional runner override for the Go analysis Build jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       golangci_lint_version:
         description: 'GolangCI-Lint version'
         type: string
@@ -156,6 +180,10 @@ on:
       # ----------------- Security (pr-security-scan.yml) -----------------
       ignore_file:
         description: 'Path to Trivy ignore file (e.g., .trivyignore.yaml)'
+        type: string
+        default: ''
+      security_scan_runner_type:
+        description: 'Optional runner override for the security_scan jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
         type: string
         default: ''
       enable_docker_scan:
@@ -229,6 +257,7 @@ jobs:
     uses: ./.github/workflows/pr-validation.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      pr_checks_summary_runner_type: ${{ inputs.pr_checks_summary_runner_type }}
       dry_run: ${{ inputs.dry_run }}
       pr_title_types: ${{ inputs.pr_title_types }}
       pr_title_scopes: ${{ inputs.pr_title_scopes }}
@@ -248,7 +277,7 @@ jobs:
   changes:
     name: Detect non-doc changes
     if: contains(fromJSON('["opened","edited","synchronize","reopened","ready_for_review"]'), github.event.action)
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     permissions:
       contents: read
       pull-requests: read
@@ -270,6 +299,10 @@ jobs:
     uses: ./.github/workflows/go-pr-analysis.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      lint_runner_type: ${{ inputs.lint_runner_type }}
+      test_runner_type: ${{ inputs.test_runner_type }}
+      coverage_runner_type: ${{ inputs.coverage_runner_type }}
+      build_runner_type: ${{ inputs.build_runner_type }}
       go_version: ${{ inputs.go_version }}
       golangci_lint_version: ${{ inputs.golangci_lint_version }}
       golangci_lint_args: ${{ inputs.golangci_lint_args }}
@@ -300,7 +333,7 @@ jobs:
     name: Go Analysis
     needs: [changes, go-analysis]
     if: always()
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
       - name: Aggregate Go Analysis result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -316,6 +349,7 @@ jobs:
     uses: ./.github/workflows/pr-security-scan.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      security_scan_runner_type: ${{ inputs.security_scan_runner_type }}
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
@@ -333,7 +367,7 @@ jobs:
     name: Security
     needs: [changes, security]
     if: always()
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
       - name: Aggregate security result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1
@@ -359,7 +393,7 @@ jobs:
     name: Lib Version
     needs: [changes, lib-version]
     if: always()
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
       - name: Aggregate Lib Version result
         uses: LerianStudio/github-actions-shared-workflows/src/validate/result-gate@v1

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -12,6 +12,14 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      build_runner_type:
+        description: 'Optional runner override for the Build jobs only (forwarded to build.yml; prepare/notify stay on runner_type). Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      release_runner_type:
+        description: 'Optional runner override for the Release (publish) jobs only (forwarded to release.yml as publish_runner_type). Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       dry_run:
         description: 'Reserved. Downstream release/build/gitops workflows do not yet expose a dry-run mode.'
         required: false
@@ -393,6 +401,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      publish_runner_type: ${{ inputs.release_runner_type }}
       semantic_version: ${{ inputs.semantic_version }}
       enable_changelog: ${{ inputs.enable_changelog }}
       enable_major_tag: ${{ inputs.enable_major_tag }}
@@ -433,6 +442,7 @@ jobs:
       release_version: ${{ github.ref_type == 'branch' && needs.release.outputs.new_release_version || '' }}
       checkout_ref: ${{ github.ref_type == 'branch' && needs.release.outputs.new_release_git_tag || '' }}
       runner_type: ${{ inputs.runner_type }}
+      build_runner_type: ${{ inputs.build_runner_type }}
       enable_dockerhub: ${{ inputs.enable_dockerhub }}
       enable_ghcr: ${{ inputs.enable_ghcr }}
       enable_gitops_artifacts: ${{ inputs.enable_gitops_artifacts }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -648,6 +648,7 @@ jobs:
       # app's version. Do not make this conditional on ref_type.
       tag_prefix: ${{ matrix.group.tag_prefix }}
       runner_type: ${{ inputs.runner_type }}
+      build_runner_type: ${{ inputs.build_runner_type }}
       enable_dockerhub: ${{ (matrix.group.enable_dockerhub == null && inputs.enable_dockerhub == true) || matrix.group.enable_dockerhub == true }}
       enable_ghcr: ${{ (matrix.group.enable_ghcr == null && inputs.enable_ghcr == true) || matrix.group.enable_ghcr == true }}
       dockerhub_org: ${{ inputs.dockerhub_org }}

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -12,6 +12,10 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      release_runner_type:
+        description: 'Optional runner override for the Release (publish) jobs only (forwarded to release.yml as publish_runner_type). Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       dry_run:
         description: 'Run semantic-release in dry-run mode (no tags/releases created) and preview the backmerge instead of applying it'
         required: false
@@ -299,6 +303,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      publish_runner_type: ${{ inputs.release_runner_type }}
       dry_run: ${{ inputs.dry_run }}
       semantic_version: ${{ inputs.semantic_version }}
       enable_changelog: ${{ inputs.enable_changelog }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -14,6 +14,10 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      security_scan_runner_type:
+        description: 'Optional runner override for the security_scan jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       filter_paths:
         description: 'Paths to monitor for changes (newline separated). If not provided, treats as single app repo'
         type: string
@@ -161,7 +165,7 @@ jobs:
   security_scan:
     needs: prepare_matrix
     if: needs.prepare_matrix.outputs.matrix != '[]'
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.security_scan_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       max-parallel: 1
       fail-fast: false

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,6 +13,10 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      pr_checks_summary_runner_type:
+        description: 'Optional runner override for the PR Checks Summary job only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       dry_run:
         description: Preview validations without posting comments or labels
         required: false
@@ -174,7 +178,7 @@ jobs:
   # ----------------- PR Checks Summary -----------------
   pr-checks-summary:
     name: PR Checks Summary
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.pr_checks_summary_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     needs: [blocking-checks, advisory-checks]
     if: always()
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ on:
         description: 'Runner to use for the workflow'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      publish_runner_type:
+        description: 'Optional runner override for the Release (publish) jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. If not provided, treats as single app repo.'
         type: string
@@ -185,7 +189,7 @@ jobs:
   publish_release:
     needs: prepare
     if: needs.prepare.outputs.has_changes == 'true' && needs.prepare.outputs.should_skip != 'true'
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.publish_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     environment:
       name: create_release
     name: Release ${{ matrix.app.name }}

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -108,9 +108,6 @@ apps:
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
 
-    # Provisioned by Severino (app-provisioning automation)
-    - severino-testing-final
-
 clusters:
   anacleto:
     # Anacleto hosts two parallel test types (chaos, fuzzing), each with two
@@ -134,9 +131,6 @@ clusters:
       - br-sisbajud
       - lender
       - ungoliant-controller
-
-      # Provisioned by Severino (app-provisioning automation)
-      - severino-testing-final
 
   benedita:
     # Benedita hosts two parallel variants per environment as sibling namespaces:
@@ -198,6 +192,3 @@ clusters:
       - go-boilerplate-ddd
       - severino-bot
       - streaming-hub
-
-      # Provisioned by Severino (app-provisioning automation)
-      - severino-testing-final

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -87,6 +87,7 @@ apps:
     - br-ccs
     - br-sisbajud
     - br-consignado-gw
+    - streaming-hub
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -106,12 +107,6 @@ apps:
     # Benedita-exclusive
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
-
-    # Provisioned by Severino (app-provisioning automation)
-    - severino-teste-4
-    - severino-teste-5
-    - severino-teste-6
-    - severino-teste-7
 
 clusters:
   anacleto:
@@ -136,10 +131,6 @@ clusters:
       - br-sisbajud
       - lender
       - ungoliant-controller
-
-      # Provisioned by Severino (app-provisioning automation)
-      - severino-teste-6
-      - severino-teste-7
 
   benedita:
     # Benedita hosts two parallel variants per environment as sibling namespaces:
@@ -200,8 +191,4 @@ clusters:
       - rosiehr
       - go-boilerplate-ddd
       - severino-bot
-
-      # Provisioned by Severino (app-provisioning automation)
-      - severino-teste-4
-      - severino-teste-5
-      - severino-teste-6
+      - streaming-hub

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -86,6 +86,7 @@ apps:
     - br-slc
     - br-ccs
     - br-sisbajud
+    - br-consignado-gw
 
     # Test/mock infrastructure
     - mock-btg-server             # benedita only (-st variant); companion to plugin-br-pix-indirect-btg
@@ -187,6 +188,7 @@ clusters:
       - br-slc
       - br-ccs
       - br-sisbajud
+      - br-consignado-gw
       - mock-btg-server
       - backoffice-console
       - cs-platform

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -108,6 +108,9 @@ apps:
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
 
+    # Provisioned by Severino (app-provisioning automation)
+    - severino-testing-final
+
 clusters:
   anacleto:
     # Anacleto hosts two parallel test types (chaos, fuzzing), each with two
@@ -131,6 +134,9 @@ clusters:
       - br-sisbajud
       - lender
       - ungoliant-controller
+
+      # Provisioned by Severino (app-provisioning automation)
+      - severino-testing-final
 
   benedita:
     # Benedita hosts two parallel variants per environment as sibling namespaces:
@@ -192,3 +198,6 @@ clusters:
       - go-boilerplate-ddd
       - severino-bot
       - streaming-hub
+
+      # Provisioned by Severino (app-provisioning automation)
+      - severino-testing-final

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -96,6 +96,7 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `build_runner_type` | string | `''` | Optional runner override for the Build jobs only (prepare/notify stay on `runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` |
 | `filter_paths` | string | `''` | Newline-separated list of path prefixes. If empty, builds from root (single-app mode) |
 | `path_level` | string | `2` | Directory depth for app name extraction |
 | `enable_dockerhub` | boolean | `true` | Enable pushing to DockerHub |

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -96,9 +96,9 @@ jobs:
 |-------|-------------|----------|---------|
 | `runner_type` | GitHub runner type | No | `firmino-lxc-runners` |
 | `lint_runner_type` | Optional runner override for the Lint jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
-| `test_runner_type` | Optional runner override for the Tests jobs only | No | `''` |
-| `coverage_runner_type` | Optional runner override for the Coverage jobs only | No | `''` |
-| `build_runner_type` | Optional runner override for the Build jobs only | No | `''` |
+| `test_runner_type` | Optional runner override for the Tests jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
+| `coverage_runner_type` | Optional runner override for the Coverage jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
+| `build_runner_type` | Optional runner override for the Build jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
 | `filter_paths` | JSON array of paths to monitor for changes. If empty, treats repo as single-app. | No | `''` |
 | `path_level` | Directory depth level to extract app name | No | `2` |
 | `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one component (`working_dir` = the filter itself) instead of the `path_level`-trimmed directory. With `false`, a change deeper than `path_level` segments inside a filtered component spawns a bogus matrix entry rooted at that subdirectory — no testable package, so no `coverage.txt`, and the coverage job fails with "Artifact not found". | No | `true` |

--- a/docs/go-pr-analysis-workflow.md
+++ b/docs/go-pr-analysis-workflow.md
@@ -95,6 +95,10 @@ jobs:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `runner_type` | GitHub runner type | No | `firmino-lxc-runners` |
+| `lint_runner_type` | Optional runner override for the Lint jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
+| `test_runner_type` | Optional runner override for the Tests jobs only | No | `''` |
+| `coverage_runner_type` | Optional runner override for the Coverage jobs only | No | `''` |
+| `build_runner_type` | Optional runner override for the Build jobs only | No | `''` |
 | `filter_paths` | JSON array of paths to monitor for changes. If empty, treats repo as single-app. | No | `''` |
 | `path_level` | Directory depth level to extract app name | No | `2` |
 | `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one component (`working_dir` = the filter itself) instead of the `path_level`-trimmed directory. With `false`, a change deeper than `path_level` segments inside a filtered component spawns a bogus matrix entry rooted at that subdirectory — no testable package, so no `coverage.txt`, and the coverage job fails with "Artifact not found". | No | `true` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -22,6 +22,13 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | Input | Description | Type | Default |
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `gate_runner_type` | Optional runner override for the umbrella utility jobs only (Detect non-doc changes + Go Analysis / Security / Lib Version result gates); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
+| `lint_runner_type` | Optional runner override for the Go analysis Lint jobs only | string | `''` |
+| `test_runner_type` | Optional runner override for the Go analysis Tests jobs only | string | `''` |
+| `coverage_runner_type` | Optional runner override for the Go analysis Coverage jobs only | string | `''` |
+| `build_runner_type` | Optional runner override for the Go analysis Build jobs only | string | `''` |
+| `security_scan_runner_type` | Optional runner override for the security_scan jobs only | string | `''` |
+| `pr_checks_summary_runner_type` | Optional runner override for the PR Checks Summary job only | string | `''` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -27,7 +27,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
 | `build_runner_type` | Optional runner override for the Build jobs only (forwarded to build.yml; prepare/notify stay on `runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
-| `release_runner_type` | Optional runner override for the Release (publish) jobs only (forwarded to release.yml as `publish_runner_type`) | string | `''` |
+| `release_runner_type` | Optional runner override for the Release (publish) jobs only (forwarded to release.yml as `publish_runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
 | `dry_run` | Reserved (downstream workflows have no dry-run mode yet) | boolean | `false` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `semantic_version` | semantic-release version | string | `23.0.8` |

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -26,6 +26,8 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | Input | Description | Type | Default |
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `build_runner_type` | Optional runner override for the Build jobs only (forwarded to build.yml; prepare/notify stay on `runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
+| `release_runner_type` | Optional runner override for the Release (publish) jobs only (forwarded to release.yml as `publish_runner_type`) | string | `''` |
 | `dry_run` | Reserved (downstream workflows have no dry-run mode yet) | boolean | `false` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `semantic_version` | semantic-release version | string | `23.0.8` |

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -28,6 +28,7 @@ Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services â€
 | Input | Description | Type | Default |
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `release_runner_type` | Optional runner override for the Release (publish) jobs only (forwarded to release.yml as `publish_runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
 | `dry_run` | Run semantic-release and build in dry-run mode (no tags/releases/images created); also skips the E2E test job entirely | boolean | `false` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `semantic_version` | semantic-release version | string | `23.0.8` |

--- a/docs/pr-security-scan-workflow.md
+++ b/docs/pr-security-scan-workflow.md
@@ -186,6 +186,7 @@ The detection regex can be overridden centrally through the optional **organizat
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
+| `security_scan_runner_type` | string | `''` | Optional runner override for the security_scan jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` |
 | `filter_paths` | string | - | Paths to monitor (newline separated). If empty, treats as single app |
 | `path_level` | string | `2` | Directory depth level to extract app name (monorepo only) |
 | `monorepo_type` | string | `type1` | Monorepo type: `type1` or `type2` |

--- a/docs/pr-validation.md
+++ b/docs/pr-validation.md
@@ -118,6 +118,7 @@ jobs:
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | GitHub runner type |
+| `pr_checks_summary_runner_type` | string | `''` | Optional runner override for the PR Checks Summary job only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` |
 | `dry_run` | boolean | `false` | Preview validations without posting comments or labels |
 | `pr_title_types` | string | (see below) | Allowed commit types (newline-separated) |
 | `pr_title_scopes` | string | `''` | Allowed scopes (newline-separated, empty = any) |

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -83,6 +83,7 @@ jobs:
 |-------|------|---------|-------------|
 | `semantic_version` | string | `23.0.8` | Semantic release version to use |
 | `runner_type` | string | `firmino-lxc-runners` | GitHub runner type |
+| `publish_runner_type` | string | `''` | Optional runner override for the Release (publish) jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` |
 | `backmerge_enabled` | boolean | `true` | Backmerge the release branch into the target branch after a successful release |
 | `backmerge_source` | string | `main` | Release branch eligible for backmerge; backmerge runs only when the release ref matches this |
 | `backmerge_target` | string | `develop` | Branch that receives the backmerge |


### PR DESCRIPTION
## Description

Promotes the current `develop` branch to `main`. This release adds optional per-job runner overrides across shared workflows, registers `br-consignado-gw` on Benedita, adds `streaming-hub` to the deployment matrix, and removes obsolete testing applications.

The release backmerge preserves the latest `main` cleanup while retaining all changes already accepted into `develop`.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Changes were validated in their original pull requests before being merged into `develop`.

## Related Issues

None.