### PR TITLE
feat(js-pr-validation): allow a path-scoped security scan without bypassing the umbrella

### DIFF
--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -136,11 +136,15 @@ on:
         required: false
         default: ''
       path_level:
-        description: 'Directory depth level to extract app name, passed through to frontend-pr-analysis.yml.'
+        description: >-
+          Directory depth level to extract app name. Passed through to BOTH frontend-pr-analysis.yml and
+          pr-security-scan.yml, which use it identically.
         type: number
         default: 2
       normalize_to_filter:
-        description: 'Collapse every changed file under a filter_paths entry into that one app, passed through to frontend-pr-analysis.yml. Default true — see that workflow for why.'
+        description: >-
+          Collapse every changed file under a filter_paths entry into that one app. Passed through to BOTH
+          frontend-pr-analysis.yml and pr-security-scan.yml. Default true — see frontend-pr-analysis.yml for why.
         type: boolean
         default: true
       app_name_prefix:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -119,12 +119,19 @@ on:
         type: boolean
         default: false
       filter_paths:
-        description: 'JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]), passed through to frontend-pr-analysis.yml. If empty, treats repo as single-app and runs against root directory. Not passed to the security scan (pr-security-scan.yml uses a different, newline-separated format for its own filter_paths) — call it directly for path-scoped security scans.'
+        description: >-
+          JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]), passed through to
+          frontend-pr-analysis.yml. If empty, treats repo as single-app and runs against root directory.
+          The security scan takes its paths from security_filter_paths instead, because pr-security-scan.yml
+          expects a newline-separated list rather than a JSON array.
         type: string
         required: false
         default: ''
       shared_paths:
-        description: 'Newline-separated list of path patterns that, when matched by any changed file, trigger analysis for ALL components in filter_paths, passed through to frontend-pr-analysis.yml. Not passed to the security scan — call it directly with its own shared_paths for path-scoped security scans.'
+        description: >-
+          Newline-separated list of path patterns that, when matched by any changed file, trigger analysis for
+          ALL components in filter_paths, passed through to frontend-pr-analysis.yml. The security scan takes
+          its own list from security_shared_paths.
         type: string
         required: false
         default: ''
@@ -270,6 +277,28 @@ on:
         description: 'Explicit path to a single Dockerfile to build and scan (e.g. Dockerfile). Leave empty to auto-discover.'
         type: string
         default: ''
+      security_filter_paths:
+        description: >-
+          Newline-separated component path prefixes for a path-scoped security scan (e.g. "components/ui").
+          Separate from filter_paths because pr-security-scan.yml expects newline-separated values while
+          frontend-pr-analysis.yml expects a JSON array. Empty = single-app root scan.
+        type: string
+        required: false
+        default: ''
+      security_shared_paths:
+        description: >-
+          Newline-separated path patterns that trigger the security scan for ALL components in
+          security_filter_paths (e.g. a shared contract directory). Empty = no shared triggers.
+        type: string
+        required: false
+        default: ''
+      build_context_from_working_dir:
+        description: >-
+          Build each component image with its own working_dir as the Docker build context instead of the
+          repository root. Required for monorepos whose components are independent packages: a component
+          Dockerfile starting with `COPY package.json pnpm-lock.yaml ./` cannot build from the repository root.
+        type: boolean
+        default: false
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -510,10 +539,15 @@ jobs:
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       prerelease_block_branches: ${{ inputs.prerelease_block_branches }}
       trivy_skip_dirs: ${{ inputs.trivy_skip_dirs }}
+      filter_paths: ${{ inputs.security_filter_paths }}
+      shared_paths: ${{ inputs.security_shared_paths }}
+      path_level: ${{ format('{0}', inputs.path_level) }}
+      normalize_to_filter: ${{ inputs.normalize_to_filter }}
     secrets: inherit
 
   security-gate:

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -42,8 +42,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
 | `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml`. The security scan uses `security_filter_paths` instead | string | `''` |
 | `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml`. The security scan uses `security_shared_paths` instead | string | `''` |
-| `path_level` | Directory depth level to extract app name, passed through to `frontend-pr-analysis.yml` only | number | `2` |
-| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app, passed through to `frontend-pr-analysis.yml` only | boolean | `true` |
+| `path_level` | Directory depth level to extract app name; passed through to **both** `frontend-pr-analysis.yml` and `pr-security-scan.yml` | number | `2` |
+| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app; passed through to **both** `frontend-pr-analysis.yml` and `pr-security-scan.yml` | boolean | `true` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
 | `enable_lint` | Enable ESLint | boolean | `true` |
 | `enable_typecheck` | Enable TypeScript type checking | boolean | `true` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -40,8 +40,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `audit_level` | npm audit severity level (`low`, `moderate`, `high`, `critical`) | string | `high` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
-| `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml` only | string | `''` |
-| `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml` only | string | `''` |
+| `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml`. The security scan uses `security_filter_paths` instead | string | `''` |
+| `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml`. The security scan uses `security_shared_paths` instead | string | `''` |
 | `path_level` | Directory depth level to extract app name, passed through to `frontend-pr-analysis.yml` only | number | `2` |
 | `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app, passed through to `frontend-pr-analysis.yml` only | boolean | `true` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
@@ -77,6 +77,9 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `prerelease_block_branches` | Target branches where pre-release versions are hard failures (comma-separated) | string | `release-candidate,main` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a Dockerfile (CLIs, libraries) | boolean | `true` |
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `Dockerfile`) | string | `''` |
+| `security_filter_paths` | Newline-separated component path prefixes for a path-scoped security scan (e.g. `components/ui`). Separate from `filter_paths` because the two callees use different formats. Empty = single-app root scan | string | `''` |
+| `security_shared_paths` | Newline-separated path patterns that trigger the security scan for ALL components in `security_filter_paths` | string | `''` |
+| `build_context_from_working_dir` | Build each component image with its own `working_dir` as the Docker build context instead of the repository root. Required for monorepos whose components are independent packages | boolean | `false` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated, e.g. `javascript-typescript`) | string | `''` |
 | `ignore_file` | Path to Trivy ignore file (e.g. `.trivyignore.yaml`) | string | `''` |
@@ -99,7 +102,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `socket_api_fail_on_actions` | Actions that block the PR — **introduced findings only**. Empty blocks nothing | string | `''` |
 | `socket_comment_when` | `findings` posts the comment only when there is something to act on; `always` posts every run | string | `findings` |
 
-> **Monorepo note:** `filter_paths`/`shared_paths`/`path_level`/`normalize_to_filter` scope the `frontend-analysis` job only. They are not passed to the `security` job because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input (JSON array vs. newline-separated). For a path-scoped security scan too, call `pr-security-scan.yml` directly.
+> **Monorepo note:** `filter_paths` scopes the `frontend-analysis` job; `security_filter_paths` scopes the `security` job. They are separate inputs because the two callees expect different formats — `frontend-pr-analysis.yml` takes a JSON array, `pr-security-scan.yml` takes a newline-separated list. `path_level` and `normalize_to_filter` are shared by both. Set `build_context_from_working_dir: true` when each component Dockerfile expects its own directory as build context.
 
 The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`js-pr-validation.yml` forwards no path scoping to `pr-security-scan.yml`, and its own input documentation tells callers to work around that:

> Not passed to the security scan (`pr-security-scan.yml` uses a different, newline-separated format for its own `filter_paths`) — **call it directly** for path-scoped security scans.

That instruction contradicts the point of an umbrella. A monorepo following it ends up with the security pipeline living outside the workflow that is supposed to orchestrate it, and then has to reconcile duplicate `Security` status checks by hand.

The obstacle was real but narrow: `filter_paths` cannot simply be forwarded, because the two callees disagree on format — `frontend-pr-analysis.yml` takes a JSON array, `pr-security-scan.yml` takes a newline-separated list. Converting between them inside a YAML expression is not something to inflict on this file, so this PR adds the newline-separated pair the scan expects as its own inputs and forwards the two inputs both callees already agree on.

`build_context_from_working_dir` is forwarded for the same reason as in [#663](https://github.com/LerianStudio/github-actions-shared-workflows/pull/663): a component Dockerfile starting with `COPY package.json pnpm-lock.yaml ./` cannot be built from the repository root, so without it a monorepo has to disable the Docker scan altogether.

**Affected workflows**

| Workflow | Change |
| --- | --- |
| `.github/workflows/js-pr-validation.yml` | Three new inputs, four values now forwarded to the `security` job |
| `docs/js-pr-validation.md` | Inputs documented; the "call it directly" monorepo note replaced |

**Input changes**

| Input | Type | Default | Forwarded to |
| --- | --- | --- | --- |
| `security_filter_paths` | string | `''` | `pr-security-scan.yml` as `filter_paths` |
| `security_shared_paths` | string | `''` | `pr-security-scan.yml` as `shared_paths` |
| `build_context_from_working_dir` | boolean | `false` | `pr-security-scan.yml` |

Existing `path_level` and `normalize_to_filter` are now forwarded to the security scan as well; they carry the same meaning in both callees.

**Usage**

```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-pr-validation.yml@vX.Y.Z
with:
  filter_paths: '["components/ui"]'        # frontend analysis — JSON array
  security_filter_paths: |                 # security scan — newline-separated
    components/ui
  security_shared_paths: |
    contracts/api/
  build_context_from_working_dir: true
```

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Every new input defaults to empty or `false`, preserving the current single-app root scan.

`path_level` and `normalize_to_filter` are newly forwarded, but with values that match the defaults `pr-security-scan.yml` already applies (`2` and `true`), so a caller that sets neither sees identical behaviour. A caller that *does* set them today only affects `frontend-pr-analysis`; after this PR the security scan honours them too — which is the consistent reading of those inputs, and is inert while `security_filter_paths` is empty.

## Testing

- [x] YAML syntax validated locally — parsed with PyYAML; the three inputs resolve with the expected types and defaults, and the `security` job forwards all four values
- [x] `yamllint -c .yamllint.yml` reports nothing new for this file
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values — additive; no existing forwarding was changed or removed
- [x] Confirmed no secrets or tokens are printed in logs — no secret handling in this change
- [x] Checked that unrelated workflows are not affected — `pr-security-scan.yml` is unchanged; `go-pr-validation.yml` is handled in #663

**Caller repo / workflow run:** not yet — needs a beta tag on `develop` first. The motivating caller is `LerianStudio/go-boilerplate-ddd-fullstack`, a monorepo with `components/api` and `components/ui` sharing a `contracts/api` directory.

## Related Issues

Closes #
