### PR TITLE
feat(pr-validation): let one umbrella own PR metadata in a multi-component repo

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -39,8 +39,11 @@ on:
           multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
           comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
-          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
-          workflow's breaking-change outputs are not produced.
+          must keep run_metadata true; setting it false everywhere disables the guard. The breaking-change
+          outputs of THIS workflow are still produced when false, but the metadata job supplies no values, so
+          they collapse to their fail-closed fallbacks: has_breaking_changes=false,
+          breaking_change_approved=false, breaking_change_result=failure. A caller that gates on
+          breaking_change_result must read it from the umbrella that still owns metadata.
         type: boolean
         default: true
       run_go_analysis:

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -33,6 +33,14 @@ on:
         default: false
 
       # ----------------- Pipeline toggles -----------------
+      run_metadata:
+        description: >-
+          Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
+          multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
+          metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
+          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+        type: boolean
+        default: true
       run_go_analysis:
         description: 'Run the Go analysis pipeline (lint, tests, coverage, build)'
         type: boolean
@@ -268,6 +276,7 @@ jobs:
   # ----------------- PR Metadata Validation -----------------
   metadata:
     name: PR Metadata
+    if: inputs.run_metadata
     uses: ./.github/workflows/pr-validation.yml
     with:
       runner_type: ${{ inputs.runner_type }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -38,7 +38,9 @@ on:
           Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
           multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
-          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+          comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
+          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
+          workflow's breaking-change outputs are not produced.
         type: boolean
         default: true
       run_go_analysis:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -29,6 +29,14 @@ on:
         default: false
 
       # ----------------- Pipeline toggles -----------------
+      run_metadata:
+        description: >-
+          Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
+          multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
+          metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
+          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+        type: boolean
+        default: true
       run_frontend_analysis:
         description: 'Run the frontend analysis pipeline (lint, typecheck, npm audit, tests, coverage, build)'
         type: boolean
@@ -400,6 +408,7 @@ jobs:
   # ----------------- PR Metadata Validation -----------------
   metadata:
     name: PR Metadata
+    if: inputs.run_metadata
     uses: ./.github/workflows/pr-validation.yml
     with:
       runner_type: ${{ inputs.runner_type }}

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -34,7 +34,9 @@ on:
           Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
           multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
-          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+          comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
+          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
+          workflow's breaking-change outputs are not produced.
         type: boolean
         default: true
       run_frontend_analysis:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -35,8 +35,11 @@ on:
           multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
           comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
-          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
-          workflow's breaking-change outputs are not produced.
+          must keep run_metadata true; setting it false everywhere disables the guard. The breaking-change
+          outputs of THIS workflow are still produced when false, but the metadata job supplies no values, so
+          they collapse to their fail-closed fallbacks: has_breaking_changes=false,
+          breaking_change_approved=false, breaking_change_result=failure. A caller that gates on
+          breaking_change_result must read it from the umbrella that still owns metadata.
         type: boolean
         default: true
       run_frontend_analysis:

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -32,6 +32,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `security_scan_runner_type` | Optional runner override for the security_scan jobs only | string | `''` |
 | `pr_checks_summary_runner_type` | Optional runner override for the PR Checks Summary job only | string | `''` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_metadata` | Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set `false` in a multi-component repository that also calls `js-pr-validation.yml`, so exactly one umbrella owns PR metadata | boolean | `true` |
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_lib_version_check` | Run the Lerian library version check | boolean | `true` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -79,6 +79,8 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
 
 > **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
+>
+> When `run_metadata` is `false`, this workflow's `has_breaking_changes`, `breaking_change_approved` and `breaking_change_result` outputs are still produced, but with no metadata job to supply values they collapse to their fail-closed fallbacks — `false`, `false` and `failure`. Read them from the umbrella that still owns metadata.
 
 ## Outputs
 

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -76,7 +76,9 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. `"tools/mock-sta-server"`). | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
 
-The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
+The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
+
+> **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
 
 ## Outputs
 
@@ -96,7 +98,7 @@ When a PR contains a breaking change, its description must contain this exact, c
 Breaking change acknowledged: I understand that this PR intentionally introduces a breaking change and requires the next release to be a major version.
 ```
 
-The guard is mandatory for every PR target branch. PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
+The guard is mandatory for every PR target branch whenever the metadata pipeline runs (see `run_metadata`). PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
 
 Caller triggers must include the five activity types in the usage example. `edited` is mandatory so removing or adding the acknowledgement reruns validation. `ready_for_review` is retained for complete validation transitions even though the guard enforces drafts.
 

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -105,6 +105,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
 
 > **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
+>
+> When `run_metadata` is `false`, this workflow's `has_breaking_changes`, `breaking_change_approved` and `breaking_change_result` outputs are still produced, but with no metadata job to supply values they collapse to their fail-closed fallbacks — `false`, `false` and `failure`. Read them from the umbrella that still owns metadata.
 
 ## Outputs
 

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -22,6 +22,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_metadata` | Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set `false` in a multi-component repository that also calls `go-pr-validation.yml`, so exactly one umbrella owns PR metadata | boolean | `true` |
 | `run_frontend_analysis` | Run the frontend analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_socket` | Run the Socket supply-chain pipeline | boolean | `true` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -8,7 +8,7 @@
 Umbrella reusable workflow for JavaScript/TypeScript repositories. A caller references this single workflow and it orchestrates everything a JS/TS PR needs:
 
 1. **PR metadata** — title, source branch, size, labels (delegates to `pr-validation.yml`).
-2. **Breaking Change Guard** — mandatory detection and enforcement inherited from `pr-validation.yml` for every PR target branch.
+2. **Breaking Change Guard** — mandatory detection and enforcement inherited from `pr-validation.yml` for every PR target branch, whenever the metadata pipeline runs (see `run_metadata`).
 3. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
 4. **Frontend analysis** — lint, typecheck, npm audit, tests, coverage and build (delegates to `frontend-pr-analysis.yml`), opt-in via `run_frontend_analysis`.
 5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
@@ -102,7 +102,9 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 
 > **Monorepo note:** `filter_paths`/`shared_paths`/`path_level`/`normalize_to_filter` scope the `frontend-analysis` job only. They are not passed to the `security` job because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input (JSON array vs. newline-separated). For a path-scoped security scan too, call `pr-security-scan.yml` directly.
 
-The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
+The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
+
+> **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
 
 ## Outputs
 


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

The umbrellas assume one stack per repository. A repository with a Go component **and** a JS component has to call both to validate both — and each runs its own PR metadata pipeline unconditionally.

The result on every PR:

- The PR title is validated twice against two (possibly different) scope lists.
- The labeler runs twice over the same changed files.
- Two sticky summary comments compete on the same pull request.

**Status-check names do not collide.** Reusable-workflow jobs are prefixed with the calling job id, so `validate / PR Metadata` and `ui / PR Metadata` are distinct check names — verified on a real run. The duplication is of *work* and of *PR comments*, which is why this is a toggle rather than a naming fix.

This PR adds `run_metadata` to both umbrellas. A multi-component caller sets it to `false` on all but one, and gets exactly one metadata pipeline:

```yaml
jobs:
  validate:                                     # owns PR metadata
    uses: .../go-pr-validation.yml@vX.Y.Z
    with:
      filter_paths: |
        components/api

  ui:
    uses: .../js-pr-validation.yml@vX.Y.Z
    with:
      run_metadata: false                       # <- metadata already covered above
      filter_paths: '["components/ui"]'
```

**Affected workflows**

| Workflow | Change |
| --- | --- |
| `.github/workflows/go-pr-validation.yml` | New input `run_metadata`; `if:` on the `metadata` job |
| `.github/workflows/js-pr-validation.yml` | New input `run_metadata`; `if:` on the `metadata` job |
| `docs/go-pr-validation.md`, `docs/js-pr-validation.md` | Input documented |

**Input changes**

| Input | Type | Default |
| --- | --- | --- |
| `run_metadata` | boolean | `true` |

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `run_metadata` defaults to `true`, so every existing caller keeps its current behaviour.

**One behaviour worth flagging for reviewers.** The workflow outputs `has_breaking_changes`, `breaking_change_approved` and `breaking_change_result` read `jobs.metadata.outputs.*`, which are empty when the job is skipped. The existing fallbacks then report `false`/`false`/`failure`. I left that as is — fail-closed is the right default for a breaking-change guard, and changing it would alter behaviour for existing callers — and documented it in the input description instead. A caller that consumes those outputs should read them from whichever umbrella still owns metadata.

If you would rather the outputs degrade to a neutral value when `run_metadata: false`, say so and I will adjust.

## Open question for reviewers — the Breaking Change Guard

Raised by CodeRabbit and worth a deliberate decision rather than a doc patch.

Both umbrellas documented the guard as having **"no input, enable flag, target-branch filter, or opt-out"** and being **"mandatory for every PR target branch"**. `run_metadata` contradicts that, because the guard lives inside the metadata pipeline: disabling the pipeline disables the guard.

The intended usage keeps this safe — one umbrella retains `run_metadata: true` and enforces the guard once for the repository. But **nothing mechanically enforces that**. A caller that sets the input `false` on every umbrella silently loses the guard, which was previously impossible.

`4ea6737` documents this in the input descriptions and both guard sections, so no one hits it unknowingly. If turning that invariant into a convention is not acceptable, the alternative is to **extract the Breaking Change Guard out of the metadata pipeline** so it always runs regardless of `run_metadata`. That is a larger change to `pr-validation.yml` and I did not want to make it unilaterally — please advise.

## Testing

- [x] YAML syntax validated locally — parsed with PyYAML; both umbrellas expose `run_metadata` as `type: boolean`, `default: true`, and both `metadata` jobs carry `if: inputs.run_metadata`
- [x] `yamllint -c .yamllint.yml` reports nothing new for either file
- [x] Verified no other job depends on `metadata` — `grep` for `needs:.*metadata` returns no consumers in either umbrella, so skipping it cannot strand a downstream job
- [x] Confirmed check-name prefixing on a real run, which is what rules out a naming collision as the alternative fix
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values — additive, default preserves current behaviour
- [x] Confirmed no secrets or tokens are printed in logs — no secret handling in this change

**Caller repo / workflow run:** not yet — needs a beta tag on `develop`. The motivating caller is `LerianStudio/go-boilerplate-ddd-fullstack`, which currently avoids the duplication by calling `frontend-pr-analysis.yml` instead of the JS umbrella — precisely the umbrella bypass this input removes the need for.

## Related Issues

Part of the same effort as #663 and #664, which close the input-forwarding gaps that also push multi-component repositories into bypassing the umbrellas.

Closes #
