### PR TITLE
feat(validation): add guard reporting support

### DIFF
--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -18,7 +18,10 @@ Posts a single mergeability summary comment aggregating all PR validation check 
 | `size-result` | Result of PR size check | No | `skipped` |
 | `label-result` | Result of auto-label step | No | `skipped` |
 | `metadata-result` | Result of PR metadata check | No | `skipped` |
+| `breaking-change-result` | Result of the blocking breaking change guard | No | `skipped` |
 | `dry-run` | When `true`, skip posting the summary comment | No | `false` |
+
+When `breaking-change-result` is `skipped` or omitted, the report omits the guard row and preserves existing mergeability behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out. When supplied, only `success` is mergeable.
 
 ## Usage as composite step
 
@@ -39,6 +42,7 @@ jobs:
           size-result: ${{ needs.advisory-checks.outputs.size-result }}
           label-result: ${{ needs.advisory-checks.outputs.label-result }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result }}
+          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result }}
 ```
 
 ## Required permissions

--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -79,7 +79,7 @@ jobs:
           size-result: ${{ needs.advisory-checks.outputs.size-result }}
           label-result: ${{ needs.advisory-checks.outputs.label-result }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result }}
-          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result || 'skipped' }}
+          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result }}
 ```
 
 ## Required permissions

--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -23,10 +23,47 @@ Posts a single mergeability summary comment aggregating all PR validation check 
 
 When `breaking-change-result` is `skipped` or omitted, the report omits the guard row and preserves existing mergeability behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out. When supplied, only `success` is mergeable.
 
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has-breaking-change-guard` | Whether the breaking change guard result was reported, i.e. `breaking-change-result` was not `skipped` (`true`/`false`) |
+
 ## Usage as composite step
+
+The `blocking-checks` job must define a `breaking-change-result` output normalized to `success`/`failure`/`cancelled`/`skipped`, derived from the [`breaking-change-guard`](../../validate/breaking-change-guard/README.md) step:
 
 ```yaml
 jobs:
+  blocking-checks:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      # ...other check outputs...
+      breaking-change-result: ${{ steps.breaking-change-result.outputs.result }}
+    steps:
+      # ...other checks...
+      - name: Breaking Change Guard
+        id: breaking-change-guard
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/breaking-change-guard@v1.x.x
+        with:
+          base-ref: ${{ github.base_ref }}
+          breaking-change-acknowledgement: 'BREAKING CHANGE APPROVED'
+      - name: Resolve breaking change result
+        id: breaking-change-result
+        if: always()
+        env:
+          GUARD_OUTCOME: ${{ steps.breaking-change-guard.outcome }}
+          HAS_BREAKING_CHANGES: ${{ steps.breaking-change-guard.outputs.has-breaking-changes }}
+          APPROVED: ${{ steps.breaking-change-guard.outputs.approved }}
+        run: |
+          if [ "$GUARD_OUTCOME" != "success" ]; then
+            echo "result=$GUARD_OUTCOME" >> "$GITHUB_OUTPUT"
+          elif [ "$HAS_BREAKING_CHANGES" = "true" ] && [ "$APPROVED" != "true" ]; then
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          fi
+
   pr-validation-report:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [blocking-checks, advisory-checks]
@@ -42,7 +79,7 @@ jobs:
           size-result: ${{ needs.advisory-checks.outputs.size-result }}
           label-result: ${{ needs.advisory-checks.outputs.label-result }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result }}
-          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result }}
+          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result || 'skipped' }}
 ```
 
 ## Required permissions

--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -56,6 +56,7 @@ jobs:
           HAS_BREAKING_CHANGES: ${{ steps.breaking-change-guard.outputs.has-breaking-changes }}
           APPROVED: ${{ steps.breaking-change-guard.outputs.approved }}
         run: |
+          set -euo pipefail
           if [ "$GUARD_OUTCOME" != "success" ]; then
             echo "result=$GUARD_OUTCOME" >> "$GITHUB_OUTPUT"
           elif [ "$HAS_BREAKING_CHANGES" = "true" ] && [ "$APPROVED" != "true" ]; then

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -52,6 +52,7 @@ runs:
       env:
         BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
       run: |
+        set -euo pipefail
         if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
           echo "has-breaking-change-guard=true" >> "$GITHUB_OUTPUT"
         else

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -38,9 +38,26 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  has-breaking-change-guard:
+    description: Whether the breaking change guard result was reported (true/false)
+    value: ${{ steps.guard-state.outputs.has-breaking-change-guard }}
+
 runs:
   using: composite
   steps:
+    - name: Resolve breaking change guard state
+      id: guard-state
+      shell: bash
+      env:
+        BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
+      run: |
+        if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
+          echo "has-breaking-change-guard=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-breaking-change-guard=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Post PR validation summary
       if: inputs.dry-run != 'true'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Result of PR metadata check (success/failure/skipped)
     required: false
     default: "skipped"
+  breaking-change-result:
+    description: Result of breaking change guard (success/failure/skipped)
+    required: false
+    default: skipped
   dry-run:
     description: When true, skip posting the summary comment
     required: false
@@ -47,6 +51,7 @@ runs:
         SIZE_RESULT: ${{ inputs.size-result }}
         LABEL_RESULT: ${{ inputs.label-result }}
         METADATA_RESULT: ${{ inputs.metadata-result }}
+        BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -59,9 +64,20 @@ runs:
             { label: 'PR Metadata',    result: process.env.METADATA_RESULT,      blocking: false },
           ];
 
+          if (process.env.BREAKING_CHANGE_RESULT !== 'skipped') {
+            checks.splice(3, 0, {
+              label: 'Breaking Change Guard',
+              result: process.env.BREAKING_CHANGE_RESULT,
+              blocking: true,
+              strict: true,
+            });
+          }
+
           const icon = (r) => ({ success: '✅', failure: '❌', skipped: '⏭️' }[r] ?? '⚠️');
 
-          const blockingFailures = checks.filter(c => c.blocking && c.result === 'failure');
+          const blockingFailures = checks.filter(c =>
+            c.blocking && (c.strict ? c.result !== 'success' : c.result === 'failure')
+          );
           const verdictHeader = blockingFailures.length > 0
             ? `## 🚫 PR Blocked — ${blockingFailures.length} blocking failure${blockingFailures.length === 1 ? '' : 's'}\n\n`
             : `## ✅ PR Mergeable — no blocking failures\n\n`;

--- a/src/validate/pr-checks-summary/README.md
+++ b/src/validate/pr-checks-summary/README.md
@@ -46,7 +46,7 @@ jobs:
           size-result: ${{ needs.advisory-checks.outputs.size-result || 'skipped' }}
           label-result: ${{ needs.advisory-checks.outputs.label-result || 'skipped' }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
-          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result || 'skipped' }}
+          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result }}
           dry-run: "true"
 ```
 

--- a/src/validate/pr-checks-summary/README.md
+++ b/src/validate/pr-checks-summary/README.md
@@ -22,6 +22,12 @@ Generates a summary table of all PR validation check results in the GitHub Actio
 
 When `breaking-change-result` is `skipped` or omitted, the summary omits the guard row and preserves existing behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out.
 
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has-breaking-change-guard` | Whether the breaking change guard result was reported, i.e. `breaking-change-result` was not `skipped` (`true`/`false`) |
+
 ## Usage as composite step
 
 ```yaml

--- a/src/validate/pr-checks-summary/README.md
+++ b/src/validate/pr-checks-summary/README.md
@@ -17,7 +17,10 @@ Generates a summary table of all PR validation check results in the GitHub Actio
 | `size-result` | Result of PR size check | No | `skipped` |
 | `label-result` | Result of auto-label step | No | `skipped` |
 | `metadata-result` | Result of PR metadata check | No | `skipped` |
+| `breaking-change-result` | Result of the breaking change guard | No | `skipped` |
 | `dry-run` | Whether this is a dry run | No | `false` |
+
+When `breaking-change-result` is `skipped` or omitted, the summary omits the guard row and preserves existing behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out.
 
 ## Usage as composite step
 
@@ -37,6 +40,7 @@ jobs:
           size-result: ${{ needs.advisory-checks.outputs.size-result || 'skipped' }}
           label-result: ${{ needs.advisory-checks.outputs.label-result || 'skipped' }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
+          breaking-change-result: ${{ needs.blocking-checks.outputs.breaking-change-result || 'skipped' }}
           dry-run: "true"
 ```
 

--- a/src/validate/pr-checks-summary/action.yml
+++ b/src/validate/pr-checks-summary/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Result of PR metadata check
     required: false
     default: skipped
+  breaking-change-result:
+    description: Result of breaking change guard
+    required: false
+    default: skipped
   dry-run:
     description: Whether this is a dry run
     required: false
@@ -43,6 +47,7 @@ runs:
         DESCRIPTION_RESULT: ${{ inputs.description-result }}
         LABEL_RESULT: ${{ inputs.label-result }}
         METADATA_RESULT: ${{ inputs.metadata-result }}
+        BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
         DRY_RUN: ${{ inputs.dry-run }}
       run: |
         icon() {
@@ -67,6 +72,9 @@ runs:
           echo "| Source Branch | $(icon "$SOURCE_BRANCH_RESULT") ${SOURCE_BRANCH_RESULT} |"
           echo "| PR Title | $(icon "$TITLE_RESULT") ${TITLE_RESULT} |"
           echo "| PR Description | $(icon "$DESCRIPTION_RESULT") ${DESCRIPTION_RESULT} |"
+          if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
+            echo "| Breaking Change Guard | $(icon "$BREAKING_CHANGE_RESULT") ${BREAKING_CHANGE_RESULT} |"
+          fi
           echo ""
           echo "### Advisory"
           echo ""

--- a/src/validate/pr-checks-summary/action.yml
+++ b/src/validate/pr-checks-summary/action.yml
@@ -35,9 +35,26 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  has-breaking-change-guard:
+    description: Whether the breaking change guard result was reported (true/false)
+    value: ${{ steps.guard-state.outputs.has-breaking-change-guard }}
+
 runs:
   using: composite
   steps:
+    - name: Resolve breaking change guard state
+      id: guard-state
+      shell: bash
+      env:
+        BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
+      run: |
+        if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
+          echo "has-breaking-change-guard=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-breaking-change-guard=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Summary
       shell: bash
       env:
@@ -53,8 +70,9 @@ runs:
         icon() {
           case "$1" in
             success) echo "✅" ;;
-            failure) echo "❌" ;;
-            *)       echo "⏭️" ;;
+            failure|cancelled) echo "❌" ;;
+            skipped) echo "⏭️" ;;
+            *)       echo "⚠️" ;;
           esac
         }
 

--- a/src/validate/pr-checks-summary/action.yml
+++ b/src/validate/pr-checks-summary/action.yml
@@ -49,6 +49,7 @@ runs:
       env:
         BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
       run: |
+        set -euo pipefail
         if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
           echo "has-breaking-change-guard=true" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds backward-compatible Breaking Change Guard result support to the PR validation reporter and Actions summary composites.

Direct consumers that omit the new result retain the current output and mergeability behavior. The mandatory `pr-validation` integration will always supply the result and will not expose a guard opt-out.

This prerequisite keeps reporter and summary output truthful when mandatory enforcement lands in the next release unit, without executing feature-branch code with a write token.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Not run. Local metadata and rendering harnesses covered omitted, skipped, success, failure, cancelled, empty, and unknown states.

## Related Issues

None.