### PR TITLE
feat(helm): route maintenance-branch releases to legacy chart lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,14 @@ on:
         description: 'JSON mapping of component names to values.yaml keys. If not mapped, uses component name as fallback. Example: {"my-app": "api", "my-app-worker": "worker"}'
         type: string
         default: ''
+      helm_legacy_patch_detection:
+        description: 'Flag releases cut from maintenance branches as legacy patches, so the Helm side updates the matching legacy chart line instead of the mainline chart'
+        type: boolean
+        default: true
+      helm_legacy_branch_patterns:
+        description: 'Glob patterns (newline or comma separated) of branches that hold maintenance/patch lines. Example: maintenance/*'
+        type: string
+        default: 'maintenance/*'
       # Path normalization
       normalize_to_filter:
         description: 'Normalize changed paths to their filter path (e.g., components/app/cmd -> components/app). Recommended for monorepos to avoid duplicate builds.'
@@ -700,6 +708,8 @@ jobs:
       env_file: ${{ inputs.helm_env_file }}
       detect_env_changes: ${{ inputs.helm_detect_env_changes }}
       values_key_mappings: ${{ inputs.helm_values_key_mappings }}
+      legacy_patch_detection: ${{ inputs.helm_legacy_patch_detection }}
+      legacy_branch_patterns: ${{ inputs.helm_legacy_branch_patterns }}
       runner_type: ${{ inputs.runner_type }}
     secrets:
       helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}

--- a/.github/workflows/dispatch-helm.yml
+++ b/.github/workflows/dispatch-helm.yml
@@ -99,7 +99,7 @@ on:
         default: 'blacksmith-4vcpu-ubuntu-2404'
     secrets:
       helm_repo_token:
-        description: 'GitHub token with access to Helm repository (needs repo scope)'
+        description: 'Token scoped to the Helm repository with Actions: read and write permission (enough to trigger workflow_dispatch). A classic token with repo scope also works but is broader than needed.'
         required: true
 
 jobs:
@@ -351,21 +351,35 @@ jobs:
 
       # ----------------- Dispatch -----------------
       - name: Dispatch to Helm repository
+        env:
+          CHART: ${{ inputs.chart }}
+          HAS_NEW_ENV_VARS: ${{ steps.process.outputs.has_new_env_vars }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref_name }}
+          SOURCE_ACTOR: ${{ github.actor }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          IS_LEGACY_PATCH: ${{ steps.source.outputs.is_legacy_patch }}
+          VERSION_LINE: ${{ steps.source.outputs.version_line }}
+          HELM_REPOSITORY: ${{ inputs.helm_repository }}
+          WORKFLOW_FILE: ${{ inputs.workflow_file }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          HELM_REPO_TOKEN: ${{ secrets.helm_repo_token }}
         run: |
           COMPONENTS=$(cat /tmp/components_payload.json)
 
           # Build the full payload
           PAYLOAD=$(jq -n \
-            --arg chart "${{ inputs.chart }}" \
+            --arg chart "${CHART}" \
             --argjson components "$COMPONENTS" \
-            --arg has_new_env_vars "${{ steps.process.outputs.has_new_env_vars }}" \
-            --arg source_repo "${{ github.repository }}" \
-            --arg source_sha "${{ github.sha }}" \
-            --arg source_ref "${{ github.ref_name }}" \
-            --arg source_actor "${{ github.actor }}" \
-            --arg source_branch "${{ steps.source.outputs.source_branch }}" \
-            --arg is_legacy_patch "${{ steps.source.outputs.is_legacy_patch }}" \
-            --arg version_line "${{ steps.source.outputs.version_line }}" \
+            --arg has_new_env_vars "${HAS_NEW_ENV_VARS}" \
+            --arg source_repo "${SOURCE_REPO}" \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg source_ref "${SOURCE_REF}" \
+            --arg source_actor "${SOURCE_ACTOR}" \
+            --arg source_branch "${SOURCE_BRANCH}" \
+            --arg is_legacy_patch "${IS_LEGACY_PATCH}" \
+            --arg version_line "${VERSION_LINE}" \
             '{
               chart: $chart,
               components: $components,
@@ -386,11 +400,16 @@ jobs:
           PAYLOAD_STRING=$(echo "$PAYLOAD" | jq -c .)
 
           # Send workflow_dispatch (allows targeting specific branch)
+          REQUEST_BODY=$(jq -n \
+            --arg ref "${TARGET_REF}" \
+            --arg payload "${PAYLOAD_STRING}" \
+            '{ref: $ref, inputs: {payload: $payload}}')
+
           HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-            -H "Authorization: token ${{ secrets.helm_repo_token }}" \
+            -H "Authorization: token ${HELM_REPO_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ inputs.helm_repository }}/actions/workflows/${{ inputs.workflow_file }}/dispatches" \
-            -d "{\"ref\":\"${{ inputs.target_ref }}\",\"inputs\":{\"payload\":$(echo "$PAYLOAD_STRING" | jq -R .)}}")
+            "https://api.github.com/repos/${HELM_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/dispatches" \
+            -d "${REQUEST_BODY}")
 
           HTTP_BODY=$(echo "$HTTP_RESPONSE" | sed '$d')
           HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)

--- a/.github/workflows/dispatch-helm.yml
+++ b/.github/workflows/dispatch-helm.yml
@@ -13,7 +13,7 @@ name: "Dispatch to Helm Repository"
 #       }
 #   ...
 #   dispatch-helm:
-#     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@main
+#     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@v1.54.0
 #     with:
 #       helm_repository: org/helm-repo
 #       chart: my-app
@@ -26,7 +26,7 @@ name: "Dispatch to Helm Repository"
 #
 # Usage (advanced - with full components_json):
 #   dispatch-helm:
-#     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@main
+#     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@v1.54.0
 #     with:
 #       helm_repository: org/helm-repo
 #       chart: my-app
@@ -85,6 +85,14 @@ on:
         description: 'JSON mapping of component names to values.yaml keys. If not mapped, uses component name as fallback.'
         type: string
         default: ''
+      legacy_patch_detection:
+        description: 'Detect releases cut from maintenance branches and flag them in the payload as legacy patches, so the Helm side routes them to the matching legacy chart line instead of the mainline chart.'
+        type: boolean
+        default: true
+      legacy_branch_patterns:
+        description: 'Glob patterns (newline or comma separated) of branches that hold maintenance/patch lines.'
+        type: string
+        default: 'maintenance/*'
       runner_type:
         description: 'GitHub runner type to use'
         type: string
@@ -99,11 +107,70 @@ jobs:
     name: Prepare and Dispatch
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
+      # ----------------- Source Detection -----------------
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-depth: 0
 
+      - name: Detect source branch
+        id: source
+        env:
+          DETECT: ${{ inputs.legacy_patch_detection }}
+          PATTERNS: ${{ inputs.legacy_branch_patterns }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          RAW_VERSION="${VERSION#v}"
+          VERSION_LINE=$(printf '%s' "$RAW_VERSION" | sed -nE 's/^([0-9]+\.[0-9]+)\..*/\1/p')
+
+          SOURCE_BRANCH=""
+          IS_LEGACY="false"
+
+          if [ "$DETECT" != "true" ]; then
+            echo "Legacy patch detection disabled"
+          elif [ -z "$VERSION_LINE" ]; then
+            echo "::warning::Could not derive an X.Y version line from '${VERSION}' — skipping legacy patch detection"
+          else
+            CONTAINING=$(git for-each-ref --contains HEAD --format='%(refname:strip=3)' refs/remotes/origin/ 2>/dev/null || true)
+            echo "Branches containing HEAD:"
+            printf '%s\n' "$CONTAINING" | sed 's/^/  /'
+
+            PATTERN_LIST=$(printf '%s' "$PATTERNS" | tr ',' '\n')
+
+            while IFS= read -r branch; do
+              [ -z "$branch" ] && continue
+              [ "$branch" = "HEAD" ] && continue
+              while IFS= read -r pattern; do
+                pattern=$(printf '%s' "$pattern" | tr -d '[:space:]')
+                [ -z "$pattern" ] && continue
+                # shellcheck disable=SC2254 # pattern is intentionally a glob
+                case "$branch" in
+                  $pattern)
+                    if [ -z "$SOURCE_BRANCH" ]; then
+                      SOURCE_BRANCH="$branch"
+                      IS_LEGACY="true"
+                    else
+                      echo "::warning::Multiple maintenance branches contain this release — using '${SOURCE_BRANCH}', ignoring '${branch}'"
+                    fi
+                    ;;
+                esac
+              done <<< "$PATTERN_LIST"
+            done <<< "$CONTAINING"
+          fi
+
+          if [ "$IS_LEGACY" = "true" ]; then
+            echo "::notice::Legacy patch detected — source branch '${SOURCE_BRANCH}', version line ${VERSION_LINE}"
+          fi
+
+          {
+            echo "source_branch=${SOURCE_BRANCH}"
+            echo "is_legacy_patch=${IS_LEGACY}"
+            echo "version_line=${VERSION_LINE}"
+          } >> "$GITHUB_OUTPUT"
+
+      # ----------------- Payload Preparation -----------------
       - name: Process all components
         id: process
         run: |
@@ -282,6 +349,7 @@ jobs:
           # Save to file to avoid escaping issues
           echo "$PROCESSED_COMPONENTS" > /tmp/components_payload.json
 
+      # ----------------- Dispatch -----------------
       - name: Dispatch to Helm repository
         run: |
           COMPONENTS=$(cat /tmp/components_payload.json)
@@ -295,6 +363,9 @@ jobs:
             --arg source_sha "${{ github.sha }}" \
             --arg source_ref "${{ github.ref_name }}" \
             --arg source_actor "${{ github.actor }}" \
+            --arg source_branch "${{ steps.source.outputs.source_branch }}" \
+            --arg is_legacy_patch "${{ steps.source.outputs.is_legacy_patch }}" \
+            --arg version_line "${{ steps.source.outputs.version_line }}" \
             '{
               chart: $chart,
               components: $components,
@@ -302,7 +373,10 @@ jobs:
               source_repo: $source_repo,
               source_sha: $source_sha,
               source_ref: $source_ref,
-              source_actor: $source_actor
+              source_actor: $source_actor,
+              source_branch: $source_branch,
+              is_legacy_patch: ($is_legacy_patch == "true"),
+              version_line: $version_line
             }')
 
           echo "Dispatching payload:"
@@ -335,6 +409,9 @@ jobs:
         env:
           HELM_REPOSITORY: ${{ inputs.helm_repository }}
           CHART: ${{ inputs.chart }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          IS_LEGACY: ${{ steps.source.outputs.is_legacy_patch }}
+          VERSION_LINE: ${{ steps.source.outputs.version_line }}
         run: |
           COMPONENTS=$(cat /tmp/components_payload.json)
 
@@ -343,6 +420,11 @@ jobs:
             echo ""
             echo "**Repository:** \`${HELM_REPOSITORY}\`"
             echo "**Chart:** \`${CHART}\`"
+
+            if [ "${IS_LEGACY}" = "true" ]; then
+              echo "**Legacy patch:** yes — line \`${VERSION_LINE}.x\` from \`${SOURCE_BRANCH}\`"
+            fi
+
             echo ""
             echo "**Components:**"
             echo ""

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -135,6 +135,14 @@ on:
         description: 'JSON mapping of component names to values.yaml keys (e.g., {"my-app": "api"})'
         type: string
         default: ''
+      helm_legacy_patch_detection:
+        description: 'Flag releases cut from maintenance branches as legacy patches, so the Helm side updates the matching legacy chart line instead of the mainline chart. Set to false to keep the previous payload shape.'
+        type: boolean
+        default: true
+      helm_legacy_branch_patterns:
+        description: 'Glob patterns (newline or comma separated) of branches that hold maintenance/patch lines. Example: maintenance/*'
+        type: string
+        default: 'maintenance/*'
       extra_builds:
         description: 'JSON array of additional build groups, each forwarded to build.yml with its own config (filter_paths, path_level, normalize_to_filter, app_name_overrides, build_context_from_working_dir, helm_*, tag_prefix, enable_dockerhub, enable_ghcr, enable_gitops_artifacts, force_full_matrix). Runs alongside the primary build on tag push; groups with enable_gitops_artifacts enabled (the default) feed the single gitops-update. A group with tag_prefix set only builds when the triggering tag starts with that prefix (e.g. a component with its own independent semver and tag scheme); omit tag_prefix to build on every tag push, as before. enable_dockerhub/enable_ghcr default to the top-level inputs of the same name when omitted (explicit true/false on the group always wins, including false) — use to publish a group to only one registry regardless of the primary build''s registries. enable_gitops_artifacts defaults to true when omitted. force_full_matrix (default false) skips change detection for this group entirely and always builds/publishes it in lockstep with the release version — use when a downstream consumer (e.g. a Helm chart defaulting every subcomponent to one shared version tag) expects this component''s image to exist at every release, not only releases that touched its own filter_paths. Empty = one build only (default).'
         type: string
@@ -458,6 +466,8 @@ jobs:
       helm_chart: ${{ inputs.helm_chart }}
       helm_detect_env_changes: ${{ inputs.helm_detect_env_changes }}
       helm_values_key_mappings: ${{ inputs.helm_values_key_mappings }}
+      helm_legacy_patch_detection: ${{ inputs.helm_legacy_patch_detection }}
+      helm_legacy_branch_patterns: ${{ inputs.helm_legacy_branch_patterns }}
       shared_paths: ${{ inputs.shared_paths }}
       filter_paths: ${{ inputs.filter_paths }}
       force_full_matrix: ${{ inputs.force_full_matrix }}
@@ -668,6 +678,8 @@ jobs:
       helm_chart: ${{ matrix.group.helm_chart }}
       helm_detect_env_changes: ${{ matrix.group.helm_detect_env_changes || true }}
       helm_values_key_mappings: ${{ matrix.group.helm_values_key_mappings }}
+      helm_legacy_patch_detection: ${{ toJSON(matrix.group.helm_legacy_patch_detection) == 'null' && inputs.helm_legacy_patch_detection || toJSON(matrix.group.helm_legacy_patch_detection) == 'true' }}
+      helm_legacy_branch_patterns: ${{ matrix.group.helm_legacy_branch_patterns || inputs.helm_legacy_branch_patterns }}
     secrets: inherit
 
   # ----------------- GitOps Update (tag push) -----------------

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -128,7 +128,7 @@ on:
         type: string
         default: ''
       helm_repository:
-        description: 'Helm repository to dispatch to (org/repo format)'
+        description: 'Helm repository to dispatch to (org/repo format). The HELM_REPO_TOKEN secret must grant Actions: read and write on it. Applies to every build, including extra_builds groups — there is no per-group override, because a single token is forwarded to all of them.'
         type: string
         default: 'LerianStudio/helm'
       helm_detect_env_changes:
@@ -681,10 +681,10 @@ jobs:
       docker_build_args: ${{ matrix.group.docker_build_args }}
       enable_helm_dispatch: ${{ matrix.group.enable_helm_dispatch || false }}
       helm_chart: ${{ matrix.group.helm_chart }}
-      helm_repository: ${{ matrix.group.helm_repository || inputs.helm_repository }}
+      helm_repository: ${{ inputs.helm_repository }}
       helm_detect_env_changes: ${{ matrix.group.helm_detect_env_changes || true }}
       helm_values_key_mappings: ${{ matrix.group.helm_values_key_mappings }}
-      helm_legacy_patch_detection: ${{ toJSON(matrix.group.helm_legacy_patch_detection) == 'null' && inputs.helm_legacy_patch_detection || toJSON(matrix.group.helm_legacy_patch_detection) == 'true' }}
+      helm_legacy_patch_detection: ${{ toJSON(matrix.group.helm_legacy_patch_detection) == 'true' || (toJSON(matrix.group.helm_legacy_patch_detection) != 'false' && inputs.helm_legacy_patch_detection) }}
       helm_legacy_branch_patterns: ${{ matrix.group.helm_legacy_branch_patterns || inputs.helm_legacy_branch_patterns }}
     secrets: inherit
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -127,6 +127,10 @@ on:
         description: 'Helm chart name to update (required when enable_helm_dispatch is true)'
         type: string
         default: ''
+      helm_repository:
+        description: 'Helm repository to dispatch to (org/repo format)'
+        type: string
+        default: 'LerianStudio/helm'
       helm_detect_env_changes:
         description: 'Detect new environment variables for Helm during dispatch'
         type: boolean
@@ -464,6 +468,7 @@ jobs:
       enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
       enable_helm_dispatch: ${{ inputs.enable_helm_dispatch }}
       helm_chart: ${{ inputs.helm_chart }}
+      helm_repository: ${{ inputs.helm_repository }}
       helm_detect_env_changes: ${{ inputs.helm_detect_env_changes }}
       helm_values_key_mappings: ${{ inputs.helm_values_key_mappings }}
       helm_legacy_patch_detection: ${{ inputs.helm_legacy_patch_detection }}
@@ -676,6 +681,7 @@ jobs:
       docker_build_args: ${{ matrix.group.docker_build_args }}
       enable_helm_dispatch: ${{ matrix.group.enable_helm_dispatch || false }}
       helm_chart: ${{ matrix.group.helm_chart }}
+      helm_repository: ${{ matrix.group.helm_repository || inputs.helm_repository }}
       helm_detect_env_changes: ${{ matrix.group.helm_detect_env_changes || true }}
       helm_values_key_mappings: ${{ matrix.group.helm_values_key_mappings }}
       helm_legacy_patch_detection: ${{ toJSON(matrix.group.helm_legacy_patch_detection) == 'null' && inputs.helm_legacy_patch_detection || toJSON(matrix.group.helm_legacy_patch_detection) == 'true' }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -682,7 +682,7 @@ jobs:
       enable_helm_dispatch: ${{ matrix.group.enable_helm_dispatch || false }}
       helm_chart: ${{ matrix.group.helm_chart }}
       helm_repository: ${{ inputs.helm_repository }}
-      helm_detect_env_changes: ${{ matrix.group.helm_detect_env_changes || true }}
+      helm_detect_env_changes: ${{ toJSON(matrix.group.helm_detect_env_changes) == 'true' || (toJSON(matrix.group.helm_detect_env_changes) != 'false' && inputs.helm_detect_env_changes) }}
       helm_values_key_mappings: ${{ matrix.group.helm_values_key_mappings }}
       helm_legacy_patch_detection: ${{ toJSON(matrix.group.helm_legacy_patch_detection) == 'true' || (toJSON(matrix.group.helm_legacy_patch_detection) != 'false' && inputs.helm_legacy_patch_detection) }}
       helm_legacy_branch_patterns: ${{ matrix.group.helm_legacy_branch_patterns || inputs.helm_legacy_branch_patterns }}

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -8,7 +8,7 @@ name: "Update Helm Chart"
 # Usage:
 #   jobs:
 #     update:
-#       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@main
+#       uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@v1.54.0
 #       with:
 #         payload: ${{ inputs.payload }}
 #         base_branch: develop
@@ -22,7 +22,7 @@ on:
         type: string
         required: true
       base_branch:
-        description: 'Target branch for the PR. Allowed: main, develop, master, staging (default: main)'
+        description: 'Target branch for the PR. Allowed: main, develop, master, staging (default: main). Legacy patches are routed to a derived chart line branch instead — see legacy_patch_enabled.'
         type: string
         default: 'main'
       scripts_path:
@@ -37,6 +37,22 @@ on:
         description: 'Whether to update README matrix (default: true)'
         type: boolean
         default: true
+      legacy_patch_enabled:
+        description: 'Honor is_legacy_patch in the payload and route the update to the matching legacy chart line branch instead of base_branch'
+        type: boolean
+        default: true
+      legacy_branch_prefix:
+        description: 'Branch prefix for legacy chart line patches (e.g. hotfix produces hotfix/<chart>-5.7.x)'
+        type: string
+        default: 'hotfix'
+      legacy_branch_source:
+        description: 'Branch a legacy chart line branch is created from when it does not exist yet'
+        type: string
+        default: 'main'
+      legacy_update_readme:
+        description: 'Update the README compatibility matrix on legacy patches. Off by default because the root README tracks the mainline.'
+        type: boolean
+        default: false
       runner_type:
         description: 'GitHub runner type to use'
         type: string
@@ -148,6 +164,9 @@ jobs:
           SOURCE_REPO=$(jq -r '.source_repo // "unknown"' /tmp/payload.json)
           SOURCE_ACTOR=$(jq -r '.source_actor // "unknown"' /tmp/payload.json)
           SOURCE_SHA=$(jq -r '.source_sha // "unknown"' /tmp/payload.json)
+          SOURCE_BRANCH=$(jq -r '.source_branch // ""' /tmp/payload.json)
+          IS_LEGACY_PATCH=$(jq -r '.is_legacy_patch // false' /tmp/payload.json)
+          VERSION_LINE=$(jq -r '.version_line // ""' /tmp/payload.json)
 
           # Generate branch name
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
@@ -160,6 +179,9 @@ jobs:
             echo "source_repo=${SOURCE_REPO}"
             echo "source_actor=${SOURCE_ACTOR}"
             echo "source_sha=${SOURCE_SHA}"
+            echo "source_branch=${SOURCE_BRANCH}"
+            echo "is_legacy_patch=${IS_LEGACY_PATCH}"
+            echo "version_line=${VERSION_LINE}"
             echo "branch_name=${BRANCH_NAME}"
           } >> "$GITHUB_OUTPUT"
 
@@ -171,13 +193,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-
-      - name: Switch to base branch
-        env:
-          BASE_BRANCH: ${{ inputs.base_branch }}
-        run: |
-          git fetch --no-tags origin "${BASE_BRANCH}"
-          git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
 
       - name: Import GPG key
         if: ${{ inputs.gpg_sign_commits }}
@@ -200,6 +215,135 @@ jobs:
           git config user.name "${GIT_USER_NAME}"
           git config user.email "${GIT_USER_EMAIL}"
 
+      # ----------------- Base Branch Resolution -----------------
+      - name: Resolve target base branch
+        id: base
+        env:
+          LEGACY_ENABLED: ${{ inputs.legacy_patch_enabled }}
+          LEGACY_PREFIX: ${{ inputs.legacy_branch_prefix }}
+          LEGACY_SOURCE: ${{ inputs.legacy_branch_source }}
+          LEGACY_UPDATE_README: ${{ inputs.legacy_update_readme }}
+          UPDATE_README: ${{ inputs.update_readme }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          CHARTS_PATH: ${{ inputs.charts_path }}
+          CHART: ${{ steps.payload.outputs.chart }}
+          IS_LEGACY_PATCH: ${{ steps.payload.outputs.is_legacy_patch }}
+          VERSION_LINE: ${{ steps.payload.outputs.version_line }}
+          SOURCE_BRANCH: ${{ steps.payload.outputs.source_branch }}
+        run: |
+          set -euo pipefail
+
+          finish() {
+            local base="$1" legacy="$2" tag="${3:-}"
+            local readme="false"
+            if [ "${UPDATE_README}" = "true" ]; then
+              if [ "${legacy}" != "true" ] || [ "${LEGACY_UPDATE_README}" = "true" ]; then
+                readme="true"
+              fi
+            fi
+            {
+              echo "resolved_base=${base}"
+              echo "is_legacy=${legacy}"
+              echo "chart_tag=${tag}"
+              echo "update_readme=${readme}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Resolved base branch: ${base} (legacy=${legacy}, chart_tag=${tag:-none}, update_readme=${readme})"
+          }
+
+          # Read a top-level scalar from a Chart.yaml reachable in git (avoids yq before setup)
+          chart_field() {
+            git show "$1" 2>/dev/null | sed -nE "s/^$2:[[:space:]]*\"?([^\"[:space:]]+)\"?.*/\1/p" | head -1
+          }
+
+          version_line_of() {
+            printf '%s' "$1" | sed -nE 's/^([0-9]+\.[0-9]+)\..*/\1/p'
+          }
+
+          if [ "${LEGACY_ENABLED}" != "true" ] || [ "${IS_LEGACY_PATCH}" != "true" ]; then
+            finish "${BASE_BRANCH}" "false"
+            exit 0
+          fi
+
+          if ! printf '%s' "${VERSION_LINE}" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "::error::Payload is flagged as a legacy patch but version_line='${VERSION_LINE}' is not an X.Y line"
+            exit 1
+          fi
+
+          echo "Legacy patch from '${SOURCE_BRANCH}' — resolving the chart line for app line ${VERSION_LINE}.x"
+
+          # Find the highest stable chart tag whose appVersion belongs to the app version line
+          CHART_TAG=""
+          CHART_VERSION=""
+          while IFS= read -r tag; do
+            [ -z "${tag}" ] && continue
+            APP_VERSION=$(chart_field "${tag}:${CHARTS_PATH}/${CHART}/Chart.yaml" appVersion)
+            [ -z "${APP_VERSION}" ] && continue
+            case "${APP_VERSION}" in
+              "${VERSION_LINE}."*) ;;
+              *) continue ;;
+            esac
+            CANDIDATE="${tag#"${CHART}-v"}"
+            if [ -z "${CHART_VERSION}" ] || \
+               [ "$(printf '%s\n%s\n' "${CHART_VERSION}" "${CANDIDATE}" | sort -V | tail -1)" = "${CANDIDATE}" ]; then
+              CHART_VERSION="${CANDIDATE}"
+              CHART_TAG="${tag}"
+            fi
+          done < <(git tag --list "${CHART}-v*" | grep -E "^${CHART}-v[0-9]+\.[0-9]+\.[0-9]+$" || true)
+
+          if [ -z "${CHART_TAG}" ]; then
+            echo "::error::No stable '${CHART}' chart tag has an appVersion in the ${VERSION_LINE} line. Refusing to apply a legacy patch to the mainline chart."
+            exit 1
+          fi
+
+          CHART_LINE=$(version_line_of "${CHART_VERSION}")
+          echo "Resolved chart line ${CHART_LINE}.x from tag ${CHART_TAG} (appVersion line ${VERSION_LINE})"
+
+          git fetch --no-tags origin "${BASE_BRANCH}" "${LEGACY_SOURCE}"
+
+          MAINLINE_VERSION=$(chart_field "origin/${BASE_BRANCH}:${CHARTS_PATH}/${CHART}/Chart.yaml" version)
+          MAINLINE_LINE=$(version_line_of "${MAINLINE_VERSION}")
+
+          if [ -n "${MAINLINE_LINE}" ] && [ "${CHART_LINE}" = "${MAINLINE_LINE}" ]; then
+            echo "::warning::Resolved chart line ${CHART_LINE}.x is the mainline chart line on '${BASE_BRANCH}' — treating this as a regular update"
+            finish "${BASE_BRANCH}" "false"
+            exit 0
+          fi
+
+          LEGACY_BRANCH="${LEGACY_PREFIX}/${CHART}-${CHART_LINE}.x"
+
+          if ! printf '%s' "${LEGACY_BRANCH}" | grep -qE '^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*-[0-9]+\.[0-9]+\.x$'; then
+            echo "::error::Derived legacy branch '${LEGACY_BRANCH}' does not match the expected pattern <prefix>/<chart>-<major>.<minor>.x"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --heads origin "${LEGACY_BRANCH}" >/dev/null 2>&1; then
+            echo "::notice::Reusing existing legacy branch ${LEGACY_BRANCH}"
+            finish "${LEGACY_BRANCH}" "true" "${CHART_TAG}"
+            exit 0
+          fi
+
+          echo "::notice::Creating ${LEGACY_BRANCH} from origin/${LEGACY_SOURCE} with ${CHARTS_PATH}/${CHART} restored from ${CHART_TAG}"
+          git checkout -B "${LEGACY_BRANCH}" "origin/${LEGACY_SOURCE}"
+          rm -rf "${CHARTS_PATH:?}/${CHART:?}"
+          git checkout "${CHART_TAG}" -- "${CHARTS_PATH}/${CHART}"
+          git add -A "${CHARTS_PATH}/${CHART}"
+
+          if git diff --staged --quiet; then
+            echo "Chart tree on ${LEGACY_SOURCE} already matches ${CHART_TAG}"
+          else
+            git commit -m "chore(${CHART}): seed ${CHART_LINE}.x maintenance line from ${CHART_TAG}"
+          fi
+
+          git push -u origin "${LEGACY_BRANCH}"
+          finish "${LEGACY_BRANCH}" "true" "${CHART_TAG}"
+
+      - name: Switch to base branch
+        env:
+          BASE_BRANCH: ${{ steps.base.outputs.resolved_base }}
+        run: |
+          git fetch --no-tags origin "${BASE_BRANCH}"
+          git checkout -B "${BASE_BRANCH}" "origin/${BASE_BRANCH}"
+
       - name: Create feature branch
         env:
           BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
@@ -207,14 +351,14 @@ jobs:
           git checkout -b "${BRANCH_NAME}"
 
       - name: Setup Go
-        if: ${{ inputs.update_readme }}
+        if: steps.base.outputs.update_readme == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
         with:
           go-version: '1.21'
           cache-dependency-path: ${{ inputs.scripts_path }}/go.mod
 
       - name: Build scripts
-        if: ${{ inputs.update_readme }}
+        if: steps.base.outputs.update_readme == 'true'
         env:
           SCRIPTS_PATH: ${{ inputs.scripts_path }}
         run: |
@@ -387,7 +531,7 @@ jobs:
           echo "updated_components=${UPDATED_COMPONENTS}" >> "$GITHUB_OUTPUT"
 
       - name: Update README matrix
-        if: ${{ inputs.update_readme }}
+        if: steps.base.outputs.update_readme == 'true'
         env:
           CHART: ${{ steps.payload.outputs.chart }}
           CHARTS_PATH: ${{ inputs.charts_path }}
@@ -418,6 +562,7 @@ jobs:
           CHART: ${{ steps.payload.outputs.chart }}
           UPDATED_COMPONENTS: ${{ steps.process.outputs.updated_components }}
           HAS_NEW_ENV_VARS: ${{ steps.payload.outputs.has_new_env_vars }}
+          IS_LEGACY: ${{ steps.base.outputs.is_legacy }}
         run: |
 
           git add -A
@@ -434,7 +579,9 @@ jobs:
           # Determine commit message based on env_vars
           # feat: when new environment variables are added (requires attention)
           # fix: when it's just a version bump (routine update)
-          if [ "${HAS_NEW_ENV_VARS}" = "true" ]; then
+          # A legacy patch is always fix: a minor bump would fall outside the
+          # maintenance range of the chart line branch and break its release.
+          if [ "${HAS_NEW_ENV_VARS}" = "true" ] && [ "${IS_LEGACY}" != "true" ]; then
             COMMIT_MSG="feat(${CHART}): update ${UPDATED_COMPONENTS} - new env vars"
           else
             COMMIT_MSG="fix(${CHART}): update ${UPDATED_COMPONENTS}"
@@ -451,10 +598,14 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART: ${{ steps.payload.outputs.chart }}
           BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
-          BASE_BRANCH: ${{ inputs.base_branch }}
+          BASE_BRANCH: ${{ steps.base.outputs.resolved_base }}
           HAS_NEW_ENV_VARS: ${{ steps.payload.outputs.has_new_env_vars }}
           UPDATED_COMPONENTS: ${{ steps.process.outputs.updated_components }}
           SOURCE_REF: ${{ steps.payload.outputs.source_ref }}
+          SOURCE_BRANCH: ${{ steps.payload.outputs.source_branch }}
+          VERSION_LINE: ${{ steps.payload.outputs.version_line }}
+          IS_LEGACY: ${{ steps.base.outputs.is_legacy }}
+          CHART_TAG: ${{ steps.base.outputs.chart_tag }}
         run: |
 
           # Push the branch
@@ -465,11 +616,21 @@ jobs:
 
           # Determine PR title prefix
           if [ "${HAS_NEW_ENV_VARS}" = "true" ]; then
-            PR_TITLE="feat(${CHART}): update ${UPDATED_COMPONENTS}"
             ATTENTION_NOTE="> ⚠️ **Attention:** This PR includes new environment variables that may require configuration."
           else
-            PR_TITLE="fix(${CHART}): update ${UPDATED_COMPONENTS}"
             ATTENTION_NOTE=""
+          fi
+
+          if [ "${HAS_NEW_ENV_VARS}" = "true" ] && [ "${IS_LEGACY}" != "true" ]; then
+            PR_TITLE="feat(${CHART}): update ${UPDATED_COMPONENTS}"
+          else
+            PR_TITLE="fix(${CHART}): update ${UPDATED_COMPONENTS}"
+          fi
+
+          LEGACY_NOTE=""
+          if [ "${IS_LEGACY}" = "true" ]; then
+            PR_TITLE="fix(${CHART}): update ${UPDATED_COMPONENTS} [legacy ${VERSION_LINE}.x]"
+            LEGACY_NOTE="> 🧬 **Legacy patch** — released from \`${SOURCE_BRANCH}\` for the \`${VERSION_LINE}.x\` app line. Base branch \`${BASE_BRANCH}\` carries the chart line seeded from \`${CHART_TAG}\`. Do **not** merge this into the mainline chart."
           fi
 
           # Build components table
@@ -485,6 +646,10 @@ jobs:
             echo ""
             echo "Automated update of Helm chart components."
             echo ""
+            if [ -n "${LEGACY_NOTE}" ]; then
+              echo "${LEGACY_NOTE}"
+              echo ""
+            fi
             if [ -n "${ATTENTION_NOTE}" ]; then
               echo "${ATTENTION_NOTE}"
               echo ""
@@ -545,10 +710,13 @@ jobs:
 
       - name: Summary
         env:
-          BASE_BRANCH: ${{ inputs.base_branch }}
+          BASE_BRANCH: ${{ steps.base.outputs.resolved_base }}
           CHART: ${{ steps.payload.outputs.chart }}
           BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
           HAS_CHANGES: ${{ steps.commit.outputs.has_changes }}
+          IS_LEGACY: ${{ steps.base.outputs.is_legacy }}
+          CHART_TAG: ${{ steps.base.outputs.chart_tag }}
+          VERSION_LINE: ${{ steps.payload.outputs.version_line }}
         run: |
           COMPONENTS=$(cat /tmp/components.json)
 
@@ -558,6 +726,11 @@ jobs:
             echo "**Chart:** \`${CHART}\`"
             echo "**Branch:** \`${BRANCH_NAME}\`"
             echo "**Base:** \`${BASE_BRANCH}\`"
+
+            if [ "${IS_LEGACY}" = "true" ]; then
+              echo "**Legacy patch:** app line \`${VERSION_LINE}.x\`, chart line seeded from \`${CHART_TAG}\`"
+            fi
+
             echo ""
 
             if [ "${HAS_CHANGES}" = "true" ]; then
@@ -587,11 +760,13 @@ jobs:
           PR_URL: ${{ steps.push-pr.outputs.pr_url }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW_NUM: ${{ github.run_number }}
-          BASE_BRANCH: ${{ inputs.base_branch }}
+          BASE_BRANCH: ${{ steps.base.outputs.resolved_base }}
           MENTION_GROUP: ${{ inputs.slack_mention_group || secrets.SLACK_GROUP_DEVOPS_SRE }}
           SLACK_CHANNEL: ${{ inputs.slack_channel || secrets.SLACK_CHANNEL_DEVOPS }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_HELM }}
           BOT_MENTION: ${{ inputs.slack_bot_mention || secrets.SLACK_BOT_SEVERINO }}
+          IS_LEGACY: ${{ steps.base.outputs.is_legacy }}
+          VERSION_LINE: ${{ steps.payload.outputs.version_line }}
         run: |
           COMPONENTS=$(cat /tmp/components.json)
 
@@ -603,6 +778,12 @@ jobs:
             TYPE_EMOJI=":sparkles:"
           else
             TYPE_EMOJI=":rocket:"
+          fi
+
+          if [ "${IS_LEGACY}" = "true" ]; then
+            HEADER_TEXT="${TYPE_EMOJI} Helm Chart Update — legacy ${VERSION_LINE}.x"
+          else
+            HEADER_TEXT="${TYPE_EMOJI} Helm Chart Update"
           fi
 
           # Build metadata
@@ -626,7 +807,7 @@ jobs:
           # Build complete payload using jq
           SLACK_PAYLOAD=$(jq -n \
             --arg channel "${SLACK_CHANNEL}" \
-            --arg header "${TYPE_EMOJI} Helm Chart Update" \
+            --arg header "${HEADER_TEXT}" \
             --arg chart "${CHART}" \
             --arg version "${APP_VERSION}" \
             --arg repo "${SOURCE_REPO}" \

--- a/.github/workflows/helm-update-chart.yml
+++ b/.github/workflows/helm-update-chart.yml
@@ -117,19 +117,24 @@ jobs:
     name: Update Chart
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     steps:
-      - name: Validate base_branch
+      - name: Validate branch inputs
         env:
           BASE_BRANCH: ${{ inputs.base_branch }}
+          LEGACY_SOURCE: ${{ inputs.legacy_branch_source }}
         run: |
-          case "${BASE_BRANCH}" in
-            main|develop|master|staging)
-              echo "✅ base_branch '${BASE_BRANCH}' is allowed"
-              ;;
-            *)
-              echo "::error::Invalid base_branch '${BASE_BRANCH}'. Allowed: main, develop, master, staging"
-              exit 1
-              ;;
-          esac
+          for pair in "base_branch:${BASE_BRANCH}" "legacy_branch_source:${LEGACY_SOURCE}"; do
+            name="${pair%%:*}"
+            value="${pair#*:}"
+            case "${value}" in
+              main|develop|master|staging)
+                echo "✅ ${name} '${value}' is allowed"
+                ;;
+              *)
+                echo "::error::Invalid ${name} '${value}'. Allowed: main, develop, master, staging"
+                exit 1
+                ;;
+            esac
+          done
 
       - name: Generate GitHub App Token
         id: app-token
@@ -250,9 +255,15 @@ jobs:
             echo "Resolved base branch: ${base} (legacy=${legacy}, chart_tag=${tag:-none}, update_readme=${readme})"
           }
 
-          # Read a top-level scalar from a Chart.yaml reachable in git (avoids yq before setup)
+          # Read a top-level scalar from a Chart.yaml reachable in git (avoids yq before setup).
+          # A missing ref or path must yield an empty value, not abort the step: git show
+          # exits 128 and pipefail would propagate it through the assignment. sed quits on
+          # the first match instead of piping into head, which also removes a SIGPIPE path.
           chart_field() {
-            git show "$1" 2>/dev/null | sed -nE "s/^$2:[[:space:]]*\"?([^\"[:space:]]+)\"?.*/\1/p" | head -1
+            local content
+            content=$(git show "$1" 2>/dev/null) || return 0
+            printf '%s\n' "${content}" \
+              | sed -nE "/^$2:/{s/^$2:[[:space:]]*\"?([^\"[:space:]]+)\"?.*/\1/p;q;}"
           }
 
           version_line_of() {

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -141,6 +141,14 @@ on:
         description: 'JSON mapping of component names to values.yaml keys'
         type: string
         default: ''
+      helm_legacy_patch_detection:
+        description: 'Flag releases cut from maintenance branches as legacy patches, so the Helm side updates the matching legacy chart line instead of the mainline chart. Set to false to keep the previous payload shape.'
+        type: boolean
+        default: true
+      helm_legacy_branch_patterns:
+        description: 'Glob patterns (newline or comma separated) of branches that hold maintenance/patch lines. Example: maintenance/*'
+        type: string
+        default: 'maintenance/*'
       enable_cosign_sign:
         description: 'Sign container images with cosign keyless (OIDC) signing after push. Requires id-token: write permission in the caller.'
         type: boolean
@@ -406,6 +414,8 @@ jobs:
       env_file: ${{ inputs.helm_env_file }}
       detect_env_changes: ${{ inputs.helm_detect_env_changes }}
       values_key_mappings: ${{ inputs.helm_values_key_mappings }}
+      legacy_patch_detection: ${{ inputs.helm_legacy_patch_detection }}
+      legacy_branch_patterns: ${{ inputs.helm_legacy_branch_patterns }}
       runner_type: ${{ inputs.runner_type }}
     secrets:
       helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}

--- a/docs/dispatch-helm.md
+++ b/docs/dispatch-helm.md
@@ -67,6 +67,21 @@ The workflow runs on a tag push, so `github.ref` is the tag and the originating 
 
 When nothing matches, `is_legacy_patch` is `false` and the payload is functionally identical to the pre-feature one.
 
+### Opting out
+
+Detection is on by default at every layer, because the alternative — a maintenance release rewriting the mainline chart — is the bug this exists to prevent. Each orchestrator that reaches this workflow exposes the same pair of inputs, so a caller opts out at whichever layer it already talks to:
+
+| Caller uses | Inputs |
+|---|---|
+| `go-release.yml` | `helm_legacy_patch_detection`, `helm_legacy_branch_patterns` |
+| `build.yml` | `helm_legacy_patch_detection`, `helm_legacy_branch_patterns` |
+| `js-release.yml` → `typescript-build.yml` | `helm_legacy_patch_detection`, `helm_legacy_branch_patterns` |
+| `dispatch-helm.yml` directly | `legacy_patch_detection`, `legacy_branch_patterns` |
+
+In `go-release.yml`, an `extra_builds` group may override both per group. An explicit value on the group — `true` or `false` — wins over the top-level input; omitting the key inherits it.
+
+The chart repository has an independent switch: `legacy_patch_enabled` on [helm-update-chart](helm-update-chart.md) makes it ignore the flag and send every payload to `base_branch`.
+
 ## Usage
 
 Recommended — path mapping:

--- a/docs/dispatch-helm.md
+++ b/docs/dispatch-helm.md
@@ -69,7 +69,7 @@ When nothing matches, `is_legacy_patch` is `false` and the payload is functional
 
 ### Opting out
 
-Detection is on by default at every layer, because the alternative — a maintenance release rewriting the mainline chart — is the bug this exists to prevent. Each orchestrator that reaches this workflow exposes the same pair of inputs, so a caller opts out at whichever layer it already talks to:
+Detection is on by default at every layer, because the alternative — a maintenance release rewriting the mainline chart — is the bug this exists to prevent. Each orchestrator that reaches this workflow exposes equivalent detection settings, but the input names are layer-specific. Use the names listed for your entry point:
 
 | Caller uses | Inputs |
 |---|---|

--- a/docs/dispatch-helm.md
+++ b/docs/dispatch-helm.md
@@ -1,0 +1,140 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>dispatch-helm</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that sends a **single** `workflow_dispatch` to a Helm chart repository carrying every component of a release, so the chart is updated in one commit instead of one per component.
+
+It also classifies the release: when the tag being dispatched was cut from a maintenance branch, the payload is flagged as a **legacy patch** so the Helm side updates the matching legacy chart line instead of overwriting the mainline chart. See [helm-update-chart](helm-update-chart.md) for the receiving end.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `helm_repository` | Helm repository to dispatch to (`org/repo`) | yes | — |
+| `chart` | Helm chart name (must match the chart directory) | yes | — |
+| `version` | Version applied to all components. A leading `v` is stripped. | yes | — |
+| `target_ref` | Ref of the Helm repository the dispatched workflow runs on | no | `main` |
+| `workflow_file` | Workflow file to trigger in the Helm repository | no | `app-sync.yml` |
+| `paths_matrix` | Raw paths matrix from the changed-paths action. Use with `path_mapping`. | no | — |
+| `path_mapping` | JSON mapping of paths to app names | no | — |
+| `components_json` | JSON array of components — alternative to `paths_matrix` | no | — |
+| `components_base_path` | Base path for components in the source repository | no | `components` |
+| `env_file` | Env example file relative to the component path | no | `.env.example` |
+| `detect_env_changes` | Detect environment variables added since the previous release | no | `true` |
+| `values_key_mappings` | JSON mapping of component names to `values.yaml` keys | no | `''` |
+| `legacy_patch_detection` | Flag releases cut from maintenance branches as legacy patches | no | `true` |
+| `legacy_branch_patterns` | Glob patterns (newline or comma separated) of maintenance branches | no | `maintenance/*` |
+| `runner_type` | GitHub runner type | no | `blacksmith-4vcpu-ubuntu-2404` |
+
+## Secrets
+
+| Secret | Description | Required |
+|---|---|---|
+| `helm_repo_token` | Token with `repo` scope on the Helm repository | yes |
+
+## Payload
+
+```json
+{
+  "chart": "my-app",
+  "components": [
+    { "name": "my-app-api", "values_key": "api", "version": "1.4.2", "env_vars": {} }
+  ],
+  "has_new_env_vars": false,
+  "source_repo": "org/my-app",
+  "source_sha": "0d1f2a3…",
+  "source_ref": "v1.4.2",
+  "source_actor": "someone",
+  "source_branch": "maintenance/v1.4.x",
+  "is_legacy_patch": true,
+  "version_line": "1.4"
+}
+```
+
+`source_branch`, `is_legacy_patch` and `version_line` are additive — receivers that ignore them behave exactly as before.
+
+## Legacy patch detection
+
+The workflow runs on a tag push, so `github.ref` is the tag and the originating branch is not available from the event. Detection is topological instead:
+
+1. The checkout uses `fetch-depth: 0`, so every remote branch is present.
+2. `git for-each-ref --contains HEAD refs/remotes/origin/` lists the branches that contain the tagged commit.
+3. Each branch is matched against `legacy_branch_patterns`. The first match wins, and additional matches are reported as warnings.
+4. `version_line` is the `X.Y` prefix of `version` — `v1.4.2` becomes `1.4`.
+
+When nothing matches, `is_legacy_patch` is `false` and the payload is functionally identical to the pre-feature one.
+
+## Usage
+
+Recommended — path mapping:
+
+```yaml
+env:
+  PATH_MAPPING: |
+    {
+      "src": {"name": "my-api", "context": "."},
+      "console": {"name": "my-console", "context": "console"}
+    }
+
+jobs:
+  dispatch-helm:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@v1.54.0
+    with:
+      helm_repository: LerianStudio/helm
+      chart: my-app
+      target_ref: main
+      version: ${{ github.ref_name }}
+      paths_matrix: ${{ needs.detect.outputs.matrix }}
+      path_mapping: ${{ env.PATH_MAPPING }}
+    secrets:
+      helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}
+```
+
+Advanced — explicit components:
+
+```yaml
+jobs:
+  dispatch-helm:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@v1.54.0
+    with:
+      helm_repository: LerianStudio/helm
+      chart: my-app
+      version: ${{ github.ref_name }}
+      components_json: '[{"name":"backend","version":"1.0.0"},{"name":"frontend","version":"1.0.0"}]'
+    secrets:
+      helm_repo_token: ${{ secrets.HELM_REPO_TOKEN }}
+```
+
+Most callers reach this workflow through [`build.yml`](../.github/workflows/build.yml) rather than directly:
+
+```yaml
+jobs:
+  build:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/build.yml@v1.54.0
+    with:
+      enable_helm_dispatch: true
+      helm_chart: my-app
+      helm_values_key_mappings: '{"my-app-api": "api"}'
+      # defaults shown for reference
+      helm_legacy_patch_detection: true
+      helm_legacy_branch_patterns: 'maintenance/*'
+    secrets: inherit
+```
+
+Testing against a branch:
+
+```yaml
+uses: LerianStudio/github-actions-shared-workflows/.github/workflows/dispatch-helm.yml@develop
+```
+
+## Required permissions
+
+The dispatch itself is authenticated by `helm_repo_token`, so the calling job needs no elevated permission:
+
+```yaml
+permissions:
+  contents: read
+```

--- a/docs/dispatch-helm.md
+++ b/docs/dispatch-helm.md
@@ -33,7 +33,7 @@ It also classifies the release: when the tag being dispatched was cut from a mai
 
 | Secret | Description | Required |
 |---|---|---|
-| `helm_repo_token` | Token with `repo` scope on the Helm repository | yes |
+| `helm_repo_token` | Token scoped to the Helm repository with `Actions: read and write`. That is the only permission the dispatch needs — a classic token with full `repo` scope also works but grants far more than required. | yes |
 
 ## Payload
 

--- a/docs/helm-update-chart.md
+++ b/docs/helm-update-chart.md
@@ -7,7 +7,7 @@
 
 Reusable workflow that consumes the dispatch payload produced by [dispatch-helm](dispatch-helm.md) and opens a PR on the Helm chart repository with the new component versions.
 
-For every component it updates `values.yaml` (`<values_key>.image.tag`), sets `Chart.yaml` `appVersion` to the highest component version, appends newly detected environment variables to the component `configmap.yaml` or `secret.yaml`, and optionally refreshes the README compatibility matrix. It never pushes to the target branch — the result is always a PR.
+For every component it updates `values.yaml` (`<values_key>.image.tag`), sets `Chart.yaml` `appVersion` to the highest component version, appends newly detected environment variables to the component `configmap.yaml` or `secret.yaml`, and optionally refreshes the README compatibility matrix. It does not push chart updates directly to the base branch — the result is always a PR. The one write outside a PR is seeding a new legacy chart line branch (see below).
 
 When the payload is flagged as a legacy patch, the PR is routed to a **chart line branch** instead of the mainline branch.
 

--- a/docs/helm-update-chart.md
+++ b/docs/helm-update-chart.md
@@ -1,0 +1,130 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>helm-update-chart</h1></td>
+  </tr>
+</table>
+
+Reusable workflow that consumes the dispatch payload produced by [dispatch-helm](dispatch-helm.md) and opens a PR on the Helm chart repository with the new component versions.
+
+For every component it updates `values.yaml` (`<values_key>.image.tag`), sets `Chart.yaml` `appVersion` to the highest component version, appends newly detected environment variables to the component `configmap.yaml` or `secret.yaml`, and optionally refreshes the README compatibility matrix. It never pushes to the target branch — the result is always a PR.
+
+When the payload is flagged as a legacy patch, the PR is routed to a **chart line branch** instead of the mainline branch.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `payload` | JSON payload with chart, components, and metadata | yes | — |
+| `base_branch` | Target branch for the PR. Allowed: `main`, `develop`, `master`, `staging`. Legacy patches are routed to a derived chart line branch instead. | no | `main` |
+| `scripts_path` | Path to the scripts directory | no | `.github/scripts` |
+| `charts_path` | Path to the charts directory | no | `charts` |
+| `update_readme` | Update the README compatibility matrix | no | `true` |
+| `legacy_patch_enabled` | Honor `is_legacy_patch` and route to the matching chart line branch | no | `true` |
+| `legacy_branch_prefix` | Branch prefix for chart line patches | no | `hotfix` |
+| `legacy_branch_source` | Branch a chart line branch is created from when it does not exist yet | no | `main` |
+| `legacy_update_readme` | Update the README matrix on legacy patches | no | `false` |
+| `runner_type` | GitHub runner type | no | `blacksmith-4vcpu-ubuntu-2404` |
+| `gpg_sign_commits` | Sign commits with GPG | no | `true` |
+| `slack_notification` | Send a Slack notification | no | `false` |
+| `slack_channel` | Slack channel ID | no | — |
+| `slack_mention_group` | Slack user group to mention. Falls back to `SLACK_GROUP_DEVOPS_SRE`. | no | — |
+| `slack_bot_mention` | Slack bot user ID for ticket creation. Falls back to `SLACK_BOT_SEVERINO`. | no | — |
+
+## Secrets
+
+| Secret | Description | Required |
+|---|---|---|
+| `APP_ID` | GitHub App client ID used to mint the push token | yes |
+| `APP_PRIVATE_KEY` | GitHub App private key | yes |
+| `GIT_USER_NAME` | Git committer name | yes |
+| `GIT_USER_EMAIL` | Git committer email | yes |
+| `GPG_KEY` | GPG private key for signing | no |
+| `GPG_KEY_PASSWORD` | GPG key passphrase | no |
+| `SLACK_BOT_TOKEN_HELM` | Slack bot token | no |
+| `SLACK_CHANNEL_DEVOPS` | Fallback Slack channel | no |
+| `SLACK_GROUP_DEVOPS_SRE` | Fallback mention group | no |
+| `SLACK_BOT_SEVERINO` | Fallback bot mention | no |
+
+## Legacy patch routing
+
+A chart repository holds a single directory per chart, always at the mainline version. A patch released from an application maintenance branch belongs to an older chart line, so applying it to the mainline directory would downgrade `appVersion` and the image tags of the current chart.
+
+When the payload carries `is_legacy_patch: true` and `version_line: "<X.Y>"`, the workflow instead:
+
+1. Scans stable chart tags `<chart>-vX.Y.Z` and reads `appVersion` from `Chart.yaml` at each one.
+2. Picks the **highest** chart version whose `appVersion` belongs to the application version line.
+3. Compares that chart line with the mainline chart line on `base_branch`. If they are the same, the update is not actually legacy — it falls back to the normal flow with a warning.
+4. Derives the branch name `<legacy_branch_prefix>/<chart>-<chartMajor>.<chartMinor>.x` and validates it against a strict pattern.
+5. Reuses the branch if it already exists. Otherwise it creates the branch from `legacy_branch_source`, restores only `charts/<chart>` from the resolved chart tag, and pushes it. The branch therefore carries current CI and scripts with a legacy chart subtree.
+6. Opens the component update PR against that branch.
+
+Two guarantees matter here:
+
+- **Fails closed.** If no chart tag matches the application version line, the run fails with an error instead of falling back to the mainline branch.
+- **Always `fix:`.** A legacy patch commit is always `fix(<chart>): …` even when new environment variables were detected. A `feat:` would resolve to a minor bump, which falls outside the maintenance range of the chart line branch and breaks its release.
+
+Worked example for a chart whose application line `3.5.x` last shipped as chart `5.7.0`, while the mainline chart is `8.7.0`:
+
+```
+app tag v3.5.5 on maintenance/v3.5.x
+  → is_legacy_patch: true, version_line: "3.5"
+  → resolves midaz-v5.7.0   (appVersion 3.5.3)
+  → base branch hotfix/midaz-5.7.x   (created from main, charts/midaz from midaz-v5.7.0)
+  → PR: fix(midaz): update … [legacy 3.5.x]
+```
+
+The README compatibility matrix is skipped by default on legacy patches because the root README tracks the mainline. Set `legacy_update_readme: true` to opt in.
+
+> The chart line branch only becomes a chart release if the chart repository releases from it. Its own release workflow must trigger on the branch and configure a matching semantic-release maintenance range.
+
+## Usage
+
+As a reusable workflow in the chart repository, driven by the dispatch:
+
+```yaml
+name: Update Helm Chart from Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: 'JSON payload with chart, components, and metadata'
+        required: true
+        type: string
+
+jobs:
+  update:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@v1.54.0
+    with:
+      payload: ${{ inputs.payload }}
+      base_branch: develop
+      slack_notification: true
+    secrets: inherit
+```
+
+Testing against a branch:
+
+```yaml
+uses: LerianStudio/github-actions-shared-workflows/.github/workflows/helm-update-chart.yml@develop
+```
+
+Legacy routing disabled — every payload lands on `base_branch`:
+
+```yaml
+    with:
+      payload: ${{ inputs.payload }}
+      base_branch: develop
+      legacy_patch_enabled: false
+```
+
+## Required permissions
+
+All writes are authenticated by the GitHub App token, so the job itself needs only:
+
+```yaml
+permissions:
+  contents: read
+```
+
+The GitHub App must be able to write contents and open pull requests on the chart repository.

--- a/src/changelog/gptchangelog/README.md
+++ b/src/changelog/gptchangelog/README.md
@@ -5,7 +5,9 @@
   </tr>
 </table>
 
-Generates `CHANGELOG.md` files using GPT (via OpenRouter) and pushes a signed commit directly to the default branch. Backmerges into `develop` automatically; falls back to a PR only when a conflict prevents the direct push. Supports both single-app and monorepo layouts. Skips prerelease tags when `stable-releases-only` is enabled.
+Generates `CHANGELOG.md` files using GPT (via OpenRouter), pushes a signed commit directly to the release line's branch and writes the same notes onto the GitHub release. Backmerges into `develop` automatically; falls back to a PR only when a conflict prevents the direct push. Supports both single-app and monorepo layouts. Skips prerelease tags when `stable-releases-only` is enabled.
+
+A tag is eligible when its commit lives on the default branch **or** on a maintenance line (`maintenance/*`, `release/*`) — patch releases cut from an older minor never reach the default branch, and gating on the default branch alone published them with empty release notes. When the run is triggered by a branch rather than a tag, the tag is looked up with `git tag --merged HEAD`, so a maintenance line never picks up the newest tag of a higher line.
 
 Bot commits (any login ending in `[bot]` plus the entries in `bot-ignore-list`) and `[skip ci]` commits (semantic-release version bumps, changelog backmerges, etc.) are filtered out before the GPT prompt is built, ensuring the changelog only reflects meaningful human-authored changes.
 

--- a/src/changelog/gptchangelog/README.md
+++ b/src/changelog/gptchangelog/README.md
@@ -5,7 +5,7 @@
   </tr>
 </table>
 
-Generates `CHANGELOG.md` files using GPT (via OpenRouter), pushes a signed commit directly to the release line's branch and writes the same notes onto the GitHub release. Backmerges into `develop` automatically; falls back to a PR only when a conflict prevents the direct push. Supports both single-app and monorepo layouts. Skips prerelease tags when `stable-releases-only` is enabled.
+Generates `CHANGELOG.md` files using GPT (via OpenRouter), pushes a signed commit directly to the release line's branch and writes the same notes onto the GitHub release. The backmerge into `develop` belongs to the caller, not to this composite (see the `backmerge` job in `release.yml` and its `backmerge_mode`, which defaults to `direct-with-pr-fallback`). Supports both single-app and monorepo layouts. Skips prerelease tags when `stable-releases-only` is enabled.
 
 A tag is eligible when its commit lives on the default branch **or** on a maintenance line (`maintenance/*`, `release/*`) — patch releases cut from an older minor never reach the default branch, and gating on the default branch alone published them with empty release notes. When the run is triggered by a branch rather than a tag, the tag is looked up with `git tag --merged HEAD`, so a maintenance line never picks up the newest tag of a higher line.
 

--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -73,7 +73,7 @@ runs:
         fi
 
     # ----------------- Stability Gate -----------------
-    - name: Check if tag is stable release on main
+    - name: Check if tag is a stable release on a supported release line
       id: check-tag
       shell: bash
       env:
@@ -87,7 +87,9 @@ runs:
           echo "📌 Triggered by branch/workflow_run, finding latest stable tags..."
           git fetch --tags --force
 
-          LATEST_TAGS=$(git tag --sort=-creatordate | head -20 || true)
+          # --merged HEAD keeps the search on the release line that triggered the run: a
+          # maintenance branch must not pick up the newest tag of another (higher) line.
+          LATEST_TAGS=$(git tag --merged HEAD --sort=-creatordate | head -20 || true)
           echo "📌 Recent tags: $LATEST_TAGS"
 
           TAG_NAME=""
@@ -118,13 +120,28 @@ runs:
         DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')
         echo "📌 Default branch: $DEFAULT_BRANCH"
 
+        # A tag is releasable when its commit lives on the default branch OR on a maintenance
+        # line (maintenance/*, release/*). Patch releases cut from an older minor never reach
+        # the default branch, and gating on it alone published them with empty release notes.
+        RELEASE_LINE=""
         if git merge-base --is-ancestor "$TAG_COMMIT" "origin/$DEFAULT_BRANCH" 2>/dev/null; then
-          echo "✅ Tag commit is on $DEFAULT_BRANCH branch"
+          RELEASE_LINE="$DEFAULT_BRANCH"
         else
-          echo "❌ Tag commit is NOT on $DEFAULT_BRANCH branch - skipping changelog"
+          while IFS= read -r remote_branch; do
+            [ -z "$remote_branch" ] && continue
+            if git merge-base --is-ancestor "$TAG_COMMIT" "$remote_branch" 2>/dev/null; then
+              RELEASE_LINE="${remote_branch#origin/}"
+              break
+            fi
+          done < <(git branch --remotes --list 'origin/maintenance/*' 'origin/release/*' --format='%(refname:short)')
+        fi
+
+        if [ -z "$RELEASE_LINE" ]; then
+          echo "❌ Tag commit is on neither $DEFAULT_BRANCH nor a maintenance line (maintenance/*, release/*) - skipping changelog"
           echo "is_stable=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
+        echo "✅ Tag commit is on release line: $RELEASE_LINE"
 
         if [[ "$TAG_NAME" =~ -(beta|rc|alpha|dev|snapshot) ]]; then
           echo "is_stable=false" >> "$GITHUB_OUTPUT"
@@ -134,7 +151,7 @@ runs:
           fi
         else
           echo "is_stable=true" >> "$GITHUB_OUTPUT"
-          echo "✅ Stable release tag on $DEFAULT_BRANCH: $TAG_NAME"
+          echo "✅ Stable release tag on $RELEASE_LINE: $TAG_NAME"
         fi
 
     - name: Set changelog matrix
@@ -148,7 +165,7 @@ runs:
         if [ "$STABLE_RELEASES_ONLY" == "true" ] && [ "$IS_STABLE" != "true" ]; then
           echo "matrix=[]" >> "$GITHUB_OUTPUT"
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          echo "🛑 Skipping: prerelease tag with stable-releases-only=true"
+          echo "🛑 Skipping: no stable release tag for this ref with stable-releases-only=true (see the stability gate above for the reason)"
           exit 0
         fi
 

--- a/src/changelog/gptchangelog/action.yml
+++ b/src/changelog/gptchangelog/action.yml
@@ -142,6 +142,9 @@ runs:
           exit 0
         fi
         echo "✅ Tag commit is on release line: $RELEASE_LINE"
+        # Later steps need the line, not just the verdict: a tag-triggered maintenance run
+        # would otherwise commit the CHANGELOG to the default branch.
+        echo "release_line=$RELEASE_LINE" >> "$GITHUB_OUTPUT"
 
         if [[ "$TAG_NAME" =~ -(beta|rc|alpha|dev|snapshot) ]]; then
           echo "is_stable=false" >> "$GITHUB_OUTPUT"
@@ -189,7 +192,9 @@ runs:
             APP_NAME=$(basename "$path")
             # shellcheck disable=SC2001,SC2016
             APP_NAME_ESCAPED=$(echo "$APP_NAME" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')
-            LATEST_TAG=$(git tag --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
+            # --merged HEAD: same release-line scoping as the stability gate, so a
+            # maintenance run cannot select a mainline tag of a higher line.
+            LATEST_TAG=$(git tag --merged HEAD --sort=-creatordate | grep "^${APP_NAME_ESCAPED}-v" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
             if [ -n "$LATEST_TAG" ]; then
               echo "📦 Found stable tag for $APP_NAME: $LATEST_TAG"
@@ -260,7 +265,10 @@ runs:
             TAG_GREP_PATTERN="^v"
           fi
 
-          LAST_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
+          # --merged HEAD scopes both ends of the range to the release line being built.
+          # Unscoped, a maintenance run resolves the highest stable tag repo-wide (e.g.
+          # v1.11.0 while releasing v1.10.5) and would then overwrite THAT release's notes.
+          LAST_TAG=$(git tag --merged HEAD --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | head -1 || true)
 
           if [ -z "$LAST_TAG" ]; then
             echo "⚠️ No stable tag found for $APP_NAME - skipping"
@@ -274,7 +282,7 @@ runs:
             continue
           fi
 
-          PREV_TAG=$(git tag --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | sed -n '2p')
+          PREV_TAG=$(git tag --merged HEAD --sort=-version:refname | grep "$TAG_GREP_PATTERN" | grep -v -e "-beta" -e "-rc" -e "-alpha" -e "-dev" -e "-snapshot" | sed -n '2p')
 
           if [ -n "$PREV_TAG" ]; then
             SINCE="$PREV_TAG"
@@ -508,17 +516,24 @@ runs:
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
     # ----------------- Commit & Push -----------------
-    - name: Commit changelog to default branch
+    - name: Commit changelog to the release line
       if: steps.generate.outputs.apps_updated != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         APPS_UPDATED: ${{ steps.generate.outputs.apps_updated }}
+        RELEASE_LINE: ${{ steps.check-tag.outputs.release_line }}
       run: |
         # shellcheck disable=SC2193
         if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-          BASE_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')
-          echo "📌 Triggered by tag, pushing to default branch: $BASE_BRANCH"
+          # The stability gate resolved which line the tag belongs to. Honour it: a
+          # maintenance tag's CHANGELOG belongs on its own line, not on the default branch.
+          if [ -n "$RELEASE_LINE" ]; then
+            BASE_BRANCH="$RELEASE_LINE"
+          else
+            BASE_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')
+          fi
+          echo "📌 Triggered by tag, pushing to release line: $BASE_BRANCH"
         else
           BASE_BRANCH="$GITHUB_REF_NAME"
           echo "📌 Pushing CHANGELOGs directly to: $BASE_BRANCH"


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

A release cut from an application maintenance branch belongs to an older `X.Y` line. Today `dispatch-helm` carries only the tag name, so `helm-update-chart` applies the patch to the mainline chart directory — downgrading its `appVersion` and image tags. A chart currently at `8.7.0` / appVersion `3.8.0` would be rewritten to appVersion `3.5.5` by a patch released from a `3.5.x` maintenance branch.

Affected workflows:

**`dispatch-helm.yml`** — the run happens on a tag push, so the originating branch is not in `github.ref`. Detection is topological: the checkout already uses `fetch-depth: 0`, so `git for-each-ref --contains HEAD refs/remotes/origin/` lists the branches holding the tagged commit, matched against the new `legacy_branch_patterns` input (default `maintenance/*`). The payload gains three additive fields — `source_branch`, `is_legacy_patch` and `version_line` (the `X.Y` prefix of the version).

**`helm-update-chart.yml`** — when the payload is flagged, it scans stable `<chart>-vX.Y.Z` tags, reads `appVersion` from `Chart.yaml` at each one, and picks the highest chart version belonging to the application version line. It then derives `hotfix/<chart>-<major>.<minor>.x`, reuses the branch if it exists, or creates it from `main` (`legacy_branch_source`) with **only** `charts/<chart>` restored from the resolved chart tag — so the branch carries current CI and scripts with a legacy chart subtree. The component PR is opened against that branch.

Three behaviours worth calling out:

- **Fails closed.** No chart tag matching the app line is an error, never a silent fallback to the mainline branch.
- **Always `fix:`.** A legacy patch commit is `fix(<chart>): …` even when new env vars were detected — a `feat:` resolves to a minor bump, which falls outside the maintenance range of the chart line branch and breaks its release.
- **Mainline guard.** If the resolved chart line is the mainline chart line on `base_branch`, it warns and falls back to the normal flow. This covers the case where a maintenance commit was backmerged into the mainline.

**`build.yml`** — exposes `helm_legacy_patch_detection` and `helm_legacy_branch_patterns` and passes them down.

Also adds the missing `docs/dispatch-helm.md` and `docs/helm-update-chart.md`, and pins the `@main` refs in both workflows' usage comments.

The chart line branch only becomes a chart release once the chart repository releases from it — its release workflow must trigger on the branch and configure a matching semantic-release maintenance range. That is a companion change in `LerianStudio/helm`, not in this PR.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

No input or output is renamed, removed or type-changed, and no new secret is required. `LerianStudio/helm` keeps working on its current pin with no change. But calling this purely additive would be wrong, so stating the behaviour change precisely:

**For a caller with no branch matching `maintenance/*`** — the overwhelming majority — nothing changes. No branch matches, `is_legacy_patch` is `false`, and the payload plus the resulting PR are identical to before.

**For a caller that releases from a maintenance branch**, behaviour changes by design, and one path can turn a previously-green run red:

| Before | After |
|---|---|
| Patch overwrote the mainline chart directory, downgrading `appVersion` and image tags — a green run producing a wrong PR | PR routed to the matching chart line branch |
| — | If no chart tag has an `appVersion` in the app version line, the run **fails** instead of touching the mainline chart |

That last row is the deliberate fail-closed choice: a hard failure beats silently corrupting the mainline chart. It is the reason the defaults are opt-out rather than opt-in — a correctness fix should not require every caller to opt in to not corrupting their chart.

**Opting out**, at any layer:

```yaml
# caller of build.yml — no detection, payload shape unchanged
helm_legacy_patch_detection: false

# chart repository — honour nothing, every payload lands on base_branch
legacy_patch_enabled: false
```

The repository's own breaking-change guard ran on this PR and passed.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

`actionlint` (including its shellcheck pass) is clean on all three workflows.

The resolution logic was extracted and run against a full clone of `LerianStudio/helm`:

| Input | Result |
|---|---|
| `midaz`, app line `3.5` | resolves `midaz-v5.7.0` (appVersion 3.5.3) → base `hotfix/midaz-5.7.x` |
| `midaz`, app line `3.8` | chart line `8.7.x` is the mainline → warns, base falls back to `develop` |
| `midaz`, app line `2.9` | no matching chart tag → error, exit 1 |
| `midaz`, not flagged | base `develop`, unchanged path |
| `midaz`, `version_line: abc` | error, exit 1 |
| `plugin-br-pix-indirect-btg`, app line `1.7` | resolves `-v3.4.1` → `hotfix/plugin-br-pix-indirect-btg-3.4.x` |
| `fetcher`, app line `3.0` | resolves `fetcher-v3.1.0` → `hotfix/fetcher-3.1.x` |

The branch detection logic was exercised separately: maintenance-only, mainline-only, backmerged (contained in both), two matching maintenance branches (warns, first wins), comma-separated multi-pattern, non-semver tag (warns, no detection), and detection disabled.

**Caller repo / workflow run:** not yet — end-to-end validation runs from the chart repository side against `@develop` with a synthetic payload, so no application release is needed to exercise it.

## Related Issues

Closes #

