### PR TITLE
fix(helm-upgrade-doc): use generic SLACK_CHANNEL secret for notifications

### DIFF
--- a/.github/workflows/helm-upgrade-doc.yml
+++ b/.github/workflows/helm-upgrade-doc.yml
@@ -14,6 +14,14 @@ name: "Helm Upgrade Doc"
 #     upgrade-doc:
 #       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-upgrade-doc.yml@v1
 #       secrets: inherit
+#
+# Slack channel: the notification channel is a GENERIC `SLACK_CHANNEL` secret, so
+# switching channels never requires editing this shared workflow. With
+# `secrets: inherit` it uses the caller's `SLACK_CHANNEL`. To point at a different
+# channel, map any channel secret to it in the CALLER (instead of inherit):
+#       secrets:
+#         SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_OPS }}   # or any channel secret
+#         # ...plus the other secrets this workflow requires...
 
 on:
   workflow_call:
@@ -58,7 +66,7 @@ on:
         required: false
       SLACK_BOT_TOKEN_HELM:
         required: false
-      SLACK_CHANNEL_OPS:
+      SLACK_CHANNEL:
         required: false
       SLACK_GROUP_TECH_SUPPORT:
         required: false
@@ -92,7 +100,7 @@ jobs:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN_HELM }}
-          slack-channel: ${{ secrets.SLACK_CHANNEL_OPS }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-group-ops: ${{ secrets.SLACK_GROUP_TECH_SUPPORT }}
           charts-root: ${{ inputs.charts_root }}
           docs-subdir: ${{ inputs.docs_subdir }}


### PR DESCRIPTION
## Description

Makes the Slack notification channel in `helm-upgrade-doc.yml` a **generic secret** so switching channels never requires a PR in this shared-workflows repo.

**Before:** the channel came from a channel-named secret `SLACK_CHANNEL_OPS` (previously `SLACK_CHANNEL_DEVOPS`). Changing channel meant renaming the secret here and opening a PR (e.g. #642).

**After:** the workflow declares and uses a generic `SLACK_CHANNEL`. Callers control the channel from their own workflow:
- `secrets: inherit` → uses the caller org/repo secret `SLACK_CHANNEL`, or
- explicit mapping to target a different channel without touching this workflow:
  ```yaml
  secrets:
    SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_OPS }}   # or any channel secret
    # ...other required secrets...
  ```

## Type of Change

- [x] `fix`: Bug fix in a workflow

## Migration note

Callers relying on `secrets: inherit` with an org secret named `SLACK_CHANNEL_OPS` must provide `SLACK_CHANNEL` instead (rename the org secret, or add `SLACK_CHANNEL` alongside). This supersedes #642 (which only renamed the channel-specific secret).
