### PR TITLE
feat(validation): add breaking change guard

### DIFF
--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -57,6 +57,21 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
+  # ----------------- Breaking Change Guard Detector Tests -----------------
+  breaking-change-guard-tests:
+    name: Breaking Change Guard Detector Tests
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run breaking-change detector matrix
+        run: bash src/validate/breaking-change-guard/test.sh
+
   # ----------------- YAML Lint -----------------
   yamllint:
     name: YAML Lint

--- a/src/validate/breaking-change-guard/README.md
+++ b/src/validate/breaking-change-guard/README.md
@@ -1,0 +1,150 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>Breaking Change Guard</h1></td>
+  </tr>
+</table>
+
+Composite action that detects breaking-change commits in a pull request and checks
+whether the pull request description contains the required approval acknowledgement.
+The action reports detection and approval separately. The caller decides whether to
+block the merge.
+
+## Behavior
+
+The guard scans only commits that are in the pull request head and not in the remote
+base branch. It uses `origin/<base>..HEAD`, requires a checkout with full history, and
+rejects shallow repositories before scanning.
+
+A commit is breaking when either condition is true:
+
+- Its subject matches the pinned parser pattern `^(\w*)(?:\((.*)\))?!: (.*)$`.
+  The type uses ASCII word characters and can be empty. The optional scope is
+  arbitrary, including nested parentheses. One space after the colon is required;
+  the captured description can be empty or start with additional whitespace.
+- A commit-message line matches the pinned note grammar: optional leading whitespace,
+  `*`, or `|`; then `BREAKING CHANGE` or `BREAKING CHANGES`; then one or more colon or
+  whitespace separators. Matching is case-insensitive. `-` bullets and
+  `BREAKING-CHANGE` are not accepted by the configured release parser.
+
+Ordinary prose that contains a reserved footer token later in a line is not breaking.
+The acknowledgement is a case-sensitive, exact literal substring of the pull request
+body. It can span multiple lines and can contain regular-expression or shell
+metacharacters. An empty acknowledgement is never approved.
+
+The guard fails closed when the repository is shallow, the remote base ref or `HEAD`
+is invalid, or Git cannot read the commit range. An unapproved breaking change is a
+valid detection result, so the composite exits successfully and leaves enforcement to
+its caller.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `base-ref` | Pull request base branch. The checkout must contain `origin/<base-ref>`. | Yes | — |
+| `breaking-change-acknowledgement` | Exact literal substring required in the pull request description. | Yes | — |
+
+The composite has no `dry-run` input. Detection has no side effects. The reusable
+workflow owns comment, label, and merge-enforcement controls.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has-breaking-changes` | `true` when at least one pull request head commit is breaking. |
+| `approved` | `true` when the complete acknowledgement occurs in the pull request body. |
+
+## Local composite usage
+
+Local paths resolve in the caller repository. Use this form only in this repository
+when testing changes to the composite itself.
+
+```yaml
+name: Test Breaking Change Guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  breaking-change-guard:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect breaking changes
+        id: guard
+        uses: ./src/validate/breaking-change-guard
+        with:
+          base-ref: ${{ github.base_ref }}
+          breaking-change-acknowledgement: >-
+            Breaking change approved: this PR intentionally ships a breaking change;
+            the next release will be a major version bump.
+
+      - name: Enforce approval
+        if: steps.guard.outputs.has-breaking-changes == 'true' && steps.guard.outputs.approved != 'true'
+        run: exit 1
+```
+
+## Pre-release testing
+
+Use `@develop` only to test the composite before it is published in `v1`:
+
+```yaml
+jobs:
+  breaking-change-guard:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+      - id: guard
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/breaking-change-guard@develop
+        with:
+          base-ref: ${{ github.base_ref }}
+          breaking-change-acknowledgement: Breaking change approved by the release owner.
+```
+
+Do not use a branch reference in production.
+
+## Production usage after release
+
+After the release publishes this composite in `v1`, use the stable major tag:
+
+```yaml
+jobs:
+  breaking-change-guard:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+      - id: guard
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/breaking-change-guard@v1
+        with:
+          base-ref: ${{ github.base_ref }}
+          breaking-change-acknowledgement: Breaking change approved by the release owner.
+```
+
+Integration with `.github/workflows/pr-validation.yml` is intentionally deferred. A
+later change will add PR enforcement only after `v1` contains this composite.
+
+## Local test
+
+Run the durable detector matrix from the repository root:
+
+```bash
+bash src/validate/breaking-change-guard/test.sh
+```
+
+The test always runs with the default `awk`. It also runs the complete matrix with
+GNU `awk` when `gawk` is installed.

--- a/src/validate/breaking-change-guard/action.yml
+++ b/src/validate/breaking-change-guard/action.yml
@@ -29,4 +29,4 @@ runs:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         set -euo pipefail
-        bash "${{ github.action_path }}/detect.sh" >> "${GITHUB_OUTPUT}"
+        bash "${GITHUB_ACTION_PATH}/detect.sh" >> "${GITHUB_OUTPUT}"

--- a/src/validate/breaking-change-guard/action.yml
+++ b/src/validate/breaking-change-guard/action.yml
@@ -1,0 +1,32 @@
+name: Breaking Change Guard
+description: "Detects breaking-change commit(s) in a PR and checks whether the PR description contains the required approval acknowledgement. Reports only — the caller workflow decides whether to block merge."
+
+inputs:
+  base-ref:
+    description: Target/base branch of the PR (used to compute the diff range of PR commits)
+    required: true
+  breaking-change-acknowledgement:
+    description: Exact string that must appear in the PR description body to approve shipping the breaking change
+    required: true
+
+outputs:
+  has-breaking-changes:
+    description: "Whether the PR contains at least one breaking-change commit (true/false)"
+    value: ${{ steps.detect.outputs.has-breaking-changes }}
+  approved:
+    description: "Whether the PR description body contains the approval acknowledgement (true/false)"
+    value: ${{ steps.detect.outputs.approved }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect breaking changes and approval
+      id: detect
+      shell: bash
+      env:
+        BASE_REF: ${{ inputs.base-ref }}
+        ACK: ${{ inputs.breaking-change-acknowledgement }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        set -euo pipefail
+        bash "${{ github.action_path }}/detect.sh" >> "${GITHUB_OUTPUT}"

--- a/src/validate/breaking-change-guard/detect.sh
+++ b/src/validate/breaking-change-guard/detect.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASE_REF=${BASE_REF:-}
+PR_BODY=${PR_BODY:-}
+ACK=${ACK:-}
+AWK_BIN=${AWK:-awk}
+
+if [[ -z "${BASE_REF}" ]]; then
+  printf 'Breaking Change Guard: BASE_REF is required.\n' >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  printf 'Breaking Change Guard: git is not available.\n' >&2
+  exit 1
+fi
+
+if ! command -v "${AWK_BIN}" >/dev/null 2>&1; then
+  printf 'Breaking Change Guard: awk implementation %q is not available.\n' "${AWK_BIN}" >&2
+  exit 1
+fi
+
+if [[ $(git rev-parse --is-shallow-repository 2>/dev/null) == true ]]; then
+  printf 'Breaking Change Guard: shallow repository detected; fetch full history before running.\n' >&2
+  exit 1
+fi
+
+if ! base_commit=$(git rev-parse --verify --quiet \
+  "refs/remotes/origin/${BASE_REF}^{commit}"); then
+  printf 'Breaking Change Guard: base ref origin/%s is missing or invalid.\n' \
+    "${BASE_REF}" >&2
+  exit 1
+fi
+
+if ! head_commit=$(git rev-parse --verify --quiet 'HEAD^{commit}'); then
+  printf 'Breaking Change Guard: HEAD is missing or invalid.\n' >&2
+  exit 1
+fi
+
+message_file=$(mktemp "${TMPDIR:-/tmp}/breaking-change-guard.XXXXXX")
+cleanup() {
+  rm -f "${message_file}"
+}
+trap cleanup EXIT INT TERM
+
+if ! git log --format='%B%x1e' \
+  "${base_commit}..${head_commit}" >"${message_file}" 2>/dev/null; then
+  printf 'Breaking Change Guard: git log failed for origin/%s..HEAD.\n' \
+    "${BASE_REF}" >&2
+  exit 1
+fi
+
+# The awk program is intentionally a literal string.
+# shellcheck disable=SC2016
+has_breaking_changes=$("${AWK_BIN}" '
+  BEGIN {
+    RS = sprintf("%c", 30)
+    found = 0
+  }
+  {
+    message = $0
+    while (substr(message, 1, 1) == "\n" || substr(message, 1, 1) == "\r") {
+      message = substr(message, 2)
+    }
+
+    line_count = split(message, lines, "\n")
+    subject = tolower(lines[1])
+    if (subject ~ /^[a-z0-9_]*(\(.*\))?!: .*$/) {
+      found = 1
+    }
+
+    for (line_number = 1; line_number <= line_count; line_number++) {
+      line = tolower(lines[line_number])
+      sub(/\r$/, "", line)
+      if (line ~ /^[[:space:]|*]*breaking changes?(:|[[:space:]])+/) {
+        found = 1
+      }
+    }
+  }
+  END {
+    print found ? "true" : "false"
+  }
+' "${message_file}")
+
+approved=false
+if [[ -n "${ACK}" && "${PR_BODY}" == *"${ACK}"* ]]; then
+  approved=true
+fi
+
+printf 'has-breaking-changes=%s\n' "${has_breaking_changes}"
+printf 'approved=%s\n' "${approved}"
+
+if [[ "${has_breaking_changes}" == true ]]; then
+  printf 'Breaking Change Guard: breaking-change commit(s) detected; acknowledgement present: %s.\n' \
+    "${approved}" >&2
+fi

--- a/src/validate/breaking-change-guard/test.sh
+++ b/src/validate/breaking-change-guard/test.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CDPATH=''
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+DETECTOR="${SCRIPT_DIR}/detect.sh"
+REAL_GIT=$(command -v git)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/breaking-change-guard.XXXXXX")
+CURRENT_REPO=
+CURRENT_REMOTE=
+AWK_BIN='awk'
+PASSED=0
+FAILED=0
+
+cleanup() {
+  rm -rf "${TEST_ROOT}"
+}
+trap cleanup EXIT INT TERM
+
+if [[ ! -f "${DETECTOR}" ]]; then
+  printf 'not ok - production detector is missing: %s\n' "${DETECTOR}" >&2
+  exit 1
+fi
+
+new_repo() {
+  local name=$1
+  local remote="${TEST_ROOT}/${AWK_BIN}-${name}-remote.git"
+  local repo="${TEST_ROOT}/${AWK_BIN}-${name}"
+
+  git init -q --bare "${remote}"
+  git --git-dir="${remote}" config core.hooksPath /dev/null
+  git init -q "${repo}"
+  git -C "${repo}" config user.name "Breaking Change Guard Test"
+  git -C "${repo}" config user.email "breaking-change-guard@example.com"
+  git -C "${repo}" config commit.gpgSign false
+  git -C "${repo}" config core.hooksPath /dev/null
+  git -C "${repo}" checkout -q -b main
+  git -C "${repo}" commit -q --allow-empty -m "chore: initial commit"
+  git -C "${repo}" remote add origin "${remote}"
+  git -C "${repo}" push -q -u origin main
+  git -C "${repo}" checkout -q -b feature
+  CURRENT_REPO=${repo}
+  CURRENT_REMOTE=${remote}
+}
+
+make_shallow_clone_without_parent() {
+  local name=$1
+  local repo="${TEST_ROOT}/${AWK_BIN}-${name}-shallow"
+  local is_shallow
+
+  git -C "${CURRENT_REPO}" push -q origin feature
+  git clone -q --depth 1 --branch feature "file://${CURRENT_REMOTE}" "${repo}"
+  git -C "${repo}" config commit.gpgSign false
+  git -C "${repo}" config core.hooksPath /dev/null
+  git -C "${repo}" fetch -q --depth=1 origin main:refs/remotes/origin/main
+
+  is_shallow=$(git -C "${repo}" rev-parse --is-shallow-repository)
+  if [[ "${is_shallow}" != true ]]; then
+    printf 'fixture error - expected a shallow repository\n' >&2
+    exit 1
+  fi
+  if git -C "${repo}" cat-file -e 'HEAD^' 2>/dev/null; then
+    printf 'fixture error - shallow clone unexpectedly contains the older breaking commit\n' >&2
+    exit 1
+  fi
+
+  CURRENT_REPO=${repo}
+}
+
+commit_message() {
+  git -C "${CURRENT_REPO}" commit -q --allow-empty --cleanup=verbatim -m "$1"
+}
+
+record_pass() {
+  PASSED=$((PASSED + 1))
+  printf 'ok - %s [%s]\n' "$1" "${AWK_BIN}"
+}
+
+record_fail() {
+  FAILED=$((FAILED + 1))
+  printf 'not ok - %s [%s]: %s\n' "$1" "${AWK_BIN}" "$2" >&2
+}
+
+assert_guard() {
+  local label=$1
+  local expected_breaking=$2
+  local expected_approved=$3
+  local body=$4
+  local acknowledgement=$5
+  local base_ref=${6:-main}
+  local command_path=${7:-${PATH}}
+  local stdout_file="${TEST_ROOT}/stdout"
+  local stderr_file="${TEST_ROOT}/stderr"
+  local expected_file="${TEST_ROOT}/expected"
+  local expected
+  local actual
+  local status
+
+  expected=$(printf 'has-breaking-changes=%s\napproved=%s' \
+    "${expected_breaking}" "${expected_approved}")
+  printf '%s\n' "${expected}" >"${expected_file}"
+
+  if (
+    cd "${CURRENT_REPO}" || exit 99
+    PATH="${command_path}" BASE_REF="${base_ref}" PR_BODY="${body}" \
+      ACK="${acknowledgement}" AWK="${AWK_BIN}" bash "${DETECTOR}"
+  ) >"${stdout_file}" 2>"${stderr_file}"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  actual=$(<"${stdout_file}")
+  if [[ ${status} -ne 0 ]]; then
+    record_fail "${label}" "expected exit 0, got ${status}: $(<"${stderr_file}")"
+  elif ! cmp -s "${expected_file}" "${stdout_file}"; then
+    record_fail "${label}" "expected [${expected}], got [${actual}]"
+  else
+    record_pass "${label}"
+  fi
+}
+
+assert_runtime_failure() {
+  local label=$1
+  local expected_stderr=$2
+  local base_ref=${3:-main}
+  local command_path=${4:-${PATH}}
+  local stdout_file="${TEST_ROOT}/stdout"
+  local stderr_file="${TEST_ROOT}/stderr"
+  local expected_stderr_file="${TEST_ROOT}/expected-stderr"
+  local status
+
+  printf '%s\n' "${expected_stderr}" >"${expected_stderr_file}"
+
+  if (
+    cd "${CURRENT_REPO}" || exit 99
+    PATH="${command_path}" BASE_REF="${base_ref}" PR_BODY="" ACK="" \
+      AWK="${AWK_BIN}" bash "${DETECTOR}"
+  ) >"${stdout_file}" 2>"${stderr_file}"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ ${status} -eq 0 ]]; then
+    record_fail "${label}" "expected a nonzero exit, got output [$(<"${stdout_file}")]"
+  elif [[ -s "${stdout_file}" ]]; then
+    record_fail "${label}" "runtime failure emitted machine-safe output [$(<"${stdout_file}")]"
+  elif [[ ! -s "${stderr_file}" ]]; then
+    record_fail "${label}" "runtime failure did not emit a diagnostic"
+  elif ! cmp -s "${expected_stderr_file}" "${stderr_file}"; then
+    record_fail "${label}" \
+      "expected stderr [${expected_stderr}], got [$(<"${stderr_file}")]"
+  else
+    record_pass "${label}"
+  fi
+}
+
+run_matrix() {
+  local multi_ack
+  local metachar_ack
+  local large_body
+  local wrapper_dir
+  local i
+
+  new_repo safe
+  commit_message "feat: add safe behavior"
+  assert_guard "ordinary safe commits" false false "No approval" "Approved"
+
+  new_repo ordinary-scoped
+  commit_message "feat(api): add safe endpoint"
+  assert_guard "ordinary scoped subject" false false "" "Approved"
+
+  new_repo type-bang-no-space
+  commit_message "feat!:missing required space"
+  assert_guard "type bang without required space" false false "" "Approved"
+
+  new_repo type-bang-empty-description
+  commit_message "feat!: "
+  assert_guard "type bang with empty description" true false "" "Approved"
+
+  new_repo underscore-type-bang
+  commit_message "ci_pipeline!: replace pipeline"
+  assert_guard "underscore type bang subject" true false "" "Approved"
+
+  new_repo hyphen-type-bang
+  commit_message "build-tools!: replace pipeline"
+  assert_guard "hyphenated type bang subject" false false "" "Approved"
+
+  new_repo nested-scope-bang
+  commit_message "feat(api(v2))!: replace response"
+  assert_guard "nested scope bang subject" true false "" "Approved"
+
+  new_repo extra-description-spaces
+  commit_message "feat!:  replace response"
+  assert_guard "type bang with extra description spaces" true false "" "Approved"
+
+  new_repo empty-type-bang
+  commit_message "!: replace response"
+  assert_guard "empty type bang subject" true false "" "Approved"
+
+  new_repo type-bang-newest
+  commit_message "fix: older safe commit"
+  commit_message "feat!: remove public field"
+  assert_guard "newest type bang subject" true false "" "Approved"
+
+  new_repo type-bang-older
+  commit_message "feat!: remove public field"
+  commit_message "fix: newest safe commit"
+  assert_guard "older type bang subject" true false "" "Approved"
+
+  new_repo scoped-bang-newest
+  commit_message "fix: older safe commit"
+  commit_message "refactor(api)!: replace response schema"
+  assert_guard "newest scoped type bang subject" true false "" "Approved"
+
+  new_repo scoped-bang-older
+  commit_message "refactor(api)!: replace response schema"
+  commit_message "fix: newest safe commit"
+  assert_guard "older scoped type bang subject" true false "" "Approved"
+
+  new_repo breaking-change-footer
+  commit_message $'feat: replace contract\n\nBREAKING CHANGE: old clients must migrate'
+  assert_guard "BREAKING CHANGE footer" true false "" "Approved"
+
+  new_repo breaking-changes-footer
+  commit_message $'feat: replace contract\n\nBREAKING CHANGES: old clients must migrate'
+  assert_guard "BREAKING CHANGES footer" true false "" "Approved"
+
+  new_repo breaking-hyphen-footer
+  commit_message $'feat: replace contract\n\nbreaking-change: old clients must migrate'
+  assert_guard "BREAKING-CHANGE is not a release footer" false false "" "Approved"
+
+  new_repo mixed-case-footer
+  commit_message $'feat: replace contract\n\nBrEaKiNg ChAnGe: old clients must migrate'
+  assert_guard "mixed-case breaking footer" true false "" "Approved"
+
+  new_repo indented-footer
+  commit_message $'feat: replace contract\n\n  BREAKING CHANGE: old clients must migrate'
+  assert_guard "indented breaking footer" true false "" "Approved"
+
+  new_repo star-footer
+  commit_message $'feat: replace contract\n\n* BREAKING CHANGES old clients must migrate'
+  assert_guard "star bullet and whitespace separator" true false "" "Approved"
+
+  new_repo pipe-footer
+  commit_message $'feat: replace contract\n\n| BREAKING CHANGE:: old clients must migrate'
+  assert_guard "pipe bullet and repeated colon separator" true false "" "Approved"
+
+  new_repo hyphen-bullet-footer
+  commit_message $'feat: replace contract\n\n- BREAKING CHANGE: old clients must migrate'
+  assert_guard "hyphen bullet is not a release note" false false "" "Approved"
+
+  new_repo invalid-note-separator
+  commit_message $'feat: replace contract\n\nBREAKING CHANGE, old clients must migrate'
+  assert_guard "comma is not a release note separator" false false "" "Approved"
+
+  new_repo prose-footer
+  commit_message "docs: explain why prose mentioning BREAKING CHANGE: is not a footer"
+  assert_guard "reserved footer text in prose is safe" false false "" "Approved"
+
+  new_repo advanced-base
+  commit_message "feat: safe feature commit"
+  git -C "${CURRENT_REPO}" checkout -q main
+  commit_message "feat!: breaking commit added only to base"
+  git -C "${CURRENT_REPO}" push -q origin main
+  git -C "${CURRENT_REPO}" checkout -q feature
+  git -C "${CURRENT_REPO}" fetch -q origin main
+  assert_guard "breaking commit only on advanced base is safe" false false "" "Approved"
+
+  new_repo missing-base
+  commit_message "feat: safe feature commit"
+  assert_runtime_failure "missing base ref fails closed" \
+    "Breaking Change Guard: base ref origin/missing is missing or invalid." missing
+
+  new_repo invalid-head
+  git -C "${CURRENT_REPO}" symbolic-ref HEAD refs/heads/unborn
+  assert_runtime_failure "invalid HEAD fails closed" \
+    "Breaking Change Guard: HEAD is missing or invalid."
+
+  new_repo git-log-failure
+  commit_message "feat: safe feature commit"
+  wrapper_dir="${TEST_ROOT}/${AWK_BIN}-git-wrapper"
+  mkdir -p "${wrapper_dir}"
+  cat >"${wrapper_dir}/git" <<EOF
+#!/usr/bin/env bash
+if [[ \${1:-} == log ]]; then
+  printf 'forced git log failure\n' >&2
+  exit 42
+fi
+exec "${REAL_GIT}" "\$@"
+EOF
+  chmod +x "${wrapper_dir}/git"
+  assert_runtime_failure "git log failure fails closed" \
+    "Breaking Change Guard: git log failed for origin/main..HEAD." \
+    main "${wrapper_dir}:${PATH}"
+
+  new_repo shallow-history
+  commit_message "feat!: older breaking commit"
+  commit_message "fix: newest safe commit"
+  make_shallow_clone_without_parent shallow-history
+  assert_runtime_failure "shallow history fails closed" \
+    "Breaking Change Guard: shallow repository detected; fetch full history before running."
+
+  new_repo acknowledgement-exact
+  commit_message "feat: safe feature commit"
+  assert_guard "exact acknowledgement present" false true \
+    "Before. Approved for major release. After." "Approved for major release."
+  assert_guard "acknowledgement absent" false false \
+    "No release approval here." "Approved for major release."
+  assert_guard "partial acknowledgement is rejected" false false \
+    "Approved for major" "Approved for major release."
+  assert_guard "empty acknowledgement is rejected" false false "anything" ""
+
+  new_repo breaking-acknowledgement
+  commit_message "feat!: replace public API"
+  assert_guard "breaking change with exact acknowledgement" true true \
+    "Approved for major release." "Approved for major release."
+  assert_guard "breaking change with acknowledgement capitalization mismatch" true false \
+    "approved for major release." "Approved for major release."
+
+  new_repo acknowledgement-literals
+  commit_message "feat: safe acknowledgement fixture"
+  multi_ack=$'Approval record:\nOwner: release team\nImpact: major version'
+  assert_guard "complete multiline acknowledgement" false true \
+    $'Context\nApproval record:\nOwner: release team\nImpact: major version\nEnd' "${multi_ack}"
+  assert_guard "partial multiline acknowledgement is rejected" false false \
+    $'Approval record:\nOwner: release team' "${multi_ack}"
+
+  metachar_ack="Approved [v1].* \$(not-a-command); ^\$ \\ literal"
+  assert_guard "acknowledgement with regex and shell metacharacters" false true \
+    "prefix ${metachar_ack} suffix" "${metachar_ack}"
+
+  large_body="Approved for major release."
+  i=0
+  while [[ ${i} -lt 600 ]]; do
+    large_body+=$'\nfiller line that must not hide an early acknowledgement'
+    i=$((i + 1))
+  done
+  printf 'info - large body fixture: %d bytes\n' "${#large_body}"
+  assert_guard "large body with acknowledgement near start" false true \
+    "${large_body}" "Approved for major release."
+}
+
+AWK_BIN='awk'
+run_matrix
+
+if command -v gawk >/dev/null 2>&1; then
+  AWK_BIN='gawk'
+  run_matrix
+else
+  printf 'skip - gawk matrix (gawk is not installed)\n'
+fi
+
+printf '\n%d passed, %d failed\n' "${PASSED}" "${FAILED}"
+[[ ${FAILED} -eq 0 ]]


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Publishes the reusable Breaking Change Guard composite action and adds its durable detector matrix to self-CI.

The action scans only pull request commits, matches the breaking-change grammar used by the pinned semantic-release parser, rejects shallow histories, and reports detection and explicit PR-description approval as separate boolean outputs.

This PR intentionally does not integrate merge enforcement into `pr-validation.yml`. That integration follows after this action is published in `v1`, so mandatory enforcement can use an immutable released reference.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [x] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Not run. Detector matrix passed 38/38 locally and 76/76 on Ubuntu 24.04 with both awk and gawk.

## Related Issues

None.