### PR TITLE
feat(go-pr-validation): forward build_context_from_working_dir to the security scan

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -208,6 +208,13 @@ on:
         description: 'Explicit path to a single Dockerfile to build and scan (e.g. components/ledger/Dockerfile). Lets monorepos without a root Dockerfile keep enable_docker_scan: true.'
         type: string
         default: ''
+      build_context_from_working_dir:
+        description: >-
+          Build each component image with its own working_dir as the Docker build context instead of the
+          repository root. Required for type1 monorepos whose components are independent modules: a component
+          Dockerfile starting with `COPY go.mod go.sum ./` cannot build from the repository root.
+        type: boolean
+        default: false
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -367,6 +374,7 @@ jobs:
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       filter_paths: ${{ inputs.filter_paths }}

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -68,6 +68,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `ignore_file` | Path to Trivy ignore file | string | `''` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a root Dockerfile (monorepos with Dockerfiles under `components/`/`cmd/`) | boolean | `true` |
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`); lets monorepos without a root Dockerfile keep `enable_docker_scan: true` | string | `''` |
+| `build_context_from_working_dir` | Build each component image with its own `working_dir` as the Docker build context instead of the repository root. Required for type1 monorepos whose components are independent modules — a component Dockerfile starting with `COPY go.mod go.sum ./` cannot build from the repository root | boolean | `false` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
 | `monorepo_type` | Monorepo layout for the security scan. `"type1"` = components in separate folders (default). `"type2"` = backend at repo root + one independent component in a sub-folder. | string | `'type1'` |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`pr-security-scan.yml` accepts `build_context_from_working_dir`, but `go-pr-validation.yml` does not forward it. Since the umbrella is how every Go repository consumes the scan, the input is effectively unreachable.

The consequence is that **type1 monorepos cannot run the Docker scan at all**. With `filter_paths` set, the scan resolves each component Dockerfile correctly but still builds it from the repository root, so a component that is an independent module fails on its first instruction — `COPY go.mod go.sum ./` finds nothing at the root.

The two workarounds available to callers today are both bad:

1. `enable_docker_scan: false` — loses image-layer scanning, health-score checks and Dockerfile checks entirely.
2. Bypass the umbrella and call `pr-security-scan.yml` directly — works, but splits the security pipeline out of the umbrella that is supposed to own it.

This PR adds the input to the umbrella and forwards it, so neither workaround is needed.

**Affected workflows**

| Workflow | Change |
| --- | --- |
| `.github/workflows/go-pr-validation.yml` | New input `build_context_from_working_dir`, forwarded to the `security` job |
| `docs/go-pr-validation.md` | Input documented in the security inputs table |

**Input changes**

| Input | Type | Default | Forwarded to |
| --- | --- | --- | --- |
| `build_context_from_working_dir` | boolean | `false` | `pr-security-scan.yml` |

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The input defaults to `false`, which is the current behaviour, and matches the default already used by `pr-security-scan.yml`. Callers that do not set it see no change.

## Testing

- [x] YAML syntax validated locally — parsed with PyYAML; input resolves as `type: boolean`, `default: false`, and the `security` job forwards `${{ inputs.build_context_from_working_dir }}`
- [x] `yamllint -c .yamllint.yml` clean for this change — the 6 remaining warnings are pre-existing (long lines at 26/142/150/186/235 and a comment-spacing warning at 447); the new block uses folded scalars to stay under the 200-column limit
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values — additive change, no existing forwarding touched
- [x] Confirmed no secrets or tokens are printed in logs — no secret handling in this change
- [x] Checked that unrelated workflows are not affected — `js-pr-validation.yml` has the same gap and is addressed in a separate PR

**Caller repo / workflow run:** not yet — this cannot be validated end-to-end until a beta tag exists on `develop`. The motivating caller is `LerianStudio/go-boilerplate-ddd-fullstack`, a type1 monorepo with `components/api` and `components/ui`, where the Docker scan is currently disabled for exactly this reason.

## Related Issues

Closes #
