### PR TITLE
fix(security): align codeql init/analyze pins with autobuild

### DIFF
--- a/src/security/codeql-analyze/action.yml
+++ b/src/security/codeql-analyze/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         category: ${{ inputs.category }}
         output: ${{ inputs.output }}

--- a/src/security/codeql-init/action.yml
+++ b/src/security/codeql-init/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         languages: ${{ inputs.languages }}
         queries: ${{ inputs.queries }}


### PR DESCRIPTION
## Description

Every `codeql_scan` job in `pr-security-scan.yml` (and thus `go-pr-validation.yml`) currently fails on Go-changing PRs with:

```
Error: We were unable to automatically build your code. ...
Loaded a configuration file for version '4.35.1', but running version '4.36.3'
```

Root cause: the `codeql-init` / `codeql-analyze` composites pin `github/codeql-action` at `c10b8064` (v4.35.1), while the `Autobuild` step inside `pr-security-scan.yml` was bumped by Dependabot to `54f647b7` (v4.36.3, tag v1.46.x) and `e4fba868` (v4.37.3, develop / v1.48+). `codeql-action` requires init/autobuild/analyze to run the exact same version, so the mix hard-fails before the build starts. Dependabot cannot see the composites (`src/**/action.yml` is outside the `github-actions` ecosystem scan, as noted in `.github/dependabot.yml`), which is how the pins drifted.

This PR aligns both composites with the pin already used by `Autobuild` and `upload-sarif` on develop:

```yaml
# src/security/codeql-init/action.yml, src/security/codeql-analyze/action.yml
- uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4 (4.35.1)
+ uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4 (4.37.3)
```

Note for consumers: because the composites resolve via the floating `@v1` tag, callers pinned to tags whose `Autobuild` step is on a different codeql-action version (e.g. v1.46.x → v4.36.3) will still mismatch after this ships; they need to bump to a tag whose autobuild pin is `e4fba868` (v1.48.0+). Longer term, consider having `pr-security-scan.yml` consume autobuild through a composite too, so all four codeql-action steps bump atomically.

## Type of Change

- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Failure reproduced on https://github.com/LerianStudio/plugin-br-bank-transfer/actions/runs/31132478400 (`validate / Security (pipeline) / codeql_scan`); the pins are only consumed via `@v1`, so a pre-merge caller run cannot exercise this change directly.

## Related Issues

Closes #
