### PR TITLE
fix: align codeql-action init/analyze SHA to autobuild

### DIFF
--- a/src/security/codeql-analyze/action.yml
+++ b/src/security/codeql-analyze/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         category: ${{ inputs.category }}
         output: ${{ inputs.output }}

--- a/src/security/codeql-init/action.yml
+++ b/src/security/codeql-init/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
       with:
         languages: ${{ inputs.languages }}
         queries: ${{ inputs.queries }}


### PR DESCRIPTION
## Problem
Go CodeQL scans fail at the Autobuild step:
`Loaded a configuration file for version '4.37.3', but running version '4.35.1'`.

Root cause: the `github/codeql-action` steps are on **two different SHAs**:
- `init` + `analyze` → `c10b8064` (CodeQL **4.35.1**)
- `autobuild` + `upload-sarif` → `e4fba868` (CodeQL **4.37.3**)

`init` sets up 4.35.1; `autobuild` (newer) expects 4.37.3 → version skew → autobuild aborts.

## Fix
Bump `codeql-init` and `codeql-analyze` composites to `e4fba868` so all four codeql-action steps run the same CodeQL (4.37.3). Same major (v4); no behavior change beyond version alignment.

Seen on LerianStudio/vault-lerian PR #3.