### PR TITLE
chore(deployment-matrix): register go-boilerplate-ddd-fullstack for benedita

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -45,6 +45,10 @@ on:
         description: 'Run the Lerian library version check (fails when a direct Lerian lib is behind latest stable)'
         type: boolean
         default: true
+      run_manifest_nudge:
+        description: 'Run the NON-BLOCKING Access-Manager RI nudge: warns via a sticky PR comment when a lib-auth repo has no permissions.yaml manifest. Never fails or blocks the PR.'
+        type: boolean
+        default: true
 
       # ----------------- Change gate -----------------
       ignore_globs:
@@ -410,3 +414,37 @@ jobs:
         with:
           result: ${{ needs.changes.result != 'success' && needs.changes.result || needs.lib-version.result }}
           label: Lib Version
+
+  # ----------------- Permission Manifest Nudge (RI) — NON-BLOCKING -----------------
+  # Part of the Access-Manager "Inversão de Responsabilidade" (RI) rollout. Reminds
+  # a lib-auth plugin/service to declare its permissions in a permissions.yaml
+  # manifest by posting a sticky, idempotent PR comment.
+  #
+  # This job is INTENTIONALLY non-blocking:
+  #   * `continue-on-error: true` — a failure here never fails the umbrella run.
+  #   * There is NO `*-gate` aggregator for it, so it is not a stable/required
+  #     status check. Do NOT add it to branch protection.
+  #   * The underlying composite is best-effort and always exits 0.
+  # It is a standalone job (no `needs`) so it never affects the required gates above.
+  permission-manifest-nudge:
+    name: Permission Manifest Nudge
+    if: inputs.run_manifest_nudge && github.event_name == 'pull_request'
+    continue-on-error: true
+    runs-on: ${{ inputs.gate_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Nudge when no permissions.yaml manifest exists
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-nudge@v1
+        with:
+          # Direct job of the umbrella (not a nested reusable), so github.token is
+          # scoped to the caller repo and can post the comment; MANAGE_TOKEN is used
+          # when provided (parity with the coverage/lib-version commenters).
+          github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
+          go-mod-path: ${{ inputs.lib_version_go_mod_path }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -39,8 +39,11 @@ on:
           multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
           comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
-          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
-          workflow's breaking-change outputs are not produced.
+          must keep run_metadata true; setting it false everywhere disables the guard. The breaking-change
+          outputs of THIS workflow are still produced when false, but the metadata job supplies no values, so
+          they collapse to their fail-closed fallbacks: has_breaking_changes=false,
+          breaking_change_approved=false, breaking_change_result=failure. A caller that gates on
+          breaking_change_result must read it from the umbrella that still owns metadata.
         type: boolean
         default: true
       run_go_analysis:

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -33,6 +33,14 @@ on:
         default: false
 
       # ----------------- Pipeline toggles -----------------
+      run_metadata:
+        description: >-
+          Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
+          multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
+          metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
+          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+        type: boolean
+        default: true
       run_go_analysis:
         description: 'Run the Go analysis pipeline (lint, tests, coverage, build)'
         type: boolean
@@ -268,6 +276,7 @@ jobs:
   # ----------------- PR Metadata Validation -----------------
   metadata:
     name: PR Metadata
+    if: inputs.run_metadata
     uses: ./.github/workflows/pr-validation.yml
     with:
       runner_type: ${{ inputs.runner_type }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -448,3 +448,5 @@ jobs:
           # when provided (parity with the coverage/lib-version commenters).
           github-token: ${{ secrets.MANAGE_TOKEN || github.token }}
           go-mod-path: ${{ inputs.lib_version_go_mod_path }}
+          # Preview mode: no comment / no PR side effects when the umbrella runs dry.
+          dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -38,7 +38,9 @@ on:
           Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
           multi-component repository that also calls js-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
-          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+          comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
+          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
+          workflow's breaking-change outputs are not produced.
         type: boolean
         default: true
       run_go_analysis:

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -208,6 +208,13 @@ on:
         description: 'Explicit path to a single Dockerfile to build and scan (e.g. components/ledger/Dockerfile). Lets monorepos without a root Dockerfile keep enable_docker_scan: true.'
         type: string
         default: ''
+      build_context_from_working_dir:
+        description: >-
+          Build each component image with its own working_dir as the Docker build context instead of the
+          repository root. Required for type1 monorepos whose components are independent modules: a component
+          Dockerfile starting with `COPY go.mod go.sum ./` cannot build from the repository root.
+        type: boolean
+        default: false
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -367,6 +374,7 @@ jobs:
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       filter_paths: ${{ inputs.filter_paths }}

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -136,11 +136,15 @@ on:
         required: false
         default: ''
       path_level:
-        description: 'Directory depth level to extract app name, passed through to frontend-pr-analysis.yml.'
+        description: >-
+          Directory depth level to extract app name. Passed through to BOTH frontend-pr-analysis.yml and
+          pr-security-scan.yml, which use it identically.
         type: number
         default: 2
       normalize_to_filter:
-        description: 'Collapse every changed file under a filter_paths entry into that one app, passed through to frontend-pr-analysis.yml. Default true — see that workflow for why.'
+        description: >-
+          Collapse every changed file under a filter_paths entry into that one app. Passed through to BOTH
+          frontend-pr-analysis.yml and pr-security-scan.yml. Default true — see frontend-pr-analysis.yml for why.
         type: boolean
         default: true
       app_name_prefix:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -29,6 +29,14 @@ on:
         default: false
 
       # ----------------- Pipeline toggles -----------------
+      run_metadata:
+        description: >-
+          Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
+          multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
+          metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
+          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+        type: boolean
+        default: true
       run_frontend_analysis:
         description: 'Run the frontend analysis pipeline (lint, typecheck, npm audit, tests, coverage, build)'
         type: boolean
@@ -400,6 +408,7 @@ jobs:
   # ----------------- PR Metadata Validation -----------------
   metadata:
     name: PR Metadata
+    if: inputs.run_metadata
     uses: ./.github/workflows/pr-validation.yml
     with:
       runner_type: ${{ inputs.runner_type }}

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -34,7 +34,9 @@ on:
           Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set to false in a
           multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
-          comments are posted. When false, this workflow's breaking-change outputs are not produced.
+          comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
+          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
+          workflow's breaking-change outputs are not produced.
         type: boolean
         default: true
       run_frontend_analysis:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -35,8 +35,11 @@ on:
           multi-component repository that also calls go-pr-validation.yml, so exactly one umbrella owns PR
           metadata — otherwise the title is validated twice, the labeler runs twice and two sticky summary
           comments are posted. WARNING: this skips the Breaking Change Guard too. One umbrella in the repository
-          must keep run_metadata true; setting it false everywhere disables the guard. When false, this
-          workflow's breaking-change outputs are not produced.
+          must keep run_metadata true; setting it false everywhere disables the guard. The breaking-change
+          outputs of THIS workflow are still produced when false, but the metadata job supplies no values, so
+          they collapse to their fail-closed fallbacks: has_breaking_changes=false,
+          breaking_change_approved=false, breaking_change_result=failure. A caller that gates on
+          breaking_change_result must read it from the umbrella that still owns metadata.
         type: boolean
         default: true
       run_frontend_analysis:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -119,12 +119,19 @@ on:
         type: boolean
         default: false
       filter_paths:
-        description: 'JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]), passed through to frontend-pr-analysis.yml. If empty, treats repo as single-app and runs against root directory. Not passed to the security scan (pr-security-scan.yml uses a different, newline-separated format for its own filter_paths) — call it directly for path-scoped security scans.'
+        description: >-
+          JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]), passed through to
+          frontend-pr-analysis.yml. If empty, treats repo as single-app and runs against root directory.
+          The security scan takes its paths from security_filter_paths instead, because pr-security-scan.yml
+          expects a newline-separated list rather than a JSON array.
         type: string
         required: false
         default: ''
       shared_paths:
-        description: 'Newline-separated list of path patterns that, when matched by any changed file, trigger analysis for ALL components in filter_paths, passed through to frontend-pr-analysis.yml. Not passed to the security scan — call it directly with its own shared_paths for path-scoped security scans.'
+        description: >-
+          Newline-separated list of path patterns that, when matched by any changed file, trigger analysis for
+          ALL components in filter_paths, passed through to frontend-pr-analysis.yml. The security scan takes
+          its own list from security_shared_paths.
         type: string
         required: false
         default: ''
@@ -270,6 +277,28 @@ on:
         description: 'Explicit path to a single Dockerfile to build and scan (e.g. Dockerfile). Leave empty to auto-discover.'
         type: string
         default: ''
+      security_filter_paths:
+        description: >-
+          Newline-separated component path prefixes for a path-scoped security scan (e.g. "components/ui").
+          Separate from filter_paths because pr-security-scan.yml expects newline-separated values while
+          frontend-pr-analysis.yml expects a JSON array. Empty = single-app root scan.
+        type: string
+        required: false
+        default: ''
+      security_shared_paths:
+        description: >-
+          Newline-separated path patterns that trigger the security scan for ALL components in
+          security_filter_paths (e.g. a shared contract directory). Empty = no shared triggers.
+        type: string
+        required: false
+        default: ''
+      build_context_from_working_dir:
+        description: >-
+          Build each component image with its own working_dir as the Docker build context instead of the
+          repository root. Required for monorepos whose components are independent packages: a component
+          Dockerfile starting with `COPY package.json pnpm-lock.yaml ./` cannot build from the repository root.
+        type: boolean
+        default: false
       enable_codeql:
         description: 'Enable CodeQL static analysis. Requires codeql_languages to be set.'
         type: boolean
@@ -510,10 +539,15 @@ jobs:
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       enable_codeql: ${{ inputs.enable_codeql }}
       codeql_languages: ${{ inputs.codeql_languages }}
       prerelease_block_branches: ${{ inputs.prerelease_block_branches }}
       trivy_skip_dirs: ${{ inputs.trivy_skip_dirs }}
+      filter_paths: ${{ inputs.security_filter_paths }}
+      shared_paths: ${{ inputs.security_shared_paths }}
+      path_level: ${{ format('{0}', inputs.path_level) }}
+      normalize_to_filter: ${{ inputs.normalize_to_filter }}
     secrets: inherit
 
   security-gate:

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -107,7 +107,7 @@ apps:
     # Benedita-exclusive
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
-    - go-boilerplate-ddd-fullstack # Go API + React UI boilerplate (reference/template); values at dev-st
+    - go-boilerplate-ddd-fullstack  # Go API + React UI boilerplate (reference/template); values at dev-st
     - billing-api                 # Lago-backed billing gateway (benedita only); values at dev-st/stg-st. The Lago install it fronts lives at cross/, the gateway itself does not
 
     # Provisioned by Severino (app-provisioning automation)

--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -107,6 +107,7 @@ apps:
     # Benedita-exclusive
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
+    - go-boilerplate-ddd-fullstack # Go API + React UI boilerplate (reference/template); values at dev-st
     - billing-api                 # Lago-backed billing gateway (benedita only); values at dev-st/stg-st. The Lago install it fronts lives at cross/, the gateway itself does not
 
     # Provisioned by Severino (app-provisioning automation)
@@ -197,6 +198,7 @@ clusters:
       - notifications
       - rosiehr
       - go-boilerplate-ddd
+      - go-boilerplate-ddd-fullstack
       - severino-bot
       - streaming-hub
       - billing-api

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -68,6 +68,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `ignore_file` | Path to Trivy ignore file | string | `''` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a root Dockerfile (monorepos with Dockerfiles under `components/`/`cmd/`) | boolean | `true` |
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `components/ledger/Dockerfile`); lets monorepos without a root Dockerfile keep `enable_docker_scan: true` | string | `''` |
+| `build_context_from_working_dir` | Build each component image with its own `working_dir` as the Docker build context instead of the repository root. Required for type1 monorepos whose components are independent modules — a component Dockerfile starting with `COPY go.mod go.sum ./` cannot build from the repository root | boolean | `false` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated) | string | `''` |
 | `monorepo_type` | Monorepo layout for the security scan. `"type1"` = components in separate folders (default). `"type2"` = backend at repo root + one independent component in a sub-folder. | string | `'type1'` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -32,6 +32,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `security_scan_runner_type` | Optional runner override for the security_scan jobs only | string | `''` |
 | `pr_checks_summary_runner_type` | Optional runner override for the PR Checks Summary job only | string | `''` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_metadata` | Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set `false` in a multi-component repository that also calls `js-pr-validation.yml`, so exactly one umbrella owns PR metadata | boolean | `true` |
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_lib_version_check` | Run the Lerian library version check | boolean | `true` |

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -79,6 +79,8 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
 
 > **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
+>
+> When `run_metadata` is `false`, this workflow's `has_breaking_changes`, `breaking_change_approved` and `breaking_change_result` outputs are still produced, but with no metadata job to supply values they collapse to their fail-closed fallbacks — `false`, `false` and `failure`. Read them from the umbrella that still owns metadata.
 
 ## Outputs
 

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -13,6 +13,7 @@ Umbrella reusable workflow for Go service repositories. A caller references this
 4. **Go analysis** — lint, tests, coverage and build (delegates to `go-pr-analysis.yml`), opt-in via `run_go_analysis`.
 5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
 6. **Lerian lib version check** — fails when a direct Lerian library is behind its latest stable release (delegates to `lerian-lib-version-check.yml`), opt-in via `run_lib_version_check`.
+7. **Permission manifest nudge (RI)** — **non-blocking** reminder that warns via a sticky PR comment when a `lib-auth` repo has no `permissions.yaml` manifest (delegates to `src/validate/permission-manifest-nudge`), opt-in via `run_manifest_nudge`. Never fails and is **not** a required check.
 
 The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Go Analysis`, `Security`, `Lib Version`) for branch protection, regardless of the internal job names. All three are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing — so broken change detection cannot let the required checks go green.
 
@@ -34,6 +35,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `run_go_analysis` | Run the Go analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_lib_version_check` | Run the Lerian library version check | boolean | `true` |
+| `run_manifest_nudge` | Run the **non-blocking** Access-Manager RI nudge: warns via a sticky PR comment when a `lib-auth` repo has no `permissions.yaml`. Never fails or blocks the PR. | boolean | `true` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the change gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `lib_version_go_mod_path` | Path to go.mod for the Lerian lib check | string | `go.mod` |
 | `lib_version_check_indirect` | Also check transitive (indirect) Lerian deps | boolean | `false` |
@@ -96,6 +98,17 @@ Breaking change acknowledged: I understand that this PR intentionally introduces
 The guard is mandatory for every PR target branch. PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
 
 Caller triggers must include the five activity types in the usage example. `edited` is mandatory so removing or adding the acknowledgement reruns validation. `ready_for_review` is retained for complete validation transitions even though the guard enforces drafts.
+
+## Permission Manifest Nudge (RI) — non-blocking
+
+Part of the Access-Manager **Inversão de Responsabilidade (RI)** rollout. The `permission-manifest-nudge` job reminds a plugin/service to declare its permissions in a `permissions.yaml` manifest instead of relying on manual Access-Manager configuration.
+
+- **Scope gate:** only acts when `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. Repos with no `go.mod` or no direct lib-auth dependency are skipped silently. (This is the intended scoping — tune the `grep` in the composite to widen or narrow it.)
+- **Presence check:** globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and only counts files with top-level `service:` **and** `permissions:` keys.
+- **Idempotent comment:** posts / updates a single find-by-marker (`<!-- permission-manifest-nudge -->`) sticky comment — never spams per push. When a manifest is present it flips any prior nudge to a positive state.
+- **Never blocks:** the job runs with `continue-on-error: true`, the composite always exits 0, and there is **no** `*-gate` aggregator for it — so it must **not** be added to branch protection. Disable it entirely with `run_manifest_nudge: false`.
+
+See [`src/validate/permission-manifest-nudge`](../src/validate/permission-manifest-nudge/README.md) for the composite action details.
 
 ## Secrets
 

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -76,7 +76,9 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. `"tools/mock-sta-server"`). | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
 
-The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
+The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
+
+> **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
 
 ## Outputs
 
@@ -96,7 +98,7 @@ When a PR contains a breaking change, its description must contain this exact, c
 Breaking change acknowledged: I understand that this PR intentionally introduces a breaking change and requires the next release to be a major version.
 ```
 
-The guard is mandatory for every PR target branch. PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
+The guard is mandatory for every PR target branch whenever the metadata pipeline runs (see `run_metadata`). PRs without the required acknowledgement fail in the existing `Blocking Checks` job, including drafts. `dry_run: true` reports detection and approval without enforcing the guard.
 
 Caller triggers must include the five activity types in the usage example. `edited` is mandatory so removing or adding the acknowledgement reruns validation. `ready_for_review` is retained for complete validation transitions even though the guard enforces drafts.
 

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -105,6 +105,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
 
 > **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
+>
+> When `run_metadata` is `false`, this workflow's `has_breaking_changes`, `breaking_change_approved` and `breaking_change_result` outputs are still produced, but with no metadata job to supply values they collapse to their fail-closed fallbacks — `false`, `false` and `failure`. Read them from the umbrella that still owns metadata.
 
 ## Outputs
 

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -22,6 +22,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
+| `run_metadata` | Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set `false` in a multi-component repository that also calls `go-pr-validation.yml`, so exactly one umbrella owns PR metadata | boolean | `true` |
 | `run_frontend_analysis` | Run the frontend analysis pipeline | boolean | `true` |
 | `run_security` | Run the security scan pipeline | boolean | `true` |
 | `run_socket` | Run the Socket supply-chain pipeline | boolean | `true` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -8,7 +8,7 @@
 Umbrella reusable workflow for JavaScript/TypeScript repositories. A caller references this single workflow and it orchestrates everything a JS/TS PR needs:
 
 1. **PR metadata** — title, source branch, size, labels (delegates to `pr-validation.yml`).
-2. **Breaking Change Guard** — mandatory detection and enforcement inherited from `pr-validation.yml` for every PR target branch.
+2. **Breaking Change Guard** — mandatory detection and enforcement inherited from `pr-validation.yml` for every PR target branch, whenever the metadata pipeline runs (see `run_metadata`).
 3. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
 4. **Frontend analysis** — lint, typecheck, npm audit, tests, coverage and build (delegates to `frontend-pr-analysis.yml`), opt-in via `run_frontend_analysis`.
 5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
@@ -102,7 +102,9 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 
 > **Monorepo note:** `filter_paths`/`shared_paths`/`path_level`/`normalize_to_filter` scope the `frontend-analysis` job only. They are not passed to the `security` job because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input (JSON array vs. newline-separated). For a path-scoped security scan too, call `pr-security-scan.yml` directly.
 
-The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
+The Breaking Change Guard has no dedicated input, enable flag or target-branch filter. This umbrella inherits the guard automatically from `pr-validation.yml`, as part of the metadata pipeline.
+
+> **`run_metadata: false` skips the guard along with the rest of the metadata pipeline.** That input exists so a multi-component repository can run metadata exactly once across several umbrellas — it is not an opt-out from the guard. In such a repository, one umbrella must keep `run_metadata: true`, and that is the one enforcing the guard. Setting it to `false` on every umbrella disables the guard for the repository.
 
 ## Outputs
 

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -42,8 +42,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
 | `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml`. The security scan uses `security_filter_paths` instead | string | `''` |
 | `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml`. The security scan uses `security_shared_paths` instead | string | `''` |
-| `path_level` | Directory depth level to extract app name, passed through to `frontend-pr-analysis.yml` only | number | `2` |
-| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app, passed through to `frontend-pr-analysis.yml` only | boolean | `true` |
+| `path_level` | Directory depth level to extract app name; passed through to **both** `frontend-pr-analysis.yml` and `pr-security-scan.yml` | number | `2` |
+| `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app; passed through to **both** `frontend-pr-analysis.yml` and `pr-security-scan.yml` | boolean | `true` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
 | `enable_lint` | Enable ESLint | boolean | `true` |
 | `enable_typecheck` | Enable TypeScript type checking | boolean | `true` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -40,8 +40,8 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `audit_level` | npm audit severity level (`low`, `moderate`, `high`, `critical`) | string | `high` |
 | `coverage_threshold` | Minimum coverage percentage (0-100) | number | `80` |
 | `fail_on_coverage_threshold` | Fail when coverage is below threshold | boolean | `false` |
-| `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml` only | string | `''` |
-| `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml` only | string | `''` |
+| `filter_paths` | JSON array of paths to monitor for changes (e.g. `["ui"]`), passed through to `frontend-pr-analysis.yml`. The security scan uses `security_filter_paths` instead | string | `''` |
+| `shared_paths` | Newline-separated path patterns that trigger analysis for ALL components in `filter_paths`, passed through to `frontend-pr-analysis.yml`. The security scan uses `security_shared_paths` instead | string | `''` |
 | `path_level` | Directory depth level to extract app name, passed through to `frontend-pr-analysis.yml` only | number | `2` |
 | `normalize_to_filter` | Collapse every changed file under a `filter_paths` entry into that one app, passed through to `frontend-pr-analysis.yml` only | boolean | `true` |
 | `app_name_prefix` | Prefix used to namespace coverage/build artifacts | string | `''` |
@@ -77,6 +77,9 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `prerelease_block_branches` | Target branches where pre-release versions are hard failures (comma-separated) | string | `release-candidate,main` |
 | `enable_docker_scan` | Build and scan a Docker image with Trivy; set `false` for repos without a Dockerfile (CLIs, libraries) | boolean | `true` |
 | `dockerfile_path` | Explicit path to a single Dockerfile to build and scan (e.g. `Dockerfile`) | string | `''` |
+| `security_filter_paths` | Newline-separated component path prefixes for a path-scoped security scan (e.g. `components/ui`). Separate from `filter_paths` because the two callees use different formats. Empty = single-app root scan | string | `''` |
+| `security_shared_paths` | Newline-separated path patterns that trigger the security scan for ALL components in `security_filter_paths` | string | `''` |
+| `build_context_from_working_dir` | Build each component image with its own `working_dir` as the Docker build context instead of the repository root. Required for monorepos whose components are independent packages | boolean | `false` |
 | `enable_codeql` | Enable CodeQL static analysis | boolean | `false` |
 | `codeql_languages` | CodeQL languages (comma-separated, e.g. `javascript-typescript`) | string | `''` |
 | `ignore_file` | Path to Trivy ignore file (e.g. `.trivyignore.yaml`) | string | `''` |
@@ -99,7 +102,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `socket_api_fail_on_actions` | Actions that block the PR — **introduced findings only**. Empty blocks nothing | string | `''` |
 | `socket_comment_when` | `findings` posts the comment only when there is something to act on; `always` posts every run | string | `findings` |
 
-> **Monorepo note:** `filter_paths`/`shared_paths`/`path_level`/`normalize_to_filter` scope the `frontend-analysis` job only. They are not passed to the `security` job because `frontend-pr-analysis.yml` and `pr-security-scan.yml` use different formats for that input (JSON array vs. newline-separated). For a path-scoped security scan too, call `pr-security-scan.yml` directly.
+> **Monorepo note:** `filter_paths` scopes the `frontend-analysis` job; `security_filter_paths` scopes the `security` job. They are separate inputs because the two callees expect different formats — `frontend-pr-analysis.yml` takes a JSON array, `pr-security-scan.yml` takes a newline-separated list. `path_level` and `normalize_to_filter` are shared by both. Set `build_context_from_working_dir: true` when each component Dockerfile expects its own directory as build context.
 
 The Breaking Change Guard has no input, enable flag, target-branch filter, or opt-out. This umbrella inherits the guard automatically from `pr-validation.yml`.
 

--- a/src/validate/permission-manifest-nudge/README.md
+++ b/src/validate/permission-manifest-nudge/README.md
@@ -1,0 +1,75 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>permission-manifest-nudge</h1></td>
+  </tr>
+</table>
+
+**NON-BLOCKING** reminder that nudges a Go plugin/service to adopt the Access-Manager **Inversão de Responsabilidade (RI)** by declaring its permissions in a `permissions.yaml` manifest.
+
+The action:
+
+1. **Scope gate** — only acts when the repo looks like a plugin/service that *should* declare permissions, i.e. its `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. No `go.mod`, or no direct lib-auth dependency → it exits cleanly with no comment.
+2. **Manifest presence** — globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and keeps only files that look like a real declaration (top-level `service:` **and** `permissions:` keys).
+3. **Sticky comment** — when in scope and no qualifying manifest exists, posts / updates a single find-by-marker PR comment inviting the team to adopt the RI. When a manifest *is* present it flips any prior nudge comment to a positive state (and never creates a new one).
+
+> It **never fails**: every step is best-effort and exits 0. Pair it with `continue-on-error: true` on the calling job so a hiccup here can never gate a merge. It is **not** a required status check.
+
+## Inputs
+
+| Input           | Description                                                                                  | Required | Default                                                                       |
+|-----------------|----------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------------------------|
+| `github-token`  | Token used to post / update the sticky PR comment. Needs `pull-requests:write` on the caller repo. | Yes      |                                                                               |
+| `go-mod-path`   | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.             | No       | `go.mod`                                                                       |
+| `guide-url`     | Link to the RI adoption guide surfaced in the nudge comment.                                 | No       | `https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0`  |
+| `comment-on-pr` | Post / update the sticky PR comment. When `false`, the check still runs but stays silent.    | No       | `true`                                                                         |
+
+## Outputs
+
+| Output         | Description                                                                        |
+|----------------|------------------------------------------------------------------------------------|
+| `applicable`   | `true` if the repo is in scope (go.mod depends on lib-auth); `false` = skipped.     |
+| `has_manifest` | `true` if at least one qualifying `permissions.yaml` manifest was found.            |
+| `state`        | `skip` (out of scope), `compliant` (manifest present), or `nudge` (in scope, none). |
+
+## Behavior matrix
+
+| Condition                                                    | Result                                                     |
+|--------------------------------------------------------------|------------------------------------------------------------|
+| `go.mod` not found at `go-mod-path`                          | `skip` — `::notice`, no comment, exit 0                     |
+| `go.mod` has no **direct** `lib-auth` dependency             | `skip` — `::notice`, no comment, exit 0                    |
+| In scope + a qualifying `permissions.yaml` exists            | `compliant` — flips an existing nudge comment to positive; creates nothing new |
+| In scope + no qualifying `permissions.yaml`                  | `nudge` — posts / updates the single sticky reminder comment |
+| Any internal / API error                                     | Logged as `::warning`; exit 0 (never fails)                |
+
+## Scope gate — reviewer knob
+
+The scope is deliberately narrow (direct lib-auth dep) to avoid noise on non-plugin repos. To tune it, edit the `grep` in `action.yml` step *Detect lib-auth scope and permission manifest*:
+
+- drop the `// indirect` exclusion to also catch transitive lib-auth,
+- match a different signal (e.g. `lib-commons`, a marker file, or a repo topic).
+
+## Usage as composite step
+
+```yaml
+jobs:
+  permission-manifest-nudge:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    continue-on-error: true   # non-blocking by contract
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-nudge@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Most callers get this for free through the [`go-pr-validation`](../../../docs/go-pr-validation.md) umbrella (`run_manifest_nudge`, default `true`).
+
+## Implementation notes
+
+- Pure Bash + `actions/github-script` — no extra runtime required on the runner.
+- The sticky comment is keyed by the HTML marker `<!-- permission-manifest-nudge -->`, so re-runs update the same comment instead of spamming per push.
+- The manifest content check is intentionally light (`service:` + `permissions:` top-level keys) — it is a nudge, not a schema validator. `make validate-permissions` is the local validator teams run.

--- a/src/validate/permission-manifest-nudge/README.md
+++ b/src/validate/permission-manifest-nudge/README.md
@@ -23,6 +23,7 @@ The action:
 | `go-mod-path`   | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.             | No       | `go.mod`                                                                       |
 | `guide-url`     | Link to the RI adoption guide surfaced in the nudge comment.                                 | No       | `https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0`  |
 | `comment-on-pr` | Post / update the sticky PR comment. When `false`, the check still runs but stays silent.    | No       | `true`                                                                         |
+| `dry-run`       | Preview mode. When `true`, the check runs but makes NO GitHub API calls / PR side effects (logs what it would post). | No       | `false`                                                                       |
 
 ## Outputs
 

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -157,7 +157,7 @@ runs:
             echo
             echo "- 📖 Guia: [Declaração de Permissões (RI) — v1.0](${GUIDE_URL})"
             echo "- 🛠️ Skill do Ring: \`ring:declaring-plugin-permissions\`"
-            echo "- ✅ Depois de criar o \`permissions.yaml\`, valide localmente com \`make validate-permissions\`."
+            echo "- ✅ Depois de criar o \`permissions.yaml\`, rode \`make validate-permissions\` localmente."
             echo
             echo "> ℹ️ Isto é **apenas um lembrete** — **não bloqueia** o merge deste PR. Sinta-se à vontade"
             echo "> para adotar quando fizer sentido para o time."

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -1,0 +1,233 @@
+name: Permission Manifest Nudge (RI)
+description: |
+  NON-BLOCKING reminder that nudges a Go plugin/service to adopt the Access-Manager
+  "Inversão de Responsabilidade" (RI) by declaring its permissions in a
+  `permissions.yaml` manifest.
+
+  Scope gate: only acts when the repository looks like a plugin/service that SHOULD
+  declare permissions — i.e. its go.mod has a DIRECT dependency on
+  `github.com/LerianStudio/lib-auth`. Otherwise it exits cleanly with no comment.
+
+  When in scope and no qualifying manifest exists, it posts / updates a single
+  sticky PR comment (find-by-marker) inviting the team to adopt the RI. It NEVER
+  fails: every step is best-effort and exits 0. Pair it with `continue-on-error: true`
+  on the calling job so a hiccup here can never gate a merge.
+
+inputs:
+  github-token:
+    description: Token used to post / update the sticky PR comment. Needs pull-requests:write on the caller repo.
+    required: true
+  go-mod-path:
+    description: Path to go.mod (relative to repo root). Used only for the lib-auth scope gate.
+    required: false
+    default: "go.mod"
+  guide-url:
+    description: Link to the RI adoption guide surfaced in the nudge comment.
+    required: false
+    default: "https://alfarrabio.lerian.net/reports/brecci/declaracao-de-permissoes-v1-0"
+  comment-on-pr:
+    description: Post / update the sticky PR comment. When false, the check still runs but stays silent.
+    required: false
+    default: "true"
+
+outputs:
+  applicable:
+    description: "true if the repo is in scope (go.mod depends on lib-auth); false = skipped."
+    value: ${{ steps.check.outputs.applicable }}
+  has_manifest:
+    description: "true if at least one qualifying permissions.yaml manifest was found."
+    value: ${{ steps.check.outputs.has_manifest }}
+  state:
+    description: "One of: skip (out of scope), compliant (manifest present), nudge (in scope, no manifest)."
+    value: ${{ steps.check.outputs.state }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect lib-auth scope and permission manifest
+      id: check
+      shell: bash
+      env:
+        GO_MOD_PATH: ${{ inputs.go-mod-path }}
+        GUIDE_URL: ${{ inputs.guide-url }}
+      run: |
+        # Best-effort by design: never `set -e`. Any internal hiccup degrades to a
+        # skip (state=skip) and exits 0 so this reminder can never gate a merge.
+        set -uo pipefail
+
+        REPORT_PATH="${RUNNER_TEMP:-/tmp}/permission-manifest-nudge.md"
+        : > "${REPORT_PATH}"
+
+        emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
+
+        # ---------------------------------------------------------------------------
+        # 1. SCOPE GATE — only nudge repos that SHOULD declare permissions.
+        #
+        #    Signal: a DIRECT dependency on github.com/LerianStudio/lib-auth in go.mod.
+        #    A repo with no go.mod, or one that does not import lib-auth directly, is
+        #    out of scope and exits silently (state=skip, no comment).
+        #
+        #    REVIEWER KNOB: to widen/narrow the scope, change the grep below. E.g. drop
+        #    the `// indirect` exclusion to also catch transitive lib-auth, or match a
+        #    different lib (lib-commons, a plugin marker file, a topic, ...).
+        # ---------------------------------------------------------------------------
+        if [[ ! -f "${GO_MOD_PATH}" ]]; then
+          echo "::notice title=Permission manifest nudge::No go.mod at '${GO_MOD_PATH}' — not a Go service, skipping."
+          emit applicable false
+          emit has_manifest false
+          emit state skip
+          emit report_path "${REPORT_PATH}"
+          exit 0
+        fi
+
+        # Match `github.com/LerianStudio/lib-auth` or `.../lib-auth/vN`, as a whole
+        # module token (space/tab after it), excluding `// indirect` lines so only a
+        # DIRECT dependency counts. The `[[:space:]]` after the optional /vN prevents
+        # matching a longer name like `lib-auth-something`.
+        if grep -E '^[[:space:]]*github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
+             | grep -qv '// indirect'; then
+          echo "Scope gate: direct github.com/LerianStudio/lib-auth dependency found — repo is in scope."
+        else
+          echo "::notice title=Permission manifest nudge::go.mod has no direct lib-auth dependency — out of scope, skipping."
+          emit applicable false
+          emit has_manifest false
+          emit state skip
+          emit report_path "${REPORT_PATH}"
+          exit 0
+        fi
+
+        emit applicable true
+
+        # ---------------------------------------------------------------------------
+        # 2. MANIFEST PRESENCE — search for a permission-declaration manifest.
+        #
+        #    Glob every `permissions.yaml` (excluding vendor / node_modules / .git),
+        #    then keep only files that look like a real declaration: top-level
+        #    `service:` AND `permissions:` keys. This light content check avoids false
+        #    positives from unrelated files that happen to be named permissions.yaml.
+        # ---------------------------------------------------------------------------
+        QUALIFYING=""
+        while IFS= read -r f; do
+          [[ -z "${f}" ]] && continue
+          # Top-level keys: unindented `service:` and `permissions:` anywhere in file.
+          if grep -qE '^service:[[:space:]]*' "${f}" 2>/dev/null \
+             && grep -qE '^permissions:[[:space:]]*' "${f}" 2>/dev/null; then
+            QUALIFYING="${f}"
+            break
+          fi
+        done < <(find . -type f -name 'permissions.yaml' \
+                   -not -path '*/vendor/*' \
+                   -not -path '*/node_modules/*' \
+                   -not -path '*/.git/*' 2>/dev/null)
+
+        if [[ -n "${QUALIFYING}" ]]; then
+          echo "Qualifying permission manifest found: ${QUALIFYING}"
+          emit has_manifest true
+          emit state compliant
+          {
+            echo "<!-- permission-manifest-nudge -->"
+            echo "### ✅ Manifesto de permissões encontrado"
+            echo
+            echo "Este repositório declara suas permissões em \`${QUALIFYING#./}\` — obrigado por adotar a **Inversão de Responsabilidade (RI)**! 🎉"
+            echo
+            echo "_Lembrete automático (não bloqueia o PR)._"
+          } > "${REPORT_PATH}"
+        else
+          echo "No qualifying permissions.yaml manifest found — will nudge."
+          emit has_manifest false
+          emit state nudge
+          {
+            echo "<!-- permission-manifest-nudge -->"
+            echo "### 🔐 Que tal adotar a Inversão de Responsabilidade (RI)?"
+            echo
+            echo "Este repositório ainda **não possui** um manifesto de permissões (\`permissions.yaml\`)."
+            echo
+            echo "Com a **Inversão de Responsabilidade** do Access-Manager, cada plugin/serviço passa a"
+            echo "**declarar as próprias permissões** em um manifesto versionado, em vez de depender de"
+            echo "configuração manual no Access-Manager. Isso deixa as permissões explícitas, revisáveis"
+            echo "no PR e reproduzíveis por ambiente."
+            echo
+            echo "**Como adotar:**"
+            echo
+            echo "- 📖 Guia: [Declaração de Permissões (RI) — v1.0](${GUIDE_URL})"
+            echo "- 🛠️ Skill do Ring: \`ring:declaring-plugin-permissions\`"
+            echo "- ✅ Depois de criar o \`permissions.yaml\`, valide localmente com \`make validate-permissions\`."
+            echo
+            echo "> ℹ️ Isto é **apenas um lembrete** — **não bloqueia** o merge deste PR. Sinta-se à vontade"
+            echo "> para adotar quando fizer sentido para o time."
+          } > "${REPORT_PATH}"
+        fi
+
+        emit report_path "${REPORT_PATH}"
+        cat "${REPORT_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+        exit 0
+
+    - name: Post / update sticky PR comment
+      # Only touches the PR when there is something to say and we are on a PR event.
+      # github-script is wrapped so an API hiccup logs and returns — never fails.
+      if: ${{ always() && inputs.comment-on-pr == 'true' && github.event_name == 'pull_request' }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        REPORT_PATH: ${{ steps.check.outputs.report_path }}
+        STATE: ${{ steps.check.outputs.state }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          try {
+            const fs = require('fs');
+            const marker = '<!-- permission-manifest-nudge -->';
+            const state = process.env.STATE || 'skip';
+            const reportPath = process.env.REPORT_PATH;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request?.number;
+            if (!issue_number) {
+              core.info('Not a pull_request event; skipping comment.');
+              return;
+            }
+
+            // Find any prior nudge comment by its stable marker.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            // Out of scope: never create a comment. If a stale nudge exists from a
+            // prior run (e.g. lib-auth was removed), leave it — we do not delete.
+            if (state === 'skip') {
+              core.info('Out of scope; no comment posted.');
+              return;
+            }
+
+            const body = (reportPath && fs.existsSync(reportPath))
+              ? fs.readFileSync(reportPath, 'utf8')
+              : null;
+            if (!body) {
+              core.info(`No report body at ${reportPath}; skipping comment.`);
+              return;
+            }
+
+            // Compliant: update an existing nudge to the positive state, but do NOT
+            // create a brand-new comment (avoid noise on already-compliant repos).
+            if (state === 'compliant') {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                core.info(`Updated nudge comment #${existing.id} to compliant state.`);
+              } else {
+                core.info('Compliant and no prior nudge comment; nothing to do.');
+              }
+              return;
+            }
+
+            // Nudge: create or update the single sticky comment.
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated sticky nudge comment #${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info('Created sticky nudge comment.');
+            }
+          } catch (err) {
+            // Non-blocking by contract: log and swallow so this can never fail a PR.
+            core.warning(`permission-manifest-nudge comment step failed (non-blocking): ${err.message}`);
+          }

--- a/src/validate/permission-manifest-nudge/action.yml
+++ b/src/validate/permission-manifest-nudge/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Post / update the sticky PR comment. When false, the check still runs but stays silent.
     required: false
     default: "true"
+  dry-run:
+    description: Preview mode. When true, the check still runs but performs NO GitHub API calls / PR side effects (no comment) — it only logs what it would post.
+    required: false
+    default: "false"
 
 outputs:
   applicable:
@@ -81,10 +85,12 @@ runs:
         fi
 
         # Match `github.com/LerianStudio/lib-auth` or `.../lib-auth/vN`, as a whole
-        # module token (space/tab after it), excluding `// indirect` lines so only a
+        # module token (space/tab after it), in BOTH go.mod forms: the block form
+        # (indented `\tgithub.com/... vX`) and the single-line form
+        # (`require github.com/... vX`). Then exclude `// indirect` lines so only a
         # DIRECT dependency counts. The `[[:space:]]` after the optional /vN prevents
         # matching a longer name like `lib-auth-something`.
-        if grep -E '^[[:space:]]*github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
+        if grep -E '^[[:space:]]*(require[[:space:]]+)?github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
              | grep -qv '// indirect'; then
           echo "Scope gate: direct github.com/LerianStudio/lib-auth dependency found — repo is in scope."
         else
@@ -170,6 +176,7 @@ runs:
       env:
         REPORT_PATH: ${{ steps.check.outputs.report_path }}
         STATE: ${{ steps.check.outputs.state }}
+        DRY_RUN: ${{ inputs.dry-run }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -178,6 +185,7 @@ runs:
             const marker = '<!-- permission-manifest-nudge -->';
             const state = process.env.STATE || 'skip';
             const reportPath = process.env.REPORT_PATH;
+            const dryRun = (process.env.DRY_RUN || 'false') === 'true';
 
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request?.number;
@@ -185,12 +193,6 @@ runs:
               core.info('Not a pull_request event; skipping comment.');
               return;
             }
-
-            // Find any prior nudge comment by its stable marker.
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
 
             // Out of scope: never create a comment. If a stale nudge exists from a
             // prior run (e.g. lib-auth was removed), leave it — we do not delete.
@@ -206,6 +208,22 @@ runs:
               core.info(`No report body at ${reportPath}; skipping comment.`);
               return;
             }
+
+            // Dry-run: preview only — NO GitHub API calls, no PR side effects.
+            // Resolved above from local files, so we log what we would post and stop
+            // before any read/write against the API.
+            if (dryRun) {
+              core.info(`[dry-run] permission-manifest-nudge would post/update (state=${state}):\n${body}`);
+              return;
+            }
+
+            // Find any prior nudge comment by its stable marker. Paginate: a single
+            // listComments page tops out at 100, so a marker beyond page 1 would be
+            // missed and we would create a duplicate sticky comment.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
 
             // Compliant: update an existing nudge to the positive state, but do NOT
             // create a brand-new comment (avoid noise on already-compliant repos).


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`go-boilerplate-ddd-fullstack` is deployed to **benedita dev-st**, and its release workflow now runs `gitops-update` for both components (`LerianStudio/go-boilerplate-ddd-fullstack` — enabling GitOps updates). Without an entry in the deployment matrix the job has no path to resolve and cannot write the image tags.

Two lines: the app joins `apps.registry` and the `benedita` cluster block, next to its predecessor `go-boilerplate-ddd`.

**Affected files**

| File | Change |
| --- | --- |
| `config/deployment-matrix.yml` | Register the app; add it to `clusters.benedita.apps` |

## Type of Change

- [x] `feat`: new capability in an existing workflow's configuration
- [ ] `fix` / `perf` / `refactor` / `docs` / `ci` / `chore` / `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. Additive; no existing app's resolution changes.

## Testing

- [x] `deployment-matrix.yml` parses; the app appears in `apps.registry` and in exactly one cluster block (`benedita`)
- [x] `yamllint` reports nothing new
- [ ] Not exercised end to end — `gitops-update` runs on a tag push in the caller repository, which happens on its next release

**Note on environments:** benedita's `env_suffixes: ["-st", "-mt"]` expand a beta tag's `dev` into `dev-st` and `dev-mt`. Only `dev-st` exists for this app in `lerian-internal-gitops` today, which matches how the predecessor `go-boilerplate-ddd` is deployed. Flagging it in case a missing `dev-mt` path is treated as an error rather than skipped — I could not confirm which from the matrix alone.

## Related Issues

Closes #