### PR TITLE
feat(go-pr-validation): non-blocking nudge when a repo has no permissions.yaml

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -45,6 +45,10 @@ on:
         description: 'Run the Lerian library version check (fails when a direct Lerian lib is behind latest stable)'
         type: boolean
         default: true
+      run_manifest_nudge:
+        description: 'Run the NON-BLOCKING Access-Manager RI nudge: warns via a sticky PR comment when a lib-auth repo has no permissions.yaml manifest. Never fails or blocks the PR.'
+        type: boolean
+        default: true
 
       # ----------------- Change gate -----------------
       ignore_globs:
@@ -410,3 +414,37 @@ jobs:
         with:
           result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.lib-version.result }}
           label: Lib Version
+
+  # ----------------- Permission Manifest Nudge (RI) — NON-BLOCKING -----------------
+  # Part of the Access-Manager "Inversão de Responsabilidade" (RI) rollout. Reminds
+  # a lib-auth plugin/service to declare its permissions in a permissions.yaml
+  # manifest by posting a sticky, idempotent PR comment.
+  #
+  # This job is INTENTIONALLY non-blocking:
+  #   * `continue-on-error: true` — a failure here never fails the umbrella run.
+  #   * There is NO `*-gate` aggregator for it, so it is not a stable/required
+  #     status check. Do NOT add it to branch protection.
+  #   * The underlying composite is best-effort and always exits 0.
+  # It is a standalone job (no `needs`) so it never affects the required gates above.
+  permission-manifest-nudge:
+    name: Permission Manifest Nudge
+    if: inputs.run_manifest_nudge && github.event_name == 'pull_request'
+    continue-on-error: true
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Nudge when no permissions.yaml manifest exists
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-nudge@v1
+        with:
+          # Direct job of the umbrella (not a nested reusable), so github.token is
+          # scoped to the caller repo and can post the comment; MANAGE_TOKEN is used
+          # when provided (parity with the coverage/lib-version commenters).
+          github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
+          go-mod-path: ${{ inputs.lib_version_go_mod_path }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -448,3 +448,5 @@ jobs:
           # when provided (parity with the coverage/lib-version commenters).
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           go-mod-path: ${{ inputs.lib_version_go_mod_path }}
+          # Preview mode: no comment / no PR side effects when the umbrella runs dry.
+          dry-run: ${{ inputs.dry_run }}

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -13,6 +13,7 @@ Umbrella reusable workflow for Go service repositories. A caller references this
 4. **Go analysis** — lint, tests, coverage and build (delegates to `go-pr-analysis.yml`), opt-in via `run_go_analysis`.
 5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
 6. **Lerian lib version check** — fails when a direct Lerian library is behind its latest stable release (delegates to `lerian-lib-version-check.yml`), opt-in via `run_lib_version_check`.
+7. **Permission manifest nudge (RI)** — **non-blocking** reminder that warns via a sticky PR comment when a `lib-auth` repo has no `permissions.yaml` manifest (delegates to `src/validate/permission-manifest-nudge`), opt-in via `run_manifest_nudge`. Never fails and is **not** a required check.
 
 The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing — so broken change detection cannot let the required checks go green.
 
@@ -34,6 +35,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_lib_version_check` | Run the Lerian library version check | boolean | `true` |
+| `run_manifest_nudge` | Run the **non-blocking** Access-Manager RI nudge: warns via a sticky PR comment when a `lib-auth` repo has no `permissions.yaml`. Never fails or blocks the PR. | boolean | `true` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `lib_version_go_mod_path` | Path to go.mod for the Lerian lib check | string | `go.mod` |
 | `lib_version_check_indirect` | Also check transitive (indirect) Lerian deps | boolean | `false` |
@@ -96,6 +98,17 @@ Breaking change acknowledged: I understand that this PR intentionally introduces
 The guard is mandatory for every PR target branch. PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
 
 Caller triggers must include the five activity types in the usage example. `edited` is mandatory so removing or adding the acknowledgement reruns validation. `ready_for_review` is retained for complete validation transitions even though the guard enforces drafts.
+
+## Permission Manifest Nudge (RI) — non-blocking
+
+Part of the Access-Manager **Inversão de Responsabilidade (RI)** rollout. The `permission-manifest-nudge` job reminds a plugin/service to declare its permissions in a `permissions.yaml` manifest instead of relying on manual Access-Manager configuration.
+
+- **Scope gate:** only acts when `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. Repos with no `go.mod` or no direct lib-auth dependency are skipped silently. (This is the intended scoping — tune the `grep` in the composite to widen or narrow it.)
+- **Presence check:** globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and only counts files with top-level `service:` **and** `permissions:` keys.
+- **Idempotent comment:** posts / updates a single find-by-marker (`<!-- permission-manifest-nudge -->`) sticky comment — never spams per push. When a manifest is present it flips any prior nudge to a positive state.
+- **Never blocks:** the job runs with `continue-on-error: true`, the composite always exits 0, and there is **no** `*-gate` aggregator for it — so it must **not** be added to branch protection. Disable it entirely with `run_manifest_nudge: false`.
+
+See [`src/validate/permission-manifest-nudge`](../src/validate/permission-manifest-nudge/README.md) for the composite action details.
 
 ## Secrets
 

--- a/src/validate/permission-manifest-nudge/README.md
+++ b/src/validate/permission-manifest-nudge/README.md
@@ -1,0 +1,75 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>permission-manifest-nudge</h1></td>
+  </tr>
+</table>
+
+**NON-BLOCKING** reminder that nudges a Go plugin/service to adopt the Access-Manager **Inversão de Responsabilidade (RI)** by declaring its permissions in a `permissions.yaml` manifest.
+
+The action:
+
+1. **Scope gate** — only acts when the repo looks like a plugin/service that *should* declare permissions, i.e. its `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. No `go.mod`, or no direct lib-auth dependency → it exits cleanly with no comment.
+2. **Manifest presence** — globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and keeps only files that look like a real declaration (top-level `service:` **and** `permissions:` keys).
+3. **Sticky comment** — when in scope and no qualifying manifest exists, posts / updates a single find-by-marker PR comment inviting the team to adopt the RI. When a manifest *is* present it flips any prior nudge comment to a positive state (and never creates a new one).
+
+> It **never fails**: every step is best-effort and exits 0. Pair it with `continue-on-error: true` on the calling job so a hiccup here can never gate a merge. It is **not** a required status check.
+
+## Inputs
+
+| Input           | Description                                                                                  | Required | Default                                                                       |
+|-----------------|----------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------------------------|
+| `github-token`  | Token used to post / update the sticky PR comment. Needs `pull-requests:write` on the caller repo. | Yes      |                                                                               |
+| `go-mod-path`   | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.             | No       | `go.mod`                                                                       |
+| `guide-url`     | Link to the RI adoption guide surfaced in the nudge comment.                                 | No       | `https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0`  |
+| `comment-on-pr` | Post / update the sticky PR comment. When `false`, the check still runs but stays silent.    | No       | `true`                                                                         |
+
+## Outputs
+
+| Output         | Description                                                                        |
+|----------------|------------------------------------------------------------------------------------|
+| `applicable`   | `true` if the repo is in scope (go.mod depends on lib-auth); `false` = skipped.     |
+| `has_manifest` | `true` if at least one qualifying `permissions.yaml` manifest was found.            |
+| `state`        | `skip` (out of scope), `compliant` (manifest present), or `nudge` (in scope, none). |
+
+## Behavior matrix
+
+| Condition                                                    | Result                                                     |
+|--------------------------------------------------------------|------------------------------------------------------------|
+| `go.mod` not found at `go-mod-path`                          | `skip` — `::notice`, no comment, exit 0                     |
+| `go.mod` has no **direct** `lib-auth` dependency             | `skip` — `::notice`, no comment, exit 0                    |
+| In scope + a qualifying `permissions.yaml` exists            | `compliant` — flips an existing nudge comment to positive; creates nothing new |
+| In scope + no qualifying `permissions.yaml`                  | `nudge` — posts / updates the single sticky reminder comment |
+| Any internal / API error                                     | Logged as `::warning`; exit 0 (never fails)                |
+
+## Scope gate — reviewer knob
+
+The scope is deliberately narrow (direct lib-auth dep) to avoid noise on non-plugin repos. To tune it, edit the `grep` in `action.yml` step *Detect lib-auth scope and permission manifest*:
+
+- drop the `// indirect` exclusion to also catch transitive lib-auth,
+- match a different signal (e.g. `lib-commons`, a marker file, or a repo topic).
+
+## Usage as composite step
+
+```yaml
+jobs:
+  permission-manifest-nudge:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    continue-on-error: true   # non-blocking by contract
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-nudge@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Most callers get this for free through the [`go-pr-validation`](../../../docs/go-pr-validation.md) umbrella (`run_manifest_nudge`, default `true`).
+
+## Implementation notes
+
+- Pure Bash + `actions/github-script` — no extra runtime required on the runner.
+- The sticky comment is keyed by the HTML marker `<!-- permission-manifest-nudge -->`, so re-runs update the same comment instead of spamming per push.
+- The manifest content check is intentionally light (`service:` + `permissions:` top-level keys) — it is a nudge, not a schema validator. `make validate-permissions` is the local validator teams run.

--- a/src/validate/permission-manifest-nudge/README.md
+++ b/src/validate/permission-manifest-nudge/README.md
@@ -23,6 +23,7 @@ The action:
 | `go-mod-path`   | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.             | No       | `go.mod`                                                                       |
 | `guide-url`     | Link to the RI adoption guide surfaced in the nudge comment.                                 | No       | `https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0`  |
 | `comment-on-pr` | Post / update the sticky PR comment. When `false`, the check still runs but stays silent.    | No       | `true`                                                                         |
+| `dry-run`       | Preview mode. When `true`, the check runs but makes NO GitHub API calls / PR side effects (logs what it would post). | No       | `false`                                                                       |
 
 ## Outputs
 

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -157,7 +157,7 @@ runs:
             echo
             echo "- 📖 Guia: [Declaração de Permissões (RI) — v1.0](${GUIDE_URL})"
             echo "- 🛠️ Skill do Ring: \`ring:declaring-plugin-permissions\`"
-            echo "- ✅ Depois de criar o \`permissions.yaml\`, valide localmente com \`make validate-permissions\`."
+            echo "- ✅ Depois de criar o \`permissions.yaml\`, rode \`make validate-permissions\` localmente."
             echo
             echo "> ℹ️ Isto é **apenas um lembrete** — **não bloqueia** o merge deste PR. Sinta-se à vontade"
             echo "> para adotar quando fizer sentido para o time."

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -1,0 +1,233 @@
+name: Permission Manifest Nudge (RI)
+description: |
+  NON-BLOCKING reminder that nudges a Go plugin/service to adopt the Access-Manager
+  "Inversão de Responsabilidade" (RI) by declaring its permissions in a
+  `permissions.yaml` manifest.
+
+  Scope gate: only acts when the repository looks like a plugin/service that SHOULD
+  declare permissions — i.e. its go.mod has a DIRECT dependency on
+  `github.com/LerianStudio/lib-auth`. Otherwise it exits cleanly with no comment.
+
+  When in scope and no qualifying manifest exists, it posts / updates a single
+  sticky PR comment (find-by-marker) inviting the team to adopt the RI. It NEVER
+  fails: every step is best-effort and exits 0. Pair it with `continue-on-error: true`
+  on the calling job so a hiccup here can never gate a merge.
+
+inputs:
+  github-token:
+    description: Token used to post / update the sticky PR comment. Needs pull-requests:write on the caller repo.
+    required: true
+  go-mod-path:
+    description: Path to go.mod (relative to repo root). Used only for the lib-auth scope gate.
+    required: false
+    default: "go.mod"
+  guide-url:
+    description: Link to the RI adoption guide surfaced in the nudge comment.
+    required: false
+    default: "https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0"
+  comment-on-pr:
+    description: Post / update the sticky PR comment. When false, the check still runs but stays silent.
+    required: false
+    default: "true"
+
+outputs:
+  applicable:
+    description: "true if the repo is in scope (go.mod depends on lib-auth); false = skipped."
+    value: ${{ steps.check.outputs.applicable }}
+  has_manifest:
+    description: "true if at least one qualifying permissions.yaml manifest was found."
+    value: ${{ steps.check.outputs.has_manifest }}
+  state:
+    description: "One of: skip (out of scope), compliant (manifest present), nudge (in scope, no manifest)."
+    value: ${{ steps.check.outputs.state }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect lib-auth scope and permission manifest
+      id: check
+      shell: bash
+      env:
+        GO_MOD_PATH: ${{ inputs.go-mod-path }}
+        GUIDE_URL: ${{ inputs.guide-url }}
+      run: |
+        # Best-effort by design: never `set -e`. Any internal hiccup degrades to a
+        # skip (state=skip) and exits 0 so this reminder can never gate a merge.
+        set -uo pipefail
+
+        REPORT_PATH="${RUNNER_TEMP:-/tmp}/permission-manifest-nudge.md"
+        : > "${REPORT_PATH}"
+
+        emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
+
+        # ---------------------------------------------------------------------------
+        # 1. SCOPE GATE — only nudge repos that SHOULD declare permissions.
+        #
+        #    Signal: a DIRECT dependency on github.com/LerianStudio/lib-auth in go.mod.
+        #    A repo with no go.mod, or one that does not import lib-auth directly, is
+        #    out of scope and exits silently (state=skip, no comment).
+        #
+        #    REVIEWER KNOB: to widen/narrow the scope, change the grep below. E.g. drop
+        #    the `// indirect` exclusion to also catch transitive lib-auth, or match a
+        #    different lib (lib-commons, a plugin marker file, a topic, ...).
+        # ---------------------------------------------------------------------------
+        if [[ ! -f "${GO_MOD_PATH}" ]]; then
+          echo "::notice title=Permission manifest nudge::No go.mod at '${GO_MOD_PATH}' — not a Go service, skipping."
+          emit applicable false
+          emit has_manifest false
+          emit state skip
+          emit report_path "${REPORT_PATH}"
+          exit 0
+        fi
+
+        # Match `github.com/LerianStudio/lib-auth` or `.../lib-auth/vN`, as a whole
+        # module token (space/tab after it), excluding `// indirect` lines so only a
+        # DIRECT dependency counts. The `[[:space:]]` after the optional /vN prevents
+        # matching a longer name like `lib-auth-something`.
+        if grep -E '^[[:space:]]*github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
+             | grep -qv '// indirect'; then
+          echo "Scope gate: direct github.com/LerianStudio/lib-auth dependency found — repo is in scope."
+        else
+          echo "::notice title=Permission manifest nudge::go.mod has no direct lib-auth dependency — out of scope, skipping."
+          emit applicable false
+          emit has_manifest false
+          emit state skip
+          emit report_path "${REPORT_PATH}"
+          exit 0
+        fi
+
+        emit applicable true
+
+        # ---------------------------------------------------------------------------
+        # 2. MANIFEST PRESENCE — search for a permission-declaration manifest.
+        #
+        #    Glob every `permissions.yaml` (excluding vendor / node_modules / .git),
+        #    then keep only files that look like a real declaration: top-level
+        #    `service:` AND `permissions:` keys. This light content check avoids false
+        #    positives from unrelated files that happen to be named permissions.yaml.
+        # ---------------------------------------------------------------------------
+        QUALIFYING=""
+        while IFS= read -r f; do
+          [[ -z "${f}" ]] && continue
+          # Top-level keys: unindented `service:` and `permissions:` anywhere in file.
+          if grep -qE '^service:[[:space:]]*' "${f}" 2>/dev/null \
+             && grep -qE '^permissions:[[:space:]]*' "${f}" 2>/dev/null; then
+            QUALIFYING="${f}"
+            break
+          fi
+        done < <(find . -type f -name 'permissions.yaml' \
+                   -not -path '*/vendor/*' \
+                   -not -path '*/node_modules/*' \
+                   -not -path '*/.git/*' 2>/dev/null)
+
+        if [[ -n "${QUALIFYING}" ]]; then
+          echo "Qualifying permission manifest found: ${QUALIFYING}"
+          emit has_manifest true
+          emit state compliant
+          {
+            echo "<!-- permission-manifest-nudge -->"
+            echo "### ✅ Manifesto de permissões encontrado"
+            echo
+            echo "Este repositório declara suas permissões em \`${QUALIFYING#./}\` — obrigado por adotar a **Inversão de Responsabilidade (RI)**! 🎉"
+            echo
+            echo "_Lembrete automático (não bloqueia o PR)._"
+          } > "${REPORT_PATH}"
+        else
+          echo "No qualifying permissions.yaml manifest found — will nudge."
+          emit has_manifest false
+          emit state nudge
+          {
+            echo "<!-- permission-manifest-nudge -->"
+            echo "### 🔐 Que tal adotar a Inversão de Responsabilidade (RI)?"
+            echo
+            echo "Este repositório ainda **não possui** um manifesto de permissões (\`permissions.yaml\`)."
+            echo
+            echo "Com a **Inversão de Responsabilidade** do Access-Manager, cada plugin/serviço passa a"
+            echo "**declarar as próprias permissões** em um manifesto versionado, em vez de depender de"
+            echo "configuração manual no Access-Manager. Isso deixa as permissões explícitas, revisáveis"
+            echo "no PR e reproduzíveis por ambiente."
+            echo
+            echo "**Como adotar:**"
+            echo
+            echo "- 📖 Guia: [Declaração de Permissões (RI) — v1.0](${GUIDE_URL})"
+            echo "- 🛠️ Skill do Ring: \`ring:declaring-plugin-permissions\`"
+            echo "- ✅ Depois de criar o \`permissions.yaml\`, valide localmente com \`make validate-permissions\`."
+            echo
+            echo "> ℹ️ Isto é **apenas um lembrete** — **não bloqueia** o merge deste PR. Sinta-se à vontade"
+            echo "> para adotar quando fizer sentido para o time."
+          } > "${REPORT_PATH}"
+        fi
+
+        emit report_path "${REPORT_PATH}"
+        cat "${REPORT_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+        exit 0
+
+    - name: Post / update sticky PR comment
+      # Only touches the PR when there is something to say and we are on a PR event.
+      # github-script is wrapped so an API hiccup logs and returns — never fails.
+      if: ${{ always() && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        REPORT_PATH: ${{ steps.check.outputs.report_path }}
+        STATE: ${{ steps.check.outputs.state }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          try {
+            const fs = require('fs');
+            const marker = '<!-- permission-manifest-nudge -->';
+            const state = process.env.STATE || 'skip';
+            const reportPath = process.env.REPORT_PATH;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request?.number;
+            if (!issue_number) {
+              core.info('Not a pull_request event; skipping comment.');
+              return;
+            }
+
+            // Find any prior nudge comment by its stable marker.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            // Out of scope: never create a comment. If a stale nudge exists from a
+            // prior run (e.g. lib-auth was removed), leave it — we do not delete.
+            if (state === 'skip') {
+              core.info('Out of scope; no comment posted.');
+              return;
+            }
+
+            const body = (reportPath && fs.existsSync(reportPath))
+              ? fs.readFileSync(reportPath, 'utf8')
+              : null;
+            if (!body) {
+              core.info(`No report body at ${reportPath}; skipping comment.`);
+              return;
+            }
+
+            // Compliant: update an existing nudge to the positive state, but do NOT
+            // create a brand-new comment (avoid noise on already-compliant repos).
+            if (state === 'compliant') {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                core.info(`Updated nudge comment #${existing.id} to compliant state.`);
+              } else {
+                core.info('Compliant and no prior nudge comment; nothing to do.');
+              }
+              return;
+            }
+
+            // Nudge: create or update the single sticky comment.
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated sticky nudge comment #${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Created sticky nudge comment.');
+            }
+          } catch (err) {
+            // Non-blocking by contract: log and swallow so this can never fail a PR.
+            core.warning(`permission-manifest-nudge comment step failed (non-blocking): ${err.message}`);
+          }

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Post / update the sticky PR comment. When false, the check still runs but stays silent.
     required: false
     default: "true"
+  dry-run:
+    description: Preview mode. When true, the check still runs but performs NO GitHub API calls / PR side effects (no comment) — it only logs what it would post.
+    required: false
+    default: "false"
 
 outputs:
   applicable:
@@ -81,10 +85,12 @@ runs:
         fi
 
         # Match `github.com/LerianStudio/lib-auth` or `.../lib-auth/vN`, as a whole
-        # module token (space/tab after it), excluding `// indirect` lines so only a
+        # module token (space/tab after it), in BOTH go.mod forms: the block form
+        # (indented `\tgithub.com/... vX`) and the single-line form
+        # (`require github.com/... vX`). Then exclude `// indirect` lines so only a
         # DIRECT dependency counts. The `[[:space:]]` after the optional /vN prevents
         # matching a longer name like `lib-auth-something`.
-        if grep -E '^[[:space:]]*github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
+        if grep -E '^[[:space:]]*(require[[:space:]]+)?github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
              | grep -qv '// indirect'; then
           echo "Scope gate: direct github.com/LerianStudio/lib-auth dependency found — repo is in scope."
         else
@@ -170,6 +176,7 @@ runs:
       env:
         REPORT_PATH: ${{ steps.check.outputs.report_path }}
         STATE: ${{ steps.check.outputs.state }}
+        DRY_RUN: ${{ inputs.dry-run }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -178,6 +185,7 @@ runs:
             const marker = '<!-- permission-manifest-nudge -->';
             const state = process.env.STATE || 'skip';
             const reportPath = process.env.REPORT_PATH;
+            const dryRun = (process.env.DRY_RUN || 'false') === 'true';
 
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request?.number;
@@ -185,12 +193,6 @@ runs:
               core.info('Not a pull_request event; skipping comment.');
               return;
             }
-
-            // Find any prior nudge comment by its stable marker.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
 
             // Out of scope: never create a comment. If a stale nudge exists from a
             // prior run (e.g. lib-auth was removed), leave it — we do not delete.
@@ -206,6 +208,22 @@ runs:
               core.info(`No report body at ${reportPath}; skipping comment.`);
               return;
             }
+
+            // Dry-run: preview only — NO GitHub API calls, no PR side effects.
+            // Resolved above from local files, so we log what we would post and stop
+            // before any read/write against the API.
+            if (dryRun) {
+              core.info(`[dry-run] permission-manifest-nudge would post/update (state=${state}):\n${body}`);
+              return;
+            }
+
+            // Find any prior nudge comment by its stable marker. Paginate: a single
+            // listComments page tops out at 100, so a marker beyond page 1 would be
+            // missed and we would create a duplicate sticky comment.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
 
             // Compliant: update an existing nudge to the positive state, but do NOT
             // create a brand-new comment (avoid noise on already-compliant repos).


### PR DESCRIPTION
## Description

Adds a **NON-BLOCKING** PR check that nudges Go plugins/services to adopt the Access-Manager **Inversão de Responsabilidade (RI)** by declaring their permissions in a `permissions.yaml` manifest. When a repo is in scope but has no manifest, it posts a friendly sticky PR comment (in pt-br). It **never fails and never blocks the merge** — it is a reminder only.

Part of the RI rollout — nudge (never block) teams that still lack a permission manifest. Refs lmap **#3942** and **ADR 0002** (plugin-access-manager).

**Affected workflow:** `go-pr-validation.yml` (umbrella). New standalone job `permission-manifest-nudge` gated by a new `run_manifest_nudge` input (default `true`), backed by a new composite action `src/validate/permission-manifest-nudge`.

### How it works
1. **Scope gate** — only acts when `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. No `go.mod` / no direct lib-auth → skipped silently (success, no comment).
2. **Manifest presence** — globs `**/permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and only counts files with top-level `service:` **and** `permissions:` keys (light check to avoid false positives).
3. **Idempotent comment** — single find-by-marker (`<!-- permission-manifest-nudge -->`) sticky comment, so re-runs update the same comment instead of spamming per push. Links the RI guide, mentions the `ring:declaring-plugin-permissions` skill and `make validate-permissions`. When a manifest is present it flips any prior nudge to a positive state (never creates a new comment on compliant repos).

Reuses the repo's **existing** commenter mechanism (`actions/github-script` find-by-marker sticky comment, exactly as `src/validate/lerian-lib-version` and the coverage job do) — no new commenter invented.

### ⚠️ Decision to confirm — the scope gate
The scope is intentionally narrow: **direct `lib-auth` dependency in `go.mod`**. This is called out explicitly so it can be tuned — the `grep` in the composite is documented as a reviewer knob (e.g. drop the `// indirect` exclusion, or key off `lib-commons` / a marker file / a repo topic instead). @brecci to confirm or adjust the scoping.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow

## Breaking Changes

None. Additive only — the new input defaults to `true` and existing jobs are untouched. Because it is `continue-on-error` with no `*-gate` aggregator, it adds **no** required status check.

## Non-blocking guarantees

- Job runs with `continue-on-error: true`.
- The composite is best-effort: every step exits 0 (internal/API errors degrade to `::warning`).
- It is a **standalone** job (no `needs`) with **no** result-gate aggregator, so it is **not** a required check and must **not** be added to branch protection.

## Testing

- [x] YAML syntax validated locally (`python3 -c "yaml.safe_load(...)"`)
- [x] `actionlint` clean on `go-pr-validation.yml`
- [x] `shellcheck` clean on the composite's bash
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (additive-only diff)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Note:** the TS / `js-pr-validation.yml` equivalent is intentionally **deferred to a follow-up** — this PR covers Go plugins only.

## Related Issues

Refs lmap #3942, ADR 0002 (plugin-access-manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
