### PR TITLE
fix(gitops): register go-boilerplate-ddd-fullstack for benedita

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -107,6 +107,7 @@ apps:
     # Benedita-exclusive
     - rosiehr                     # internal HR app (benedita only); values at cross/
     - go-boilerplate-ddd          # Go service boilerplate (reference/template)
+    - go-boilerplate-ddd-fullstack  # Go API + React UI boilerplate (reference/template); values at dev-st
     - billing-api                 # Lago-backed billing gateway (benedita only); values at dev-st/stg-st. The Lago install it fronts lives at cross/, the gateway itself does not
 
 clusters:
@@ -191,6 +192,7 @@ clusters:
       - notifications
       - rosiehr
       - go-boilerplate-ddd
+      - go-boilerplate-ddd-fullstack
       - severino-bot
       - streaming-hub
       - billing-api


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`go-boilerplate-ddd-fullstack` is deployed to **benedita dev-st**, and its release workflow now runs `gitops-update` for both components. Without an entry in the deployment matrix the job has no path to resolve and cannot write the image tags — so the caller's next release cannot complete.

Two lines: the app joins `apps.registry` and the `benedita` cluster block, next to its predecessor `go-boilerplate-ddd`.

| File | Change |
| --- | --- |
| `config/deployment-matrix.yml` | Register the app; add it to `clusters.benedita.apps` |

## Why a hotfix straight to `main`

Per `CONTRIBUTING.md`, `hotfix/*` → `main` is for a fix that must bypass `develop`. This one gates a release in a caller repository: until it lands on `main`, `gitops-update` there has nothing to resolve. Routing it through `develop` would hold it behind the next release train for a two-line additive config entry.

Branched from `main`, so the diff is exactly those two lines — `develop` is currently 9 lines ahead of `main` in this file and none of that is pulled in.

**A backmerge to `develop` is required after merge**, per the repository's merge strategy table.

## Type of Change

- [ ] `feat`
- [x] `fix`: the matrix is missing an entry a deployed app needs
- [ ] `perf` / `refactor` / `docs` / `ci` / `chore` / `test`
- [ ] `BREAKING CHANGE`

## Breaking Changes

None. Additive; no existing app's resolution changes.

## Testing

- [x] `deployment-matrix.yml` parses; the app appears in `apps.registry` and in exactly one cluster block (`benedita`)
- [x] `yamllint -c .yamllint.yml` reports nothing new
- [x] `git diff --stat` confirms the change is 2 insertions and nothing else
- [ ] Not exercised end to end — `gitops-update` runs on a tag push in the caller repository, on its next release

**Note on environments:** benedita's `env_suffixes: ["-st", "-mt"]` expand a beta tag's `dev` into `dev-st` and `dev-mt`. Only `dev-st` exists for this app in `lerian-internal-gitops` today, matching how the predecessor `go-boilerplate-ddd` is deployed. Flagging it in case a missing `dev-mt` path is treated as an error rather than skipped — I could not determine which from the matrix alone.

## Related Issues

Supersedes #666, which targeted `develop`.

Closes #