### PR TITLE
chore(release): promote v1.53.1

### DIFF
--- a/src/security/codeql-analyze/action.yml
+++ b/src/security/codeql-analyze/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         category: ${{ inputs.category }}
         output: ${{ inputs.output }}

--- a/src/security/codeql-init/action.yml
+++ b/src/security/codeql-init/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         languages: ${{ inputs.languages }}
         queries: ${{ inputs.queries }}


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Promotes the validated `develop` state to `main` for the stable `v1.53.1` release, so the CodeQL pin alignment from #655 reaches the floating `v1` tag.

Every Go-changing PR in the org is currently red on `codeql_scan` with:

```
##[error]We were unable to automatically build your code. Please replace the call to the
autobuild action with your custom build steps. Loaded a configuration file for version
'4.35.1', but running version '4.36.3'
```

`pr-security-scan.yml` resolves the CodeQL composites through the floating `v1` tag while pinning `autobuild` by SHA in the workflow itself, so the two must agree:

```yaml
      - name: Initialize CodeQL
        uses: LerianStudio/github-actions-shared-workflows/src/security/codeql-init@v1   # v1 -> v1.53.0 -> codeql-action v4.35.1
      # ...
      - name: Autobuild
        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81   # v4.37.3
```

`codeql-action` hard-fails on any init/autobuild version mismatch. #655 fixed it by moving `codeql-init` and `codeql-analyze` to `e4fba86` (v4.37.3), matching `autobuild`, but that fix currently only exists on `develop` and in the pre-release `v1.53.1-beta.1`. `v1` still points at `v1.53.0` (`e76b082`), which carries the mismatched `c10b806` (v4.35.1) pin, so callers stay broken until a stable release moves the tag.

This promotion carries three commits: #655 and its backmerge/rebase commits. No workflow inputs, outputs, or defaults change.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None to the workflow interface. Worth flagging for release notes: once `v1` moves, the composites resolve to codeql-action v4.37.3, so callers pinned to a shared-workflows tag whose `autobuild` SHA is older than `e4fba86` (that is, anything below `v1.48.0`) will keep failing with the inverse mismatch and need to bump their pipeline ref to `v1.48.0` or newer. `plugin-br-bank-transfer` is one such caller and is being bumped in LerianStudio/plugin-br-bank-transfer#282.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** Verified by pin inspection across tags: `v1.48.0`..`v1.53.0` pin `autobuild@e4fba86` (v4.37.3) while `codeql-init@v1` resolves to `c10b806` (v4.35.1); at `v1.53.1-beta.1` all three (`init`, `analyze`, `autobuild`) are `e4fba86`. Failing caller run: https://github.com/LerianStudio/plugin-br-bank-transfer/actions/runs/31134542606/job/92731111874

## Related Issues

Ships #655.