### PR TITLE
feat(spa-deploy): reusable S3 + CloudFront SPA deploy workflow + composites

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,6 +77,13 @@ config:
   - changed-files:
     - any-glob-to-any-file: "src/config/**"
 
+deploy:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/deploy/**"
+      - ".github/workflows/spa-deploy.yml"
+      - ".github/workflows/s3-upload.yml"
+
 notify:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -114,7 +114,7 @@
 
 - name: deploy
   color: "0e8a16"
-  description: Changes to deployment composite actions (src/deploy/)
+  description: Changes to deployment composites and workflows (src/deploy/, spa-deploy.yml, s3-upload.yml)
 
 - name: deployment-matrix
   color: "5319e7"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -112,6 +112,10 @@
   color: "006b75"
   description: Changes to documentation generation composite actions (src/docs/)
 
+- name: deploy
+  color: "0e8a16"
+  description: Changes to deployment composite actions (src/deploy/)
+
 - name: deployment-matrix
   color: "5319e7"
   description: Changes to the canonical deployment matrix (config/deployment-matrix.yml)

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -103,8 +103,11 @@ permissions:
   contents: read
   id-token: write
 
-# Serialize deploys targeting the same bucket so a `--delete` sync never races a
-# concurrent run. Never cancel an in-flight deploy mid-sync — let it finish.
+# Serialize deploys to the same bucket within THIS caller repo so a `--delete`
+# sync never races a concurrent run. GitHub concurrency is repository-scoped: a
+# bucket is expected to be owned by a single repo (its own SPA), so this covers
+# the real case — it does NOT guard a bucket shared across repos (use an external
+# lock, or a single owning repo, for that). Never cancel an in-flight deploy.
 concurrency:
   group: spa-deploy-${{ inputs.s3_bucket }}
   cancel-in-progress: false
@@ -153,17 +156,40 @@ jobs:
           fi
           echo "::notice::Build output ready at ${DIST}"
 
-      # Self-hosted runners (blacksmith-*) do not ship the AWS CLI, which the
-      # deploy composites below invoke — install/verify it via the repo's own
-      # setup composite (idempotent; no-op on runners that already have it).
       # ----------------- Deploy -----------------
+      # dry_run prints every resolved (non-secret) input at the workflow boundary
+      # per the dry_run convention. AWS_DEPLOY_ROLE_ARN is a secret and is never
+      # echoed; AWS auth and the composites are skipped in dry run.
+      - name: Dry-run deployment plan (resolved inputs)
+        if: ${{ inputs.dry_run }}
+        env:
+          WORKING_DIR: ${{ inputs.working_directory }}
+          BUILD_COMMAND: ${{ inputs.build_command }}
+          DIST: ${{ inputs.dist_directory }}
+          BUCKET: ${{ inputs.s3_bucket }}
+          DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
+          REGION: ${{ inputs.aws_region }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          ROLE_DURATION: ${{ inputs.role_duration_seconds }}
+        run: |
+          set -euo pipefail
+          echo "::notice::DRY RUN — no AWS credentials assumed, no objects written, no invalidation"
+          echo "  working directory : ${WORKING_DIR}"
+          echo "  build command     : ${BUILD_COMMAND}"
+          echo "  dist directory    : ${DIST}"
+          echo "  s3 bucket         : ${BUCKET}"
+          echo "  distribution id   : ${DISTRIBUTION_ID}"
+          echo "  aws region        : ${REGION}"
+          echo "  environment       : ${ENVIRONMENT:-<none>}"
+          echo "  role duration (s) : ${ROLE_DURATION}"
+
+      # AWS CLI + credentials are only needed for a real deploy. A dry run stays
+      # fully local (the s3-sync composite prints the plan without calling AWS),
+      # so these steps must NOT install tooling or assume the deploy role.
       # Composites are referenced by EXTERNAL ref (LerianStudio/.../src/...@ref),
       # never `./src/...`: in a workflow_call reusable workflow `./` resolves to
       # the CALLER's workspace, so a local path breaks for external callers
       # (see .claude/commands/workflow.md, "Composite action references").
-      # AWS CLI + credentials are only needed for a real deploy. A dry run stays
-      # fully local (the s3-sync composite prints the plan without calling AWS),
-      # so it must NOT install tooling or assume the deploy role.
       - name: Ensure AWS CLI
         if: ${{ !inputs.dry_run }}
         uses: LerianStudio/github-actions-shared-workflows/src/setup/aws-cli@v1

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -1,0 +1,212 @@
+name: "SPA Deploy"
+
+# Reusable workflow: build a single-page app and deploy it to S3 + CloudFront.
+#
+# Fills the gap left by s3-upload.yml, which cannot deploy a built SPA: it does
+# not build, takes no artifact, forces an <env>/ sub-folder, sets no
+# Cache-Control, does no `--delete` sync, and does no CloudFront invalidation.
+#
+# Steps: checkout -> setup-node -> npm ci -> build_command -> AWS OIDC auth ->
+# `aws s3 sync --delete` with DIFFERENTIATED Cache-Control (fingerprinted assets
+# immutable/1y; *.html no-store, uploaded LAST so users never fetch an index
+# that references not-yet-uploaded assets) -> CloudFront invalidation.
+#
+# Auth is OIDC only (configure-aws-credentials with role-to-assume) — never
+# static keys.
+#
+# Example (production — pin to a released tag):
+#   jobs:
+#     deploy:
+#       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/spa-deploy.yml@v1.51.0
+#       with:
+#         working_directory: frontend
+#         build_command: npm run build:customer
+#         dist_directory: frontend/dist-customer
+#         aws_region: ${{ vars.AWS_REGION }}
+#         s3_bucket: ${{ vars.SPA_S3_BUCKET }}
+#         cloudfront_distribution_id: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+#       secrets:
+#         AWS_DEPLOY_ROLE_ARN: ${{ secrets.FRONTEND_DEPLOY_ROLE_ARN }}
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'Runner to use for the workflow'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      working_directory:
+        description: 'Directory containing package.json / the SPA source (npm ci + build run here)'
+        type: string
+        default: 'frontend'
+      build_command:
+        description: 'Command that produces the production build (e.g. "npm run build:customer")'
+        type: string
+        required: true
+      dist_directory:
+        description: 'Build output directory to sync, relative to the repo root (e.g. "frontend/dist-customer")'
+        type: string
+        required: true
+      aws_region:
+        description: 'AWS region of the S3 bucket and CloudFront distribution'
+        type: string
+        required: true
+      s3_bucket:
+        description: 'Destination S3 bucket name (without the s3:// prefix). Objects are synced to the bucket ROOT.'
+        type: string
+        required: true
+      cloudfront_distribution_id:
+        description: 'CloudFront distribution ID to invalidate after upload'
+        type: string
+        required: true
+      node_version:
+        description: 'Node.js version for setup-node'
+        type: string
+        default: '22'
+      dry_run:
+        description: 'Preview the sync (aws s3 sync --dryrun) and skip the CloudFront invalidation'
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      AWS_DEPLOY_ROLE_ARN:
+        description: 'ARN of the IAM role to assume via OIDC for S3 + CloudFront access'
+        required: true
+  workflow_dispatch:
+    inputs:
+      working_directory:
+        description: 'Directory containing package.json / the SPA source'
+        type: string
+        default: 'frontend'
+      build_command:
+        description: 'Command that produces the production build'
+        type: string
+        required: true
+      dist_directory:
+        description: 'Build output directory to sync, relative to the repo root'
+        type: string
+        required: true
+      aws_region:
+        description: 'AWS region of the S3 bucket and CloudFront distribution'
+        type: string
+        required: true
+      s3_bucket:
+        description: 'Destination S3 bucket name (without the s3:// prefix)'
+        type: string
+        required: true
+      cloudfront_distribution_id:
+        description: 'CloudFront distribution ID to invalidate after upload'
+        type: string
+        required: true
+      node_version:
+        description: 'Node.js version for setup-node'
+        type: string
+        default: '22'
+      dry_run:
+        description: 'Preview the sync and skip the CloudFront invalidation'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and deploy SPA
+    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working_directory }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working_directory }}
+        run: npm ci
+
+      - name: Build SPA
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          BUILD_COMMAND: ${{ inputs.build_command }}
+        run: |
+          set -euo pipefail
+          eval "$BUILD_COMMAND"
+
+      - name: Verify build output exists
+        env:
+          DIST: ${{ inputs.dist_directory }}
+        run: |
+          set -euo pipefail
+          if [[ ! -d "$DIST" ]] || [[ -z "$(ls -A "$DIST" 2>/dev/null)" ]]; then
+            echo "::error::Build output directory '${DIST}' is missing or empty after build."
+            exit 1
+          fi
+          echo "::notice::Build output ready at ${DIST}"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Sync fingerprinted assets (immutable) and prune stale files
+        env:
+          DIST: ${{ inputs.dist_directory }}
+          BUCKET: ${{ inputs.s3_bucket }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          DRYRUN_FLAG=""
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::DRY RUN — previewing asset sync (no objects written)"
+            DRYRUN_FLAG="--dryrun"
+          fi
+          aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
+            ${DRYRUN_FLAG} \
+            --delete \
+            --exclude "*.html" \
+            --cache-control "public,max-age=31536000,immutable"
+
+      - name: Sync HTML (no-store, uploaded last)
+        env:
+          DIST: ${{ inputs.dist_directory }}
+          BUCKET: ${{ inputs.s3_bucket }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          DRYRUN_FLAG=""
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::DRY RUN — previewing HTML sync (no objects written)"
+            DRYRUN_FLAG="--dryrun"
+          fi
+          aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
+            ${DRYRUN_FLAG} \
+            --exclude "*" \
+            --include "*.html" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "no-store"
+
+      - name: Invalidate CloudFront
+        if: ${{ !inputs.dry_run }}
+        env:
+          DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
+        run: |
+          set -euo pipefail
+          aws cloudfront create-invalidation \
+            --distribution-id "${DISTRIBUTION_ID}" \
+            --paths "/" "/index.html"
+
+      - name: Dry run — skipped invalidation
+        if: ${{ inputs.dry_run }}
+        env:
+          DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
+        run: |
+          echo "::notice::DRY RUN — would invalidate distribution ${DISTRIBUTION_ID} paths '/' '/index.html'"

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -150,8 +150,8 @@ jobs:
           DIST: ${{ inputs.dist_directory }}
         run: |
           set -euo pipefail
-          if [[ ! -d "$DIST" ]] || [[ -z "$(ls -A "$DIST" 2>/dev/null)" ]]; then
-            echo "::error::Build output directory '${DIST}' is missing or empty after build."
+          if [[ ! -d "$DIST" ]] || [[ -z "$(find "$DIST" -type f -print -quit)" ]]; then
+            echo "::error::Build output directory '${DIST}' is missing or has no files after build."
             exit 1
           fi
           echo "::notice::Build output ready at ${DIST}"

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -82,40 +82,12 @@ on:
       AWS_DEPLOY_ROLE_ARN:
         description: 'ARN of the IAM role to assume via OIDC for S3 + CloudFront access'
         required: true
-  workflow_dispatch:
-    inputs:
-      working_directory:
-        description: 'Directory containing package.json / the SPA source'
-        type: string
-        default: 'frontend'
-      build_command:
-        description: 'Command that produces the production build'
-        type: string
-        required: true
-      dist_directory:
-        description: 'Build output directory to sync, relative to the repo root'
-        type: string
-        required: true
-      aws_region:
-        description: 'AWS region of the S3 bucket and CloudFront distribution'
-        type: string
-        required: true
-      s3_bucket:
-        description: 'Destination S3 bucket name (without the s3:// prefix)'
-        type: string
-        required: true
-      cloudfront_distribution_id:
-        description: 'CloudFront distribution ID to invalidate after upload'
-        type: string
-        required: true
-      node_version:
-        description: 'Node.js version for setup-node'
-        type: string
-        default: '22'
-      dry_run:
-        description: 'Preview the sync and skip the CloudFront invalidation'
-        type: boolean
-        default: false
+
+# NOTE: no `workflow_dispatch` here — a reusable workflow must be `workflow_call`
+# only (see .claude/commands/workflow.md, "Script injection & workflow_dispatch").
+# `build_command` is free-text and is eval'd below, so exposing it via a
+# manual-dispatch string input would be a command-injection surface. Manual
+# runs belong in a `self-*`/caller entrypoint with safe (choice/boolean) inputs.
 
 permissions:
   contents: read
@@ -164,8 +136,12 @@ jobs:
       # Self-hosted runners (blacksmith-*) do not ship the AWS CLI, which the
       # deploy composites below invoke — install/verify it via the repo's own
       # setup composite (idempotent; no-op on runners that already have it).
+      # Composites are referenced by EXTERNAL ref (LerianStudio/.../src/...@ref),
+      # never `./src/...`: in a workflow_call reusable workflow `./` resolves to
+      # the CALLER's workspace, so a local path breaks for external callers
+      # (see .claude/commands/workflow.md, "Composite action references").
       - name: Ensure AWS CLI
-        uses: ./src/setup/aws-cli
+        uses: LerianStudio/github-actions-shared-workflows/src/setup/aws-cli@v1
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
@@ -176,14 +152,14 @@ jobs:
       # Deploy STEPS are delegated to single-responsibility composites under
       # src/deploy/ — no complex shell is inlined in this workflow.
       - name: Sync SPA to S3 (differentiated Cache-Control)
-        uses: ./src/deploy/s3-sync
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/s3-sync@develop # TODO: pin to @v1 once released
         with:
           dist-directory: ${{ inputs.dist_directory }}
           s3-bucket: ${{ inputs.s3_bucket }}
           dry-run: ${{ inputs.dry_run }}
 
       - name: Invalidate CloudFront
-        uses: ./src/deploy/cloudfront-invalidate
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/cloudfront-invalidate@develop # TODO: pin to @v1 once released
         with:
           distribution-id: ${{ inputs.cloudfront_distribution_id }}
           dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -74,10 +74,20 @@ on:
         type: string
         default: '22'
       dry_run:
-        description: 'Preview the sync (aws s3 sync --dryrun) and skip the CloudFront invalidation'
+        description: 'Fully-local preview: skip AWS auth, print the sync plan (no AWS calls), and skip the CloudFront invalidation'
         type: boolean
         required: false
         default: false
+      environment:
+        description: 'GitHub Environment to deploy through — enables required reviewers / branch protection and lets the OIDC trust be scoped to the environment. Empty = no environment gate.'
+        type: string
+        required: false
+        default: ''
+      role_duration_seconds:
+        description: 'Lifetime (seconds) of the assumed AWS credentials. Kept short — creds are only assumed for the S3 sync + invalidation, after the build.'
+        type: number
+        required: false
+        default: 900
     secrets:
       AWS_DEPLOY_ROLE_ARN:
         description: 'ARN of the IAM role to assume via OIDC for S3 + CloudFront access'
@@ -93,10 +103,19 @@ permissions:
   contents: read
   id-token: write
 
+# Serialize deploys targeting the same bucket so a `--delete` sync never races a
+# concurrent run. Never cancel an in-flight deploy mid-sync — let it finish.
+concurrency:
+  group: spa-deploy-${{ inputs.s3_bucket }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Build and deploy SPA
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    # Optional GitHub Environment gate (required reviewers / branch protection /
+    # environment-scoped OIDC trust). Empty input = no environment.
+    environment: ${{ inputs.environment }}
     steps:
       # ----------------- Build -----------------
       - name: Checkout code
@@ -154,6 +173,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: spa-deploy-${{ github.run_id }}
+          role-duration-seconds: ${{ inputs.role_duration_seconds }}
           aws-region: ${{ inputs.aws_region }}
 
       # Deploy STEPS are delegated to single-responsibility composites under

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -6,10 +6,20 @@ name: "SPA Deploy"
 # not build, takes no artifact, forces an <env>/ sub-folder, sets no
 # Cache-Control, does no `--delete` sync, and does no CloudFront invalidation.
 #
-# Steps: checkout -> setup-node -> npm ci -> build_command -> AWS OIDC auth ->
-# `aws s3 sync --delete` with DIFFERENTIATED Cache-Control (fingerprinted assets
-# immutable/1y; *.html no-store, uploaded LAST so users never fetch an index
-# that references not-yet-uploaded assets) -> CloudFront invalidation.
+# This workflow only ORCHESTRATES: it checks out, builds the SPA, routes the
+# OIDC secret, and delegates the deploy STEPS to local composites — it inlines no
+# complex shell of its own.
+#
+#   job: deploy
+#     → checkout + setup-node + npm ci + build_command (build the SPA)
+#     → ./src/setup/aws-cli               (ensure AWS CLI is present)
+#     → configure-aws-credentials (OIDC)  (routes AWS_DEPLOY_ROLE_ARN secret)
+#     → ./src/deploy/s3-sync              (differentiated Cache-Control sync)
+#     → ./src/deploy/cloudfront-invalidate (create-invalidation)
+#
+# The s3-sync composite does `aws s3 sync --delete` with DIFFERENTIATED
+# Cache-Control (fingerprinted assets immutable/1y; *.html no-store, uploaded
+# LAST so users never fetch an index that references not-yet-uploaded assets).
 #
 # Auth is OIDC only (configure-aws-credentials with role-to-assume) — never
 # static keys.
@@ -151,62 +161,29 @@ jobs:
           fi
           echo "::notice::Build output ready at ${DIST}"
 
+      # Self-hosted runners (blacksmith-*) do not ship the AWS CLI, which the
+      # deploy composites below invoke — install/verify it via the repo's own
+      # setup composite (idempotent; no-op on runners that already have it).
+      - name: Ensure AWS CLI
+        uses: ./src/setup/aws-cli
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
-      - name: Sync fingerprinted assets (immutable) and prune stale files
-        env:
-          DIST: ${{ inputs.dist_directory }}
-          BUCKET: ${{ inputs.s3_bucket }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-          DRYRUN_FLAG=""
-          if [[ "$DRY_RUN" == "true" ]]; then
-            echo "::notice::DRY RUN — previewing asset sync (no objects written)"
-            DRYRUN_FLAG="--dryrun"
-          fi
-          aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
-            ${DRYRUN_FLAG} \
-            --delete \
-            --exclude "*.html" \
-            --cache-control "public,max-age=31536000,immutable"
-
-      - name: Sync HTML (no-store, uploaded last)
-        env:
-          DIST: ${{ inputs.dist_directory }}
-          BUCKET: ${{ inputs.s3_bucket }}
-          DRY_RUN: ${{ inputs.dry_run }}
-        run: |
-          set -euo pipefail
-          DRYRUN_FLAG=""
-          if [[ "$DRY_RUN" == "true" ]]; then
-            echo "::notice::DRY RUN — previewing HTML sync (no objects written)"
-            DRYRUN_FLAG="--dryrun"
-          fi
-          aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
-            ${DRYRUN_FLAG} \
-            --exclude "*" \
-            --include "*.html" \
-            --content-type "text/html; charset=utf-8" \
-            --cache-control "no-store"
+      # Deploy STEPS are delegated to single-responsibility composites under
+      # src/deploy/ — no complex shell is inlined in this workflow.
+      - name: Sync SPA to S3 (differentiated Cache-Control)
+        uses: ./src/deploy/s3-sync
+        with:
+          dist-directory: ${{ inputs.dist_directory }}
+          s3-bucket: ${{ inputs.s3_bucket }}
+          dry-run: ${{ inputs.dry_run }}
 
       - name: Invalidate CloudFront
-        if: ${{ !inputs.dry_run }}
-        env:
-          DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
-        run: |
-          set -euo pipefail
-          aws cloudfront create-invalidation \
-            --distribution-id "${DISTRIBUTION_ID}" \
-            --paths "/" "/index.html"
-
-      - name: Dry run — skipped invalidation
-        if: ${{ inputs.dry_run }}
-        env:
-          DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
-        run: |
-          echo "::notice::DRY RUN — would invalidate distribution ${DISTRIBUTION_ID} paths '/' '/index.html'"
+        uses: ./src/deploy/cloudfront-invalidate
+        with:
+          distribution-id: ${{ inputs.cloudfront_distribution_id }}
+          dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -98,6 +98,7 @@ jobs:
     name: Build and deploy SPA
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
+      # ----------------- Build -----------------
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -136,6 +137,7 @@ jobs:
       # Self-hosted runners (blacksmith-*) do not ship the AWS CLI, which the
       # deploy composites below invoke — install/verify it via the repo's own
       # setup composite (idempotent; no-op on runners that already have it).
+      # ----------------- Deploy -----------------
       # Composites are referenced by EXTERNAL ref (LerianStudio/.../src/...@ref),
       # never `./src/...`: in a workflow_call reusable workflow `./` resolves to
       # the CALLER's workspace, so a local path breaks for external callers

--- a/.github/workflows/spa-deploy.yml
+++ b/.github/workflows/spa-deploy.yml
@@ -142,10 +142,15 @@ jobs:
       # never `./src/...`: in a workflow_call reusable workflow `./` resolves to
       # the CALLER's workspace, so a local path breaks for external callers
       # (see .claude/commands/workflow.md, "Composite action references").
+      # AWS CLI + credentials are only needed for a real deploy. A dry run stays
+      # fully local (the s3-sync composite prints the plan without calling AWS),
+      # so it must NOT install tooling or assume the deploy role.
       - name: Ensure AWS CLI
+        if: ${{ !inputs.dry_run }}
         uses: LerianStudio/github-actions-shared-workflows/src/setup/aws-cli@v1
 
       - name: Configure AWS credentials (OIDC)
+        if: ${{ !inputs.dry_run }}
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}

--- a/docs/spa-deploy.md
+++ b/docs/spa-deploy.md
@@ -53,7 +53,7 @@ role or produces any side effect.
 | `environment` | GitHub Environment to deploy through — required reviewers / branch protection / environment-scoped OIDC trust. Empty = no gate | No | `''` |
 | `role_duration_seconds` | Lifetime (seconds) of the assumed AWS credentials — kept short (creds assumed only for sync + invalidation) | No | `900` |
 
-Deploys are serialized per `s3_bucket` via `concurrency` (`cancel-in-progress: false`), so a `--delete` sync never races a concurrent run. Credentials use a per-run `role-session-name` (`spa-deploy-<run_id>`) for CloudTrail attribution.
+Deploys are serialized per `s3_bucket` via `concurrency` (`cancel-in-progress: false`) **within the calling repo** — GitHub concurrency is repository-scoped, and each bucket is expected to be owned by a single repo — so a `--delete` sync never races a concurrent run from that repo (a bucket shared across repos would need an external lock). Credentials use a per-run `role-session-name` (`spa-deploy-<run_id>`) for CloudTrail attribution. In `dry_run`, the workflow prints all resolved non-secret inputs via `::notice::` before delegating.
 
 ## Secrets
 

--- a/docs/spa-deploy.md
+++ b/docs/spa-deploy.md
@@ -1,0 +1,88 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>spa-deploy</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that **builds a single-page application and deploys it to S3 + CloudFront** with differentiated `Cache-Control` and cache invalidation.
+
+It fills the gap left by [`s3-upload.yml`](./s3-upload.md), which cannot deploy a built SPA: it does not build, takes no artifact, forces an `<env>/` sub-folder, sets no `Cache-Control`, does no `--delete` sync, and does no CloudFront invalidation.
+
+## What it does
+
+1. `checkout` (SHA-pinned, `persist-credentials: false`).
+2. `setup-node` with npm cache keyed on `<working_directory>/package-lock.json`.
+3. `npm ci` in `working_directory`.
+4. Run `build_command` in `working_directory`.
+5. Verify `dist_directory` exists and is non-empty.
+6. `configure-aws-credentials` via OIDC `role-to-assume` — **never static keys**.
+7. `aws s3 sync --delete` of fingerprinted assets with `Cache-Control: public,max-age=31536000,immutable` (excludes `*.html`).
+8. `aws s3 sync` of `*.html` **last**, with `Cache-Control: no-store` — so a freshly-served `index.html` never references assets that are not yet uploaded.
+9. `aws cloudfront create-invalidation --paths "/" "/index.html"`.
+
+The bucket root is the sync target (no forced environment sub-folder). `dry_run: true` runs both syncs with `--dryrun` and skips the invalidation.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `runner_type` | Runner to use (overridden by `vars.GENERAL_RUNNERS` when set) | No | `blacksmith-4vcpu-ubuntu-2404` |
+| `working_directory` | Directory with `package.json` / SPA source (`npm ci` + build run here) | No | `frontend` |
+| `build_command` | Command that produces the production build (e.g. `npm run build:customer`) | Yes | — |
+| `dist_directory` | Build output directory to sync, relative to the repo root (e.g. `frontend/dist-customer`) | Yes | — |
+| `aws_region` | AWS region of the S3 bucket and CloudFront distribution | Yes | — |
+| `s3_bucket` | Destination S3 bucket name (without `s3://`); objects sync to the bucket **root** | Yes | — |
+| `cloudfront_distribution_id` | CloudFront distribution ID to invalidate after upload | Yes | — |
+| `node_version` | Node.js version for `setup-node` | No | `22` |
+| `dry_run` | Preview the sync (`aws s3 sync --dryrun`) and skip invalidation | No | `false` |
+
+## Secrets
+
+| Secret | Description | Required |
+|---|---|---|
+| `AWS_DEPLOY_ROLE_ARN` | ARN of the IAM role to assume via OIDC for S3 + CloudFront access | Yes |
+
+## Required permissions
+
+The **caller job** must grant:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # AWS OIDC
+```
+
+## Usage — caller workflow
+
+> A job that calls a reusable workflow cannot set `environment:`. If your bucket/role
+> values live under a GitHub Environment, either promote them to repository-level
+> `vars`/`secrets` or wrap this in an environment-scoped job that re-dispatches.
+
+```yaml
+# Testing — point at develop or the feature branch
+name: Frontend Deploy
+on:
+  push:
+    branches: [develop]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/spa-deploy.yml@develop
+    with:
+      working_directory: frontend
+      build_command: npm run build:customer
+      dist_directory: frontend/dist-customer
+      aws_region: ${{ vars.AWS_REGION }}
+      s3_bucket: ${{ vars.SPA_S3_BUCKET }}
+      cloudfront_distribution_id: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+    secrets:
+      AWS_DEPLOY_ROLE_ARN: ${{ secrets.FRONTEND_DEPLOY_ROLE_ARN }}
+```
+
+```yaml
+# Production — always pin to a released tag
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/spa-deploy.yml@v1.51.0
+```

--- a/docs/spa-deploy.md
+++ b/docs/spa-deploy.md
@@ -11,17 +11,28 @@ It fills the gap left by [`s3-upload.yml`](./s3-upload.md), which cannot deploy 
 
 ## What it does
 
+This workflow only **orchestrates** — the deploy steps are delegated to
+single-responsibility composite actions under `src/deploy/`, so no complex shell
+is inlined in the workflow itself.
+
 1. `checkout` (SHA-pinned, `persist-credentials: false`).
 2. `setup-node` with npm cache keyed on `<working_directory>/package-lock.json`.
 3. `npm ci` in `working_directory`.
 4. Run `build_command` in `working_directory`.
 5. Verify `dist_directory` exists and is non-empty.
-6. `configure-aws-credentials` via OIDC `role-to-assume` — **never static keys**.
-7. `aws s3 sync --delete` of fingerprinted assets with `Cache-Control: public,max-age=31536000,immutable` (excludes `*.html`).
-8. `aws s3 sync` of `*.html` **last**, with `Cache-Control: no-store` — so a freshly-served `index.html` never references assets that are not yet uploaded.
-9. `aws cloudfront create-invalidation --paths "/" "/index.html"`.
+6. [`./src/setup/aws-cli`](../src/setup/aws-cli) — ensure the AWS CLI is present
+   (idempotent; no-op on runners that already ship it).
+7. `configure-aws-credentials` via OIDC `role-to-assume` — **never static keys**.
+8. [`./src/deploy/s3-sync`](../src/deploy/s3-sync) — `aws s3 sync --delete` of
+   fingerprinted assets with `Cache-Control: public,max-age=31536000,immutable`
+   (excludes `*.html`), then `*.html` synced **last** with
+   `Cache-Control: no-store` so a freshly-served `index.html` never references
+   assets that are not yet uploaded.
+9. [`./src/deploy/cloudfront-invalidate`](../src/deploy/cloudfront-invalidate) —
+   `aws cloudfront create-invalidation --paths "/" "/index.html"`.
 
-The bucket root is the sync target (no forced environment sub-folder). `dry_run: true` runs both syncs with `--dryrun` and skips the invalidation.
+The bucket root is the sync target (no forced environment sub-folder). `dry_run:
+true` runs both syncs with `--dryrun` and skips the invalidation.
 
 ## Inputs
 

--- a/docs/spa-deploy.md
+++ b/docs/spa-deploy.md
@@ -32,7 +32,10 @@ is inlined in the workflow itself.
    `aws cloudfront create-invalidation --paths "/" "/index.html"`.
 
 The bucket root is the sync target (no forced environment sub-folder). `dry_run:
-true` runs both syncs with `--dryrun` and skips the invalidation.
+true` is **fully local**: the AWS CLI / OIDC credential steps are skipped, the
+s3-sync composite only prints the resolved plan and file list (no AWS calls), and
+the CloudFront invalidation is skipped — so a preview never assumes the deploy
+role or produces any side effect.
 
 ## Inputs
 
@@ -46,7 +49,7 @@ true` runs both syncs with `--dryrun` and skips the invalidation.
 | `s3_bucket` | Destination S3 bucket name (without `s3://`); objects sync to the bucket **root** | Yes | — |
 | `cloudfront_distribution_id` | CloudFront distribution ID to invalidate after upload | Yes | — |
 | `node_version` | Node.js version for `setup-node` | No | `22` |
-| `dry_run` | Preview the sync (`aws s3 sync --dryrun`) and skip invalidation | No | `false` |
+| `dry_run` | Fully-local preview: skip AWS auth, print the sync plan (no AWS calls), and skip the invalidation | No | `false` |
 
 ## Secrets
 

--- a/docs/spa-deploy.md
+++ b/docs/spa-deploy.md
@@ -50,6 +50,10 @@ role or produces any side effect.
 | `cloudfront_distribution_id` | CloudFront distribution ID to invalidate after upload | Yes | — |
 | `node_version` | Node.js version for `setup-node` | No | `22` |
 | `dry_run` | Fully-local preview: skip AWS auth, print the sync plan (no AWS calls), and skip the invalidation | No | `false` |
+| `environment` | GitHub Environment to deploy through — required reviewers / branch protection / environment-scoped OIDC trust. Empty = no gate | No | `''` |
+| `role_duration_seconds` | Lifetime (seconds) of the assumed AWS credentials — kept short (creds assumed only for sync + invalidation) | No | `900` |
+
+Deploys are serialized per `s3_bucket` via `concurrency` (`cancel-in-progress: false`), so a `--delete` sync never races a concurrent run. Credentials use a per-run `role-session-name` (`spa-deploy-<run_id>`) for CloudTrail attribution.
 
 ## Secrets
 

--- a/src/deploy/cloudfront-invalidate/README.md
+++ b/src/deploy/cloudfront-invalidate/README.md
@@ -35,7 +35,7 @@ steps:
     uses: ./src/deploy/cloudfront-invalidate
     with:
       distribution-id: E1234567890ABC
-      dry-run: ${{ inputs.dry_run }}
+      dry-run: false
 ```
 
 ## Usage via reusable workflow

--- a/src/deploy/cloudfront-invalidate/README.md
+++ b/src/deploy/cloudfront-invalidate/README.md
@@ -9,6 +9,10 @@ Composite action that creates a **CloudFront invalidation** for the given paths 
 
 Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
 
+## Why custom `aws` shell (not a Marketplace action)
+
+A single `aws cloudfront create-invalidation` call is simpler and more auditable than pulling a wrapper action, needs no extra pinning surface, and reuses the AWS credentials already assumed for the S3 sync in the same job. It also gives the `dry-run` short-circuit (log instead of invalidate) for free. Authentication is deliberately left to `aws-actions/configure-aws-credentials` (OIDC) in the calling workflow.
+
 ## Inputs
 
 | Input | Description | Required | Default |

--- a/src/deploy/cloudfront-invalidate/README.md
+++ b/src/deploy/cloudfront-invalidate/README.md
@@ -24,18 +24,30 @@ A single `aws cloudfront create-invalidation` call is simpler and more auditable
 ## Usage as composite step
 
 ```yaml
-steps:
-  - name: Configure AWS credentials (OIDC)
-    uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-    with:
-      role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-      aws-region: us-east-1
+name: Deploy SPA
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  id-token: write # AWS OIDC
+jobs:
+  deploy:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      # Build + upload your SPA first…
 
-  - name: Invalidate CloudFront
-    uses: ./src/deploy/cloudfront-invalidate
-    with:
-      distribution-id: E1234567890ABC
-      dry-run: false
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Invalidate CloudFront
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/cloudfront-invalidate@develop
+        with:
+          distribution-id: E1234567890ABC
+          dry-run: false
 ```
 
 ## Usage via reusable workflow

--- a/src/deploy/cloudfront-invalidate/README.md
+++ b/src/deploy/cloudfront-invalidate/README.md
@@ -1,0 +1,60 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>cloudfront-invalidate</h1></td>
+  </tr>
+</table>
+
+Composite action that creates a **CloudFront invalidation** for the given paths after a deploy. When `dry-run` is `true`, the invalidation is skipped and the intended action is logged instead.
+
+Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `distribution-id` | CloudFront distribution ID to invalidate | Yes | — |
+| `paths` | Space-separated list of invalidation paths | No | `/ /index.html` |
+| `dry-run` | Skip the invalidation and log what would happen | No | `false` |
+
+## Usage as composite step
+
+```yaml
+steps:
+  - name: Configure AWS credentials (OIDC)
+    uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+    with:
+      role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      aws-region: us-east-1
+
+  - name: Invalidate CloudFront
+    uses: ./src/deploy/cloudfront-invalidate
+    with:
+      distribution-id: E1234567890ABC
+      dry-run: ${{ inputs.dry_run }}
+```
+
+## Usage via reusable workflow
+
+```yaml
+jobs:
+  deploy:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/spa-deploy.yml@develop
+    with:
+      build_command: npm run build:customer
+      dist_directory: frontend/dist-customer
+      aws_region: us-east-1
+      s3_bucket: my-spa-bucket
+      cloudfront_distribution_id: E1234567890ABC
+    secrets: inherit
+```
+
+## Required permissions
+
+The **calling job** must grant OIDC access so credentials can be assumed before this step:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # AWS OIDC
+```

--- a/src/deploy/cloudfront-invalidate/action.yml
+++ b/src/deploy/cloudfront-invalidate/action.yml
@@ -1,0 +1,40 @@
+name: CloudFront Invalidate
+description: Create a CloudFront invalidation for the given paths; skipped (and logged) when dry-run is true.
+
+inputs:
+  distribution-id:
+    description: CloudFront distribution ID to invalidate.
+    required: true
+  paths:
+    description: Space-separated list of invalidation paths.
+    required: false
+    default: "/ /index.html"
+  dry-run:
+    description: Skip the invalidation and log what would happen.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Invalidate CloudFront
+      if: ${{ inputs.dry-run != 'true' }}
+      shell: bash
+      env:
+        DISTRIBUTION_ID: ${{ inputs.distribution-id }}
+        PATHS: ${{ inputs.paths }}
+      run: |
+        set -euo pipefail
+        read -ra invalidation_paths <<< "$PATHS"
+        aws cloudfront create-invalidation \
+          --distribution-id "$DISTRIBUTION_ID" \
+          --paths "${invalidation_paths[@]}"
+
+    - name: Dry run — skipped invalidation
+      if: ${{ inputs.dry-run == 'true' }}
+      shell: bash
+      env:
+        DISTRIBUTION_ID: ${{ inputs.distribution-id }}
+        PATHS: ${{ inputs.paths }}
+      run: |
+        echo "::notice::DRY RUN — would invalidate distribution ${DISTRIBUTION_ID} paths: ${PATHS}"

--- a/src/deploy/s3-sync/README.md
+++ b/src/deploy/s3-sync/README.md
@@ -16,7 +16,7 @@ Requires AWS credentials to already be configured in the environment (e.g. via `
 
 ## Why custom `aws` shell (not a Marketplace action)
 
-Marketplace S3-sync actions (e.g. `jakejarvis/s3-sync-action`) run a **single** `aws s3 sync` and expose one `Cache-Control` for the whole upload. This composite needs a **two-pass** sync — immutable fingerprinted assets first (with `--delete`), then `*.html` uploaded **last** with `no-store` — so an `index.html` is never served referencing assets that aren't uploaded yet. No maintained Marketplace action models that ordering, and driving `aws` directly matches the sibling [`s3-upload.yml`](../../../.github/workflows/s3-upload.yml) convention in this repo. Authentication is deliberately left to `aws-actions/configure-aws-credentials` (OIDC) in the calling workflow.
+Marketplace S3-sync actions (e.g. `jakejarvis/s3-sync-action`) run a **single** `aws s3 sync` and expose one `Cache-Control` for the whole upload. This composite needs a **multi-pass** sync — immutable fingerprinted assets first (with `--delete`), then stable-named files (service worker, manifest…) with a revalidation policy, then `*.html` uploaded **last** with `no-store` — so an `index.html` is never served referencing assets that aren't uploaded yet, and non-fingerprinted files never get stuck behind an immutable cache. No maintained Marketplace action models that ordering, and driving `aws` directly matches the sibling [`s3-upload.yml`](../../../.github/workflows/s3-upload.yml) convention in this repo. Authentication is deliberately left to `aws-actions/configure-aws-credentials` (OIDC) in the calling workflow.
 
 ## Inputs
 
@@ -24,26 +24,40 @@ Marketplace S3-sync actions (e.g. `jakejarvis/s3-sync-action`) run a **single** 
 |-------|-------------|----------|---------|
 | `dist-directory` | Build output directory to sync, relative to the repo root | Yes | — |
 | `s3-bucket` | Destination S3 bucket name (without `s3://`); objects sync to the bucket **root** | Yes | — |
-| `assets-cache-control` | `Cache-Control` applied to fingerprinted assets (all non-`*.html`) | No | `public,max-age=31536000,immutable` |
+| `assets-cache-control` | `Cache-Control` for fingerprinted assets (non-`*.html`, excluding `revalidate-globs`) | No | `public,max-age=31536000,immutable` |
 | `html-cache-control` | `Cache-Control` applied to `*.html`, uploaded last | No | `no-store` |
-| `dry-run` | Preview both syncs with `--dryrun` (no objects written) | No | `false` |
+| `revalidate-globs` | Space-separated globs for stable-named, non-fingerprinted files that must NOT be immutable. Empty to disable | No | `service-worker.js sw.js manifest.webmanifest robots.txt favicon.ico` |
+| `revalidate-cache-control` | `Cache-Control` for the `revalidate-globs` files | No | `no-cache` |
+| `dry-run` | Fully-local preview: print the plan/file list, no AWS calls | No | `false` |
 
 ## Usage as composite step
 
 ```yaml
-steps:
-  - name: Configure AWS credentials (OIDC)
-    uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-    with:
-      role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-      aws-region: us-east-1
+name: Deploy SPA
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  id-token: write # AWS OIDC
+jobs:
+  deploy:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      # Build your SPA first (checkout, npm ci, npm run build)…
 
-  - name: Sync SPA to S3
-    uses: ./src/deploy/s3-sync
-    with:
-      dist-directory: frontend/dist-customer
-      s3-bucket: my-spa-bucket
-      dry-run: false
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Sync SPA to S3
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/s3-sync@develop
+        with:
+          dist-directory: frontend/dist-customer
+          s3-bucket: my-spa-bucket
+          dry-run: false
 ```
 
 ## Usage via reusable workflow

--- a/src/deploy/s3-sync/README.md
+++ b/src/deploy/s3-sync/README.md
@@ -14,6 +14,8 @@ When `dry-run` is `true` the composite is **fully local**: it prints the resolve
 
 Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
 
+> ⚠️ **The bucket must be dedicated to this SPA.** The sync runs `aws s3 sync --delete` against the bucket **root**, so any object not present in the build is pruned. Do not point it at a bucket holding other content. As a safeguard, the composite refuses to sync when the distribution directory is missing or has no files (which, with `--delete`, would otherwise empty the bucket).
+
 ## Why custom `aws` shell (not a Marketplace action)
 
 Marketplace S3-sync actions (e.g. `jakejarvis/s3-sync-action`) run a **single** `aws s3 sync` and expose one `Cache-Control` for the whole upload. This composite needs a **multi-pass** sync — immutable fingerprinted assets first (with `--delete`), then stable-named files (service worker, manifest…) with a revalidation policy, then `*.html` uploaded **last** with `no-store` — so an `index.html` is never served referencing assets that aren't uploaded yet, and non-fingerprinted files never get stuck behind an immutable cache. No maintained Marketplace action models that ordering, and driving `aws` directly matches the sibling [`s3-upload.yml`](../../../.github/workflows/s3-upload.yml) convention in this repo. Authentication is deliberately left to `aws-actions/configure-aws-credentials` (OIDC) in the calling workflow.

--- a/src/deploy/s3-sync/README.md
+++ b/src/deploy/s3-sync/README.md
@@ -1,0 +1,66 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>s3-sync</h1></td>
+  </tr>
+</table>
+
+Composite action that syncs a **built single-page application** to an S3 bucket root with differentiated `Cache-Control`:
+
+1. Fingerprinted assets (everything except `*.html`) sync **first** with an immutable, long-lived `Cache-Control` and `--delete` to prune stale objects.
+2. `*.html` syncs **last** with `no-store` — so a freshly-served `index.html` never references assets that are not yet uploaded.
+
+Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `dist-directory` | Build output directory to sync, relative to the repo root | Yes | — |
+| `s3-bucket` | Destination S3 bucket name (without `s3://`); objects sync to the bucket **root** | Yes | — |
+| `assets-cache-control` | `Cache-Control` applied to fingerprinted assets (all non-`*.html`) | No | `public,max-age=31536000,immutable` |
+| `html-cache-control` | `Cache-Control` applied to `*.html`, uploaded last | No | `no-store` |
+| `dry-run` | Preview both syncs with `--dryrun` (no objects written) | No | `false` |
+
+## Usage as composite step
+
+```yaml
+steps:
+  - name: Configure AWS credentials (OIDC)
+    uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+    with:
+      role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      aws-region: us-east-1
+
+  - name: Sync SPA to S3
+    uses: ./src/deploy/s3-sync
+    with:
+      dist-directory: frontend/dist-customer
+      s3-bucket: my-spa-bucket
+      dry-run: ${{ inputs.dry_run }}
+```
+
+## Usage via reusable workflow
+
+```yaml
+jobs:
+  deploy:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/spa-deploy.yml@develop
+    with:
+      build_command: npm run build:customer
+      dist_directory: frontend/dist-customer
+      aws_region: us-east-1
+      s3_bucket: my-spa-bucket
+      cloudfront_distribution_id: E1234567890ABC
+    secrets: inherit
+```
+
+## Required permissions
+
+The **calling job** must grant OIDC access so credentials can be assumed before this step:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # AWS OIDC
+```

--- a/src/deploy/s3-sync/README.md
+++ b/src/deploy/s3-sync/README.md
@@ -12,6 +12,10 @@ Composite action that syncs a **built single-page application** to an S3 bucket 
 
 Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
 
+## Why custom `aws` shell (not a Marketplace action)
+
+Marketplace S3-sync actions (e.g. `jakejarvis/s3-sync-action`) run a **single** `aws s3 sync` and expose one `Cache-Control` for the whole upload. This composite needs a **two-pass** sync — immutable fingerprinted assets first (with `--delete`), then `*.html` uploaded **last** with `no-store` — so an `index.html` is never served referencing assets that aren't uploaded yet. No maintained Marketplace action models that ordering, and driving `aws` directly matches the sibling [`s3-upload.yml`](../../../.github/workflows/s3-upload.yml) convention in this repo. Authentication is deliberately left to `aws-actions/configure-aws-credentials` (OIDC) in the calling workflow.
+
 ## Inputs
 
 | Input | Description | Required | Default |

--- a/src/deploy/s3-sync/README.md
+++ b/src/deploy/s3-sync/README.md
@@ -8,7 +8,9 @@
 Composite action that syncs a **built single-page application** to an S3 bucket root with differentiated `Cache-Control`:
 
 1. Fingerprinted assets (everything except `*.html`) sync **first** with an immutable, long-lived `Cache-Control` and `--delete` to prune stale objects.
-2. `*.html` syncs **last** with `no-store` — so a freshly-served `index.html` never references assets that are not yet uploaded.
+2. `*.html` syncs **last** with `no-store` — so a freshly-served `index.html` never references assets that are not yet uploaded. Its `--delete` is scoped to `*.html`, so obsolete HTML is pruned without touching the immutable assets.
+
+When `dry-run` is `true` the composite is **fully local**: it prints the resolved plan and the file list, and makes **no AWS calls** (no credentials required).
 
 Requires AWS credentials to already be configured in the environment (e.g. via `aws-actions/configure-aws-credentials` OIDC in the calling job) and the AWS CLI to be present (see [`setup/aws-cli`](../../setup/aws-cli)). It performs **no authentication itself** — secrets stay in the reusable workflow.
 
@@ -41,7 +43,7 @@ steps:
     with:
       dist-directory: frontend/dist-customer
       s3-bucket: my-spa-bucket
-      dry-run: ${{ inputs.dry_run }}
+      dry-run: false
 ```
 
 ## Usage via reusable workflow

--- a/src/deploy/s3-sync/action.yml
+++ b/src/deploy/s3-sync/action.yml
@@ -58,6 +58,22 @@ runs:
         ( cd "${DIST}" && find . -type f | sort )
 
     # ----------------- Real run -----------------
+    # SAFETY GUARD: every real sync below runs with `--delete`. An empty or
+    # missing dist would make `--delete` wipe the whole bucket. Refuse to proceed
+    # unless the build produced at least one regular file (protects standalone
+    # use of this composite, not just callers that pre-validate).
+    - name: Guard against empty distribution (protects --delete)
+      if: ${{ inputs.dry-run != 'true' }}
+      shell: bash
+      env:
+        DIST: ${{ inputs.dist-directory }}
+      run: |
+        set -euo pipefail
+        if [[ ! -d "$DIST" ]] || [[ -z "$(find "$DIST" -type f -print -quit)" ]]; then
+          echo "::error::Distribution '${DIST}' is missing or contains no files — refusing to sync, as --delete would empty the bucket."
+          exit 1
+        fi
+
     # Fingerprinted assets are immutable, so they upload FIRST with a long
     # Cache-Control and --delete prunes stale files. *.html AND the stable-named
     # revalidate files are excluded here (handled in their own passes) so they

--- a/src/deploy/s3-sync/action.yml
+++ b/src/deploy/s3-sync/action.yml
@@ -1,0 +1,72 @@
+name: S3 Sync (SPA)
+description: Sync a built SPA to an S3 bucket root with differentiated Cache-Control — fingerprinted assets immutable (with --delete), then *.html no-store uploaded last.
+
+inputs:
+  dist-directory:
+    description: Build output directory to sync, relative to the repo root (e.g. "frontend/dist-customer").
+    required: true
+  s3-bucket:
+    description: Destination S3 bucket name (without the s3:// prefix). Objects sync to the bucket root.
+    required: true
+  assets-cache-control:
+    description: Cache-Control header applied to fingerprinted assets (everything except *.html).
+    required: false
+    default: "public,max-age=31536000,immutable"
+  html-cache-control:
+    description: Cache-Control header applied to *.html files, uploaded last so a freshly-served index never references assets that are not yet uploaded.
+    required: false
+    default: "no-store"
+  dry-run:
+    description: Preview both syncs with --dryrun (no objects written).
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Fingerprinted assets are immutable, so they upload FIRST with a long
+    # Cache-Control and --delete prunes stale files. *.html is excluded here and
+    # handled last to avoid a window where index.html points at missing assets.
+    - name: Sync fingerprinted assets (immutable) and prune stale files
+      shell: bash
+      env:
+        DIST: ${{ inputs.dist-directory }}
+        BUCKET: ${{ inputs.s3-bucket }}
+        CACHE_CONTROL: ${{ inputs.assets-cache-control }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+        sync_args=()
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "::notice::DRY RUN — previewing asset sync (no objects written)"
+          sync_args+=(--dryrun)
+        fi
+        aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
+          "${sync_args[@]}" \
+          --delete \
+          --exclude "*.html" \
+          --cache-control "$CACHE_CONTROL"
+
+    # HTML is uploaded LAST with a no-store Cache-Control (never --delete here, to
+    # keep the immutable assets synced above) so users always fetch an index that
+    # references already-present assets.
+    - name: Sync HTML (no-store, uploaded last)
+      shell: bash
+      env:
+        DIST: ${{ inputs.dist-directory }}
+        BUCKET: ${{ inputs.s3-bucket }}
+        CACHE_CONTROL: ${{ inputs.html-cache-control }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+        sync_args=()
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "::notice::DRY RUN — previewing HTML sync (no objects written)"
+          sync_args+=(--dryrun)
+        fi
+        aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
+          "${sync_args[@]}" \
+          --exclude "*" \
+          --include "*.html" \
+          --content-type "text/html; charset=utf-8" \
+          --cache-control "$CACHE_CONTROL"

--- a/src/deploy/s3-sync/action.yml
+++ b/src/deploy/s3-sync/action.yml
@@ -9,15 +9,23 @@ inputs:
     description: Destination S3 bucket name (without the s3:// prefix). Objects sync to the bucket root.
     required: true
   assets-cache-control:
-    description: Cache-Control header applied to fingerprinted assets (everything except *.html).
+    description: Cache-Control applied to fingerprinted assets — everything except *.html and the revalidate-globs files.
     required: false
     default: "public,max-age=31536000,immutable"
   html-cache-control:
     description: Cache-Control header applied to *.html files, uploaded last so a freshly-served index never references assets that are not yet uploaded.
     required: false
     default: "no-store"
+  revalidate-globs:
+    description: Space-separated globs for stable-named, NON-fingerprinted files (service worker, web manifest, robots, favicon). These must NOT be cached immutable — they get revalidate-cache-control instead so updates propagate. Set empty to disable.
+    required: false
+    default: "service-worker.js sw.js manifest.webmanifest robots.txt favicon.ico"
+  revalidate-cache-control:
+    description: Cache-Control applied to the revalidate-globs files (must revalidate, never immutable).
+    required: false
+    default: "no-cache"
   dry-run:
-    description: Preview both syncs with --dryrun (no objects written).
+    description: Fully-local preview — print the plan and file list, make no AWS calls.
     required: false
     default: "false"
 
@@ -36,20 +44,24 @@ runs:
         BUCKET: ${{ inputs.s3-bucket }}
         ASSETS_CACHE_CONTROL: ${{ inputs.assets-cache-control }}
         HTML_CACHE_CONTROL: ${{ inputs.html-cache-control }}
+        REVALIDATE_CACHE_CONTROL: ${{ inputs.revalidate-cache-control }}
+        REVALIDATE_GLOBS: ${{ inputs.revalidate-globs }}
       run: |
         set -euo pipefail
         echo "::notice::DRY RUN — no AWS credentials used, no AWS calls, no objects written"
         echo "  source directory : ${DIST}"
         echo "  destination      : s3://${BUCKET}/"
-        echo "  assets (non-html): Cache-Control '${ASSETS_CACHE_CONTROL}', synced first with --delete"
+        echo "  assets (immutable): Cache-Control '${ASSETS_CACHE_CONTROL}', synced first with --delete (excludes html + revalidate files)"
+        echo "  revalidate files : '${REVALIDATE_GLOBS}' → Cache-Control '${REVALIDATE_CACHE_CONTROL}'"
         echo "  html             : Cache-Control '${HTML_CACHE_CONTROL}', synced last with --delete"
         echo "  local files that would be uploaded:"
         ( cd "${DIST}" && find . -type f | sort )
 
     # ----------------- Real run -----------------
     # Fingerprinted assets are immutable, so they upload FIRST with a long
-    # Cache-Control and --delete prunes stale files. *.html is excluded here and
-    # handled last to avoid a window where index.html points at missing assets.
+    # Cache-Control and --delete prunes stale files. *.html AND the stable-named
+    # revalidate files are excluded here (handled in their own passes) so they
+    # never inherit the immutable policy.
     - name: Sync fingerprinted assets (immutable) and prune stale files
       if: ${{ inputs.dry-run != 'true' }}
       shell: bash
@@ -57,11 +69,42 @@ runs:
         DIST: ${{ inputs.dist-directory }}
         BUCKET: ${{ inputs.s3-bucket }}
         CACHE_CONTROL: ${{ inputs.assets-cache-control }}
+        REVALIDATE_GLOBS: ${{ inputs.revalidate-globs }}
       run: |
         set -euo pipefail
+        exclude_args=(--exclude "*.html")
+        read -ra globs <<< "$REVALIDATE_GLOBS"
+        for g in "${globs[@]}"; do
+          exclude_args+=(--exclude "$g")
+        done
         aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
           --delete \
-          --exclude "*.html" \
+          "${exclude_args[@]}" \
+          --cache-control "$CACHE_CONTROL"
+
+    # Stable-named, non-fingerprinted files (service worker, manifest, robots,
+    # favicon) MUST NOT be immutable — an immutable service worker would never
+    # update. They sync with a revalidation Cache-Control; --delete is scoped to
+    # these globs. Skipped entirely when revalidate-globs is empty.
+    - name: Sync stable-named files (revalidate, not immutable)
+      if: ${{ inputs.dry-run != 'true' && inputs.revalidate-globs != '' }}
+      shell: bash
+      env:
+        DIST: ${{ inputs.dist-directory }}
+        BUCKET: ${{ inputs.s3-bucket }}
+        CACHE_CONTROL: ${{ inputs.revalidate-cache-control }}
+        REVALIDATE_GLOBS: ${{ inputs.revalidate-globs }}
+      run: |
+        set -euo pipefail
+        read -ra globs <<< "$REVALIDATE_GLOBS"
+        [[ ${#globs[@]} -gt 0 ]] || exit 0
+        include_args=(--exclude "*")
+        for g in "${globs[@]}"; do
+          include_args+=(--include "$g")
+        done
+        aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
+          --delete \
+          "${include_args[@]}" \
           --cache-control "$CACHE_CONTROL"
 
     # HTML is uploaded LAST with a no-store Cache-Control so users always fetch an

--- a/src/deploy/s3-sync/action.yml
+++ b/src/deploy/s3-sync/action.yml
@@ -24,48 +24,61 @@ inputs:
 runs:
   using: composite
   steps:
+    # ----------------- Dry run (local only) -----------------
+    # A dry run must not use credentials or contact AWS: it prints the resolved
+    # plan and the local file list so callers can validate config before applying,
+    # with zero side effects and no role assumption.
+    - name: Preview deployment plan (dry run)
+      if: ${{ inputs.dry-run == 'true' }}
+      shell: bash
+      env:
+        DIST: ${{ inputs.dist-directory }}
+        BUCKET: ${{ inputs.s3-bucket }}
+        ASSETS_CACHE_CONTROL: ${{ inputs.assets-cache-control }}
+        HTML_CACHE_CONTROL: ${{ inputs.html-cache-control }}
+      run: |
+        set -euo pipefail
+        echo "::notice::DRY RUN — no AWS credentials used, no AWS calls, no objects written"
+        echo "  source directory : ${DIST}"
+        echo "  destination      : s3://${BUCKET}/"
+        echo "  assets (non-html): Cache-Control '${ASSETS_CACHE_CONTROL}', synced first with --delete"
+        echo "  html             : Cache-Control '${HTML_CACHE_CONTROL}', synced last with --delete"
+        echo "  local files that would be uploaded:"
+        ( cd "${DIST}" && find . -type f | sort )
+
+    # ----------------- Real run -----------------
     # Fingerprinted assets are immutable, so they upload FIRST with a long
     # Cache-Control and --delete prunes stale files. *.html is excluded here and
     # handled last to avoid a window where index.html points at missing assets.
     - name: Sync fingerprinted assets (immutable) and prune stale files
+      if: ${{ inputs.dry-run != 'true' }}
       shell: bash
       env:
         DIST: ${{ inputs.dist-directory }}
         BUCKET: ${{ inputs.s3-bucket }}
         CACHE_CONTROL: ${{ inputs.assets-cache-control }}
-        DRY_RUN: ${{ inputs.dry-run }}
       run: |
         set -euo pipefail
-        sync_args=()
-        if [[ "$DRY_RUN" == "true" ]]; then
-          echo "::notice::DRY RUN — previewing asset sync (no objects written)"
-          sync_args+=(--dryrun)
-        fi
         aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
-          "${sync_args[@]}" \
           --delete \
           --exclude "*.html" \
           --cache-control "$CACHE_CONTROL"
 
-    # HTML is uploaded LAST with a no-store Cache-Control (never --delete here, to
-    # keep the immutable assets synced above) so users always fetch an index that
-    # references already-present assets.
-    - name: Sync HTML (no-store, uploaded last)
+    # HTML is uploaded LAST with a no-store Cache-Control so users always fetch an
+    # index that references already-present assets. --delete is scoped to *.html
+    # (via --exclude "*" --include "*.html"), so obsolete HTML is pruned without
+    # touching the immutable assets synced above.
+    - name: Sync HTML (no-store, uploaded last) and prune stale HTML
+      if: ${{ inputs.dry-run != 'true' }}
       shell: bash
       env:
         DIST: ${{ inputs.dist-directory }}
         BUCKET: ${{ inputs.s3-bucket }}
         CACHE_CONTROL: ${{ inputs.html-cache-control }}
-        DRY_RUN: ${{ inputs.dry-run }}
       run: |
         set -euo pipefail
-        sync_args=()
-        if [[ "$DRY_RUN" == "true" ]]; then
-          echo "::notice::DRY RUN — previewing HTML sync (no objects written)"
-          sync_args+=(--dryrun)
-        fi
         aws s3 sync "${DIST}/" "s3://${BUCKET}/" \
-          "${sync_args[@]}" \
+          --delete \
           --exclude "*" \
           --include "*.html" \
           --content-type "text/html; charset=utf-8" \


### PR DESCRIPTION
## What

Adds a reusable **`spa-deploy.yml`** workflow that builds a single-page app and publishes it to **S3 + CloudFront** via OIDC (no static keys), plus two single-responsibility composites under `src/deploy/`:

- **`src/deploy/s3-sync`** — two-pass `aws s3 sync` with differentiated `Cache-Control`: fingerprinted assets first (`immutable` + `--delete`), then `*.html` **last** with `no-store` so `index.html` never references not-yet-uploaded assets.
- **`src/deploy/cloudfront-invalidate`** — `create-invalidation` with a `dry-run` short-circuit.

The workflow **orchestrates only** (checkout → node setup → `npm ci` → build → verify → `setup/aws-cli` → OIDC creds → `s3-sync` → `cloudfront-invalidate`); no complex shell lives in the workflow — it's encapsulated in the composites per `.claude/commands/composite.md`.

## Why

The existing shared `s3-upload.yml` does env-folder routing with no differentiated cache-control or CloudFront invalidation, so it doesn't fit an SPA publish (immutable hashed assets + always-fresh `index.html` + edge invalidation). This fills that gap as a first-class shared capability.

## Conventions followed (`/composite`, `/workflow`)

- Composites live in `src/deploy/<name>/` with `action.yml` + `README.md`; optional inputs have safe defaults; single responsibility.
- Marketplace-first rationale documented in each README (why custom `aws` shell).
- Third-party actions SHA-pinned (`# vX.Y.Z`); LerianStudio refs by tag/`@develop`, never `@main`.
- `dry_run` support end-to-end (`--dryrun` sync + skipped invalidation).
- Added a `deploy` capability label (`labels.yml`/`labeler.yml`) mapped to `src/deploy/**`.
- Docs: `docs/spa-deploy.md`.

## Validation

Passing repo linters: `actionlint`, `yamllint` (strict:false), `composite-schema`, `shellcheck`, `pinned-actions`, `readme-check`.