### PR TITLE
feat(go-release): publish permissions.yaml to the RI S3 catalog on release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -635,6 +635,13 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      # Secrets can't be referenced directly in a step `if:`, so surface the
+      # role's presence as a job-level env boolean. run_manifest_publish defaults
+      # to true, so a repo that never mapped AWS_INIT_DATA_ROLE_ARN must SKIP the
+      # real upload (not attempt an unauthenticated one) — a dry-run still runs
+      # since the composite previews without any AWS call.
+      HAS_INIT_DATA_ROLE: ${{ secrets.AWS_INIT_DATA_ROLE_ARN != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -658,15 +665,19 @@ jobs:
           echo "folder=${FOLDER}" >> "$GITHUB_OUTPUT"
           [[ -n "$FOLDER" ]] && echo "📁 Environment: ${FOLDER}" || echo "::warning::Tag '${TAG}' matched no environment — manifest publish skipped."
 
+      # Skip on a dry-run (the composite previews with no AWS call) and when the
+      # role secret is absent (nothing to assume — the publish step is skipped too).
       - name: Configure AWS credentials
-        if: steps.env.outputs.folder != ''
+        if: steps.env.outputs.folder != '' && env.HAS_INIT_DATA_ROLE == 'true' && inputs.dry_run != true
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
           aws-region: us-east-2
 
+      # Publish when there are real creds, or preview when dry-running; otherwise
+      # (no role secret and not a dry-run) skip rather than fail a credential-less upload.
       - name: Publish permission manifest to the RI catalog
-        if: steps.env.outputs.folder != ''
+        if: steps.env.outputs.folder != '' && (env.HAS_INIT_DATA_ROLE == 'true' || inputs.dry_run == true)
         uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-publish@v1
         with:
           environment: ${{ steps.env.outputs.folder }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -255,6 +255,12 @@ on:
         description: 'JSON array of S3 upload entries run after build on tag push, each forwarded to s3-upload.yml. Each object: {"s3_bucket": "...", "file_pattern": "...", "s3_prefix": "...", "strip_prefix": "...", "flatten": true|false} (only s3_bucket and file_pattern are required; flatten defaults to true). Empty = no upload (default).'
         type: string
         default: ''
+
+      # ----------------- Permission Manifest Publish (RI, permission-manifest-publish composite) -----------------
+      run_manifest_publish:
+        description: 'Publish this service''s own permissions.yaml manifest to the shared Access-Manager RI catalog in S3 on tag push (upstream half of the Inversão de Responsabilidade). Auto-detects the manifest and no-ops when out of scope (no direct lib-auth dep) or absent. The job is continue-on-error, so a hiccup never blocks the release. Requires the AWS_INIT_DATA_ROLE_ARN secret to be mapped by the caller.'
+        type: boolean
+        default: true
       # ----------------- API Dog E2E (api-dog-e2e-tests.yml) -----------------
       enable_apidog_e2e:
         description: 'Run the ApiDog E2E test job on tag push after a successful gitops-update'
@@ -342,6 +348,8 @@ on:
       HELM_REPO_TOKEN:
         required: false
       AWS_MIGRATIONS_ROLE_ARN:
+      AWS_INIT_DATA_ROLE_ARN:
+        required: false
       APIDOG_TEST_SCENARIO_ID:
         required: false
       APIDOG_ACCESS_TOKEN:
@@ -607,6 +615,63 @@ jobs:
               upload_entry "$BUCKET" "$PATTERN" "$PREFIX" "$STRIP_PREFIX" "$FLATTEN"
             fi
           done
+
+  # ----------------- Permission Manifest Publish (RI, tag push, opt-in) -----------------
+  # Upstream half of the Access-Manager "Inversão de Responsabilidade": on a tag push
+  # each in-scope Go service publishes its OWN permissions.yaml to the shared RI catalog
+  # in S3 (one object per service, keyed by the manifest's `service:` value). The
+  # tenant-manager aggregates at read time by listing the prefix — there is no merge here.
+  #
+  # Reads repo files (not build artifacts), so it does NOT gate on the image build like
+  # s3_upload does; it only mirrors s3_upload's tag-push guard and its tag -> FOLDER
+  # derivation, assuming the casdoor-init-data-scoped AWS_INIT_DATA_ROLE_ARN via OIDC.
+  # continue-on-error keeps a publish hiccup from ever blocking the release.
+  permission_manifest_publish:
+    name: Permission Manifest Publish
+    if: >-
+      !cancelled() && github.ref_type == 'tag' && inputs.run_manifest_publish
+    runs-on: ${{ inputs.runner_type }}
+    continue-on-error: true
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Determine environment folder from tag
+        id: env
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" == *-beta* ]]; then
+            FOLDER="development"
+          elif [[ "$TAG" == *-rc* ]]; then
+            FOLDER="staging"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            FOLDER="production"
+          else
+            FOLDER=""
+          fi
+          echo "folder=${FOLDER}" >> "$GITHUB_OUTPUT"
+          [[ -n "$FOLDER" ]] && echo "📁 Environment: ${FOLDER}" || echo "::warning::Tag '${TAG}' matched no environment — manifest publish skipped."
+
+      - name: Configure AWS credentials
+        if: steps.env.outputs.folder != ''
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Publish permission manifest to the RI catalog
+        if: steps.env.outputs.folder != ''
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-publish@v1
+        with:
+          environment: ${{ steps.env.outputs.folder }}
+          github-token: ${{ github.token }}
+          dry-run: ${{ inputs.dry_run }}
 
   # ----------------- Extra Builds (tag push, opt-in) -----------------
   extra_build:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -643,6 +643,7 @@ jobs:
       # since the composite previews without any AWS call.
       HAS_INIT_DATA_ROLE: ${{ secrets.AWS_INIT_DATA_ROLE_ARN != '' }}
     steps:
+      # ----------------- Checkout & environment resolution -----------------
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -665,6 +666,7 @@ jobs:
           echo "folder=${FOLDER}" >> "$GITHUB_OUTPUT"
           [[ -n "$FOLDER" ]] && echo "📁 Environment: ${FOLDER}" || echo "::warning::Tag '${TAG}' matched no environment — manifest publish skipped."
 
+      # ----------------- AWS credentials (guarded) -----------------
       # Skip on a dry-run (the composite previews with no AWS call) and when the
       # role secret is absent (nothing to assume — the publish step is skipped too).
       - name: Configure AWS credentials
@@ -674,6 +676,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
           aws-region: us-east-2
 
+      # ----------------- Publish manifest to the RI catalog -----------------
       # Publish when there are real creds, or preview when dry-running; otherwise
       # (no role secret and not a dry-run) skip rather than fail a credential-less upload.
       - name: Publish permission manifest to the RI catalog

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -28,7 +28,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
 | `build_runner_type` | Optional runner override for the Build jobs only (forwarded to build.yml; prepare/notify stay on `runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
 | `release_runner_type` | Optional runner override for the Release (publish) jobs only (forwarded to release.yml as `publish_runner_type`); empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
-| `dry_run` | Reserved (downstream workflows have no dry-run mode yet) | boolean | `false` |
+| `dry_run` | Preview mode for **permission-manifest publishing only** — forwarded to `permission-manifest-publish`, which logs the target key + `aws s3 cp` command without calling AWS. The other release jobs (release/build/gitops) have no full-workflow preview yet. | boolean | `false` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `semantic_version` | semantic-release version | string | `23.0.8` |
 | `enable_changelog` | Generate CHANGELOG.md via GPT after a successful release | boolean | `false` |

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -80,6 +80,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `kustomize_version` | Version of kustomize CLI to install (used only when `gitops_layout=kustomize`) | string | `v5.4.3` |
 | `argocd_app_name_template` | Template for the ArgoCD application name. Placeholders `{server}`, `{app}`, `{env}`. For kustomize layouts without env split use e.g. `{server}-{app}` | string | `{server}-{app}-{env}` |
 | `s3_uploads` | JSON array of S3 upload entries run after build on tag push (see [S3 migrations upload](#s3-migrations-upload)) | string | `''` |
+| `run_manifest_publish` | Publish this service's own `permissions.yaml` to the shared Access-Manager RI catalog in S3 on tag push (see [Permission manifest publish](#permission-manifest-publish-ri)) | boolean | `true` |
 | `enable_apidog_e2e` | Run the ApiDog E2E test job on tag push after a successful gitops-update | boolean | `false` |
 | `apidog_runner_type` | Runner for the ApiDog E2E test job (needs reach to the deployed environment) | string | `eveo-lxc-runners` |
 | `apidog_auto_detect_environment` | Auto-detect the ApiDog environment from the tag (beta → dev, rc → stg); when `false`, uses `APIDOG_ENVIRONMENT_ID` | boolean | `true` |
@@ -106,6 +107,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
 | `HELM_REPO_TOKEN` | Token for dispatching Helm chart updates (when enabled in build) | No |
 | `AWS_MIGRATIONS_ROLE_ARN` | IAM role ARN assumed by the S3 upload job (required when `s3_uploads` is set) | No |
+| `AWS_INIT_DATA_ROLE_ARN` | IAM role ARN (scoped to the `lerian-casdoor-init-data` bucket) assumed by the permission-manifest publish job (used when `run_manifest_publish` is enabled and the repo is in scope) | No |
 | `APIDOG_TEST_SCENARIO_ID` | ApiDog test scenario ID (required when `enable_apidog_e2e`) | No |
 | `APIDOG_ACCESS_TOKEN` | ApiDog access token (required when `enable_apidog_e2e`) | No |
 | `APIDOG_DEV_ENVIRONMENT_ID` | ApiDog dev environment ID (used for beta tags in auto-detect mode) | No |
@@ -174,6 +176,22 @@ with:
       { "s3_bucket": "lerian-casdoor-init-data", "file_pattern": "init/casdoor/*.json", "aws_role_arn": "${{ secrets.AWS_INIT_DATA_ROLE_ARN }}" }
     ]
 ```
+## Permission manifest publish (RI)
+
+`run_manifest_publish` (default `true`) is the **upstream half** of the Access-Manager **Inversão de Responsabilidade (RI)**: on a **tag push**, each in-scope Go service publishes its **own** `permissions.yaml` to the shared RI catalog in S3, so the tenant-manager can materialize per-tenant permissions by reading it. It uses the [permission-manifest-publish](../src/validate/permission-manifest-publish/README.md) composite and pairs with the [permission-manifest-nudge](../src/validate/permission-manifest-nudge/README.md) PR reminder (same detection, so the two agree on what a manifest is).
+
+The `permission_manifest_publish` job is **`continue-on-error`** — a publish hiccup never blocks the release — and **auto-detects** the manifest, no-opping when the repo is out of scope (`go.mod` has no direct `github.com/LerianStudio/lib-auth` dependency) or has no qualifying `permissions.yaml` (a file with top-level `service:` and `permissions:` keys). Unlike `s3_upload` it reads repo files, so it does **not** gate on the image build.
+
+The catalog is **per-service and env-scoped**: each service writes exactly one object, keyed by its manifest's `service:` value, to
+
+```
+s3://lerian-casdoor-init-data/{environment}/permissions/{service}.yaml
+```
+
+The `{environment}` folder is derived from the tag suffix exactly like the S3 upload job (`-beta` → `development`, `-rc` → `staging`, `vX.Y.Z` → `production`). There is **no aggregation** on write — the tenant-manager aggregates at read time by listing the `{environment}/permissions/` prefix, and each release overwrites only its own file.
+
+The job assumes the **`AWS_INIT_DATA_ROLE_ARN`** secret (scoped to the `lerian-casdoor-init-data` bucket — the same bucket the Casdoor `init_data.json` uses) via OIDC in region `us-east-2`; map it in the caller (`secrets: inherit` is sufficient). Set `run_manifest_publish: false` to opt out.
+
 ## ApiDog E2E tests
 
 Set `enable_apidog_e2e: true` to run [api-dog-e2e-tests](./api-dog-e2e-tests-workflow.md) on tag push after a successful `update_gitops`. The job is skipped on branch pushes and when the gitops update did not succeed.

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -101,7 +101,7 @@ The composite itself uses none — it is pure Bash + the AWS CLI. The two extern
 | Action | Why |
 |--------|-----|
 | `actions/checkout` | Checks the repository out so the `permissions.yaml` manifest is present in the workspace for detection and upload. |
-| `aws-actions/configure-aws-credentials` | Obtains short-lived OIDC credentials for the `aws s3 cp` upload, assuming the bucket-scoped `AWS_INIT_DATA_ROLE_ARN` role — no long-lived keys. Skipped on a dry-run (no AWS call) and when the role secret is unset. |
+| `aws-actions/configure-aws-credentials` | Obtains short-lived OIDC credentials for the `aws s3 cp` upload, assuming the bucket-scoped `AWS_INIT_DATA_ROLE_ARN` role — no long-lived keys. In the [`go-release`](../../../docs/go-release-workflow.md) umbrella the credential step is guarded (`if: … dry_run != true && HAS_INIT_DATA_ROLE == 'true'`), so it is skipped on a dry-run and when the role secret is unset; a standalone caller (the minimal snippet above) must add the equivalent guard itself if it wants that skip behaviour. |
 
 ## Implementation notes
 

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -1,0 +1,102 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>permission-manifest-publish</h1></td>
+  </tr>
+</table>
+
+Publishes a Go plugin/service's **own** permission manifest (`permissions.yaml`) to the shared Access-Manager **Inversão de Responsabilidade (RI)** catalog in S3, **on release**.
+
+This is the **upstream half** of the RI: each service publishes exactly **one** object and the tenant-manager aggregates at **read time** by listing the prefix. There is **no merge / no aggregation** on write — one service overwrites only its own file. It is the release-time counterpart to [`permission-manifest-nudge`](../permission-manifest-nudge/README.md) (the PR reminder) and **reuses the same detection**, so the two always agree on what a manifest is.
+
+The action:
+
+1. **Scope gate** — identical to the nudge: only acts when `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. No `go.mod`, or an only-transitive (`// indirect`) dependency → `state=skip`.
+2. **Manifest presence** — globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and keeps only a file with top-level `service:` **and** `permissions:` keys. No qualifying manifest → `state=skip`.
+3. **Service name** — extracts the manifest's top-level `service:` value; that is the **S3 object basename**.
+4. **Publish** — `aws s3 cp <manifest> s3://<bucket>/<environment>/<prefix>/<service>.yaml --content-type application/yaml`. On `dry-run` it logs the exact target key + command and calls no AWS.
+
+> **Best-effort by contract.** Every path exits 0; an upload hiccup logs `::warning` (not a failure). AWS credentials are assumed by the **caller** job (mirroring the `go-release` `s3_upload` job) before this composite runs. Pair it with `continue-on-error: true` on the calling job so a publish hiccup can never gate a release.
+
+## S3 key layout
+
+Per-service, env-scoped — one object per service:
+
+```
+s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
+# e.g. s3://lerian-casdoor-init-data/development/permissions/br-sisbajud.yaml
+```
+
+`{environment}` (`development` | `staging` | `production`) is passed in by the caller, derived from the tag suffix exactly like the S3 upload job (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production). `{service}` is the manifest's `service:` value. The tenant-manager lists the `{environment}/{s3-prefix}/` prefix to aggregate every service's declaration.
+
+## Inputs
+
+| Input          | Description                                                                                     | Required | Default                      |
+|----------------|-------------------------------------------------------------------------------------------------|----------|------------------------------|
+| `environment`  | Resolved environment folder (`development` \| `staging` \| `production`), derived by the caller from the tag suffix. Empty → `skip`. | Yes      |                              |
+| `go-mod-path`  | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.               | No       | `go.mod`                     |
+| `s3-bucket`    | Target S3 bucket (without the `s3://` prefix). Same bucket as the Casdoor `init_data`.          | No       | `lerian-casdoor-init-data`   |
+| `s3-prefix`    | Prefix inside the environment folder — the key is `{environment}/{s3-prefix}/{service}.yaml`.   | No       | `permissions`                |
+| `aws-region`   | AWS region for the `aws s3 cp` call.                                                             | No       | `us-east-2`                  |
+| `github-token` | Optional. Reserved for future summary/annotation use; no PR side effects.                       | No       | `""`                         |
+| `dry-run`      | Preview mode. When `true`, logs the exact target key and `aws s3 cp` command WITHOUT calling AWS. | No       | `false`                      |
+
+## Outputs
+
+| Output    | Description                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------|
+| `state`   | `skip` (out of scope / no manifest / no environment / upload hiccup), `published` (uploaded), or `dryrun` (previewed). |
+| `service` | The `service:` value extracted from the manifest — the S3 object basename (empty when skipped). |
+| `s3_key`  | The full S3 object key it published (or would publish), e.g. `development/permissions/br-sisbajud.yaml`. |
+
+## Behavior matrix
+
+| Condition                                                     | Result                                                    |
+|---------------------------------------------------------------|-----------------------------------------------------------|
+| `go.mod` not found at `go-mod-path`                           | `skip` — `::notice`, no upload, exit 0                     |
+| `go.mod` has no **direct** `lib-auth` dependency              | `skip` — `::notice`, no upload, exit 0                     |
+| In scope + no qualifying `permissions.yaml`                   | `skip` — `::notice`, no upload, exit 0                     |
+| Manifest has an empty `service:` value                        | `skip` — `::warning`, no upload, exit 0                    |
+| `environment` empty (tag matched no env)                      | `skip` — `::warning`, no upload, exit 0                    |
+| In scope + manifest + `dry-run: true`                         | `dryrun` — logs target key + command, no AWS call, exit 0  |
+| In scope + manifest + real upload succeeds                    | `published` — `aws s3 cp`, `::notice` with the key, exit 0 |
+| Upload fails (AWS hiccup)                                      | `skip` — `::warning`, exit 0 (never fails the release)     |
+
+## Usage as composite step
+
+The **caller** assumes AWS credentials first (via OIDC), then invokes the composite:
+
+```yaml
+jobs:
+  permission-manifest-publish:
+    if: github.ref_type == 'tag'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    continue-on-error: true      # non-blocking by contract
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      # Derive the env folder from the tag suffix (beta→development, rc→staging, vX.Y.Z→production)
+      # ... then assume the casdoor-init-data-scoped role:
+      - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-publish@v1
+        with:
+          environment: development   # resolved from the tag
+```
+
+Most callers get this for free through the [`go-release`](../../../docs/go-release-workflow.md) umbrella (`run_manifest_publish`, default `true`), which handles the checkout, tag→folder derivation and role-assume for you.
+
+## Implementation notes
+
+- Pure Bash + the AWS CLI (pre-installed on the runners). No extra runtime required.
+- **Detection is copied verbatim from `permission-manifest-nudge`** (scope grep + `service:`/`permissions:` content check) so the nudge and the publisher never disagree on "what is a manifest". Keep them in sync if either changes.
+- One object per service, keyed by `service:` — a rename of the service creates a **new** object; the old key is not garbage-collected here.
+- Credentials are the caller's responsibility (as with the `s3_upload` job): the composite runs `aws s3 cp` against whatever role the caller assumed.

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -94,6 +94,15 @@ jobs:
 
 Most callers get this for free through the [`go-release`](../../../docs/go-release-workflow.md) umbrella (`run_manifest_publish`, default `true`), which handles the checkout, tag→folder derivation and role-assume for you.
 
+### Third-party actions
+
+The composite itself uses none — it is pure Bash + the AWS CLI. The two external actions above belong to the **caller** and are pinned by full commit SHA:
+
+| Action | Why |
+|--------|-----|
+| `actions/checkout` | Checks the repository out so the `permissions.yaml` manifest is present in the workspace for detection and upload. |
+| `aws-actions/configure-aws-credentials` | Obtains short-lived OIDC credentials for the `aws s3 cp` upload, assuming the bucket-scoped `AWS_INIT_DATA_ROLE_ARN` role — no long-lived keys. Skipped on a dry-run (no AWS call) and when the role secret is unset. |
+
 ## Implementation notes
 
 - Pure Bash + the AWS CLI (pre-installed on the runners). No extra runtime required.

--- a/src/validate/permission-manifest-publish/action.yml
+++ b/src/validate/permission-manifest-publish/action.yml
@@ -1,0 +1,185 @@
+name: Permission Manifest Publish (RI)
+description: |
+  Publishes a Go plugin/service's OWN permission manifest (`permissions.yaml`) to the
+  shared Access-Manager "Inversão de Responsabilidade" (RI) catalog in S3, ON RELEASE.
+
+  This is the UPSTREAM half of the RI: each service publishes exactly ONE object,
+  `s3://{bucket}/{environment}/{prefix}/{service}.yaml`, keyed by the `service:` value in
+  its manifest. There is NO aggregation — the tenant-manager aggregates at read time by
+  listing the prefix. One service overwrites only its own file.
+
+  Scope gate (identical to `permission-manifest-nudge`): only acts when the repo has a
+  DIRECT dependency on `github.com/LerianStudio/lib-auth` in go.mod AND ships a qualifying
+  `permissions.yaml` (top-level `service:` AND `permissions:` keys). Otherwise → state=skip.
+
+  Best-effort by contract: every step exits 0 and an upload hiccup logs `::warning` rather
+  than failing. AWS credentials are assumed by the CALLER job (mirroring the go-release
+  `s3_upload` job) before this composite runs; pair it with `continue-on-error: true` so a
+  publish hiccup can never gate the release.
+
+inputs:
+  github-token:
+    description: Optional token. Reserved for future summary/annotation use; no PR side effects.
+    required: false
+    default: ""
+  go-mod-path:
+    description: Path to go.mod (relative to repo root). Used only for the lib-auth scope gate.
+    required: false
+    default: "go.mod"
+  s3-bucket:
+    description: Target S3 bucket (without the s3:// prefix). Same bucket as the Casdoor init_data.
+    required: false
+    default: "lerian-casdoor-init-data"
+  s3-prefix:
+    description: Prefix inside the environment folder — the key is {environment}/{s3-prefix}/{service}.yaml.
+    required: false
+    default: "permissions"
+  aws-region:
+    description: AWS region for the aws s3 cp call.
+    required: false
+    default: "us-east-2"
+  environment:
+    description: Resolved environment folder (development|staging|production), derived by the caller from the tag suffix.
+    required: true
+  dry-run:
+    description: Preview mode. When true, logs the exact target key and aws s3 cp command WITHOUT calling AWS.
+    required: false
+    default: "false"
+
+outputs:
+  state:
+    description: "One of: skip (out of scope / no manifest / no environment), published (uploaded), dryrun (previewed)."
+    value: ${{ steps.publish.outputs.state }}
+  service:
+    description: "The service name extracted from the manifest — the S3 object basename."
+    value: ${{ steps.publish.outputs.service }}
+  s3_key:
+    description: "The full S3 object key it published (or would publish), e.g. development/permissions/br-sisbajud.yaml."
+    value: ${{ steps.publish.outputs.s3_key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect manifest and publish to the RI catalog
+      id: publish
+      shell: bash
+      env:
+        GO_MOD_PATH: ${{ inputs.go-mod-path }}
+        S3_BUCKET: ${{ inputs.s3-bucket }}
+        S3_PREFIX: ${{ inputs.s3-prefix }}
+        AWS_REGION: ${{ inputs.aws-region }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        # Best-effort by design: never `set -e`. Any internal hiccup degrades to a
+        # skip (state=skip) or a logged ::warning and exits 0 so publishing can never
+        # gate the release. The caller adds `continue-on-error: true` as a second net.
+        set -uo pipefail
+
+        emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
+
+        # Emit deterministic defaults so downstream `steps.publish.outputs.*` are never
+        # blank on an early exit.
+        emit service ""
+        emit s3_key ""
+
+        # ---------------------------------------------------------------------------
+        # 1. SCOPE GATE — identical to permission-manifest-nudge so the nudge and the
+        #    publisher agree on "what is in scope": a DIRECT github.com/LerianStudio/
+        #    lib-auth dependency in go.mod. No go.mod, or only a transitive/indirect
+        #    dependency, is out of scope (state=skip, no upload).
+        # ---------------------------------------------------------------------------
+        if [[ ! -f "${GO_MOD_PATH}" ]]; then
+          echo "::notice title=Permission manifest publish::No go.mod at '${GO_MOD_PATH}' — not a Go service, skipping."
+          emit state skip
+          exit 0
+        fi
+
+        # Match `github.com/LerianStudio/lib-auth` or `.../lib-auth/vN` as a whole module
+        # token, in both the block form (indented) and single-line `require` form, then
+        # exclude `// indirect` so only a DIRECT dependency counts.
+        if grep -E '^[[:space:]]*(require[[:space:]]+)?github\.com/LerianStudio/lib-auth(/v[0-9]+)?[[:space:]]' "${GO_MOD_PATH}" \
+             | grep -qv '// indirect'; then
+          echo "Scope gate: direct github.com/LerianStudio/lib-auth dependency found — repo is in scope."
+        else
+          echo "::notice title=Permission manifest publish::go.mod has no direct lib-auth dependency — out of scope, skipping."
+          emit state skip
+          exit 0
+        fi
+
+        # ---------------------------------------------------------------------------
+        # 2. MANIFEST PRESENCE — identical detection to the nudge: glob every
+        #    permissions.yaml (excluding vendor / node_modules / .git) and keep only a
+        #    file with top-level `service:` AND `permissions:` keys.
+        # ---------------------------------------------------------------------------
+        QUALIFYING=""
+        while IFS= read -r f; do
+          [[ -z "${f}" ]] && continue
+          if grep -qE '^service:[[:space:]]*' "${f}" 2>/dev/null \
+             && grep -qE '^permissions:[[:space:]]*' "${f}" 2>/dev/null; then
+            QUALIFYING="${f}"
+            break
+          fi
+        done < <(find . -type f -name 'permissions.yaml' \
+                   -not -path '*/vendor/*' \
+                   -not -path '*/node_modules/*' \
+                   -not -path '*/.git/*' 2>/dev/null)
+
+        if [[ -z "${QUALIFYING}" ]]; then
+          echo "::notice title=Permission manifest publish::No qualifying permissions.yaml manifest found — nothing to publish, skipping."
+          emit state skip
+          exit 0
+        fi
+        echo "Qualifying permission manifest found: ${QUALIFYING}"
+
+        # ---------------------------------------------------------------------------
+        # 3. SERVICE NAME — the `service:` value is the S3 object basename. Take the
+        #    first top-level `service:` line, strip the key, surrounding quotes, an
+        #    inline `# comment`, and whitespace.
+        # ---------------------------------------------------------------------------
+        SERVICE="$(grep -m1 -E '^service:[[:space:]]*' "${QUALIFYING}" \
+          | sed -E 's/^service:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^["'"'"']//; s/["'"'"']$//; s/[[:space:]]+$//')"
+        if [[ -z "${SERVICE}" ]]; then
+          echo "::warning title=Permission manifest publish::Manifest '${QUALIFYING}' has an empty service: value — skipping."
+          emit state skip
+          exit 0
+        fi
+        emit service "${SERVICE}"
+
+        # ---------------------------------------------------------------------------
+        # 4. ENVIRONMENT — the caller resolves it from the tag suffix (beta ->
+        #    development, rc -> staging, release -> production). An empty value means
+        #    the tag matched no environment: skip rather than write to the bucket root.
+        # ---------------------------------------------------------------------------
+        if [[ -z "${ENVIRONMENT}" ]]; then
+          echo "::warning title=Permission manifest publish::No environment resolved (tag matched none) — skipping."
+          emit state skip
+          exit 0
+        fi
+
+        S3_KEY="${ENVIRONMENT}/${S3_PREFIX}/${SERVICE}.yaml"
+        S3_URI="s3://${S3_BUCKET}/${S3_KEY}"
+        emit s3_key "${S3_KEY}"
+
+        # ---------------------------------------------------------------------------
+        # 5. PUBLISH — one object per service, overwriting only its own file. Dry-run
+        #    logs the exact target + command and stops before any AWS call. A real
+        #    upload failure logs ::warning (best-effort) and still exits 0.
+        # ---------------------------------------------------------------------------
+        if [[ "${DRY_RUN}" == "true" ]]; then
+          echo "::notice title=Permission manifest publish::[dry-run] would publish ${QUALIFYING#./} -> ${S3_URI}"
+          echo "  [dry-run] aws s3 cp ${QUALIFYING} ${S3_URI} --content-type application/yaml --region ${AWS_REGION}"
+          emit state dryrun
+          exit 0
+        fi
+
+        if aws s3 cp "${QUALIFYING}" "${S3_URI}" \
+             --content-type application/yaml \
+             --region "${AWS_REGION}"; then
+          echo "::notice title=Permission manifest publish::Published ${SERVICE} manifest to ${S3_KEY} (bucket ${S3_BUCKET})."
+          emit state published
+        else
+          echo "::warning title=Permission manifest publish::aws s3 cp to ${S3_URI} failed (non-blocking) — the release is unaffected."
+          emit state skip
+        fi
+        exit 0


### PR DESCRIPTION
## O quê

A metade **upstream** da Inversão de Responsabilidade (RI): cada plugin/serviço Go publica **o próprio** `permissions.yaml` no catálogo RI do S3 **no release**. O tenant-manager consome esse catálogo (PR [tenant-manager#462](https://github.com/LerianStudio/tenant-manager/pull/462)) pra materializar as permissions por-tenant.

Irmã da action `permission-manifest-nudge` (#661, já mergeada): reusa **verbatim** a detecção dela (glob `permissions.yaml` + scope-gate de lib-auth direto no go.mod + content-check `service:`/`permissions:`); o nudge **avisa** no PR, esta **publica** no release.

## Catálogo por-plugin, env-scoped

- **Um objeto por serviço**, sem agregação na escrita: `s3://lerian-casdoor-init-data/{env}/permissions/{service}.yaml`. Cada serviço sobrescreve só o próprio arquivo; o tenant-manager agrega **na leitura** listando o prefixo.
- `{env}` = `development|staging|production`, derivado do **sufixo da tag** (beta→development, rc→staging, release→production) — **exatamente** o padrão do job `s3_upload` que já existe neste workflow.
- `{service}` = o valor `service:` do manifesto (autoritativo), não o nome do repo.

## Como reusa o que já existe

- Detecção: copiada da `permission-manifest-nudge` (documentado que as duas têm que ficar em sync).
- AWS/OIDC + tag→FOLDER: o job novo copia o padrão do `s3_upload` (mesmo `configure-aws-credentials@v6.2.0` pinado, `id-token: write`, mesma derivação de env). Role = `AWS_INIT_DATA_ROLE_ARN` (a role escopada ao bucket casdoor-init-data, do exemplo no header do `s3-upload.yml`).

## Trigger + segurança

- **Só no release (tag push)**, nunca em PR. Novo job opt-in `permission_manifest_publish` no `go-release.yml`, gated por `run_manifest_publish` (default true).
- **Não-bloqueante:** `continue-on-error: true` no job + a action sempre sai 0 (out-of-scope / sem manifesto / env vazio → `state=skip`; hiccup de upload → `::warning`, release intacto). `dry-run` loga a key exata sem chamar a AWS.

## Arquivos

- `src/validate/permission-manifest-publish/action.yml` (novo) + README.
- `.github/workflows/go-release.yml` — input `run_manifest_publish` + secret `AWS_INIT_DATA_ROLE_ARN` (opcional) + job `permission_manifest_publish`.
- `docs/go-release-workflow.md` — linha do input/secret + seção "Permission manifest publish (RI)".

## Validação

`actionlint -shellcheck` limpo no go-release.yml + action; harness de shellcheck do repo, `composite-schema` (0 violações) e `readme-check` passam.

## Follow-ups (fora deste PR)

- A **role `AWS_INIT_DATA_ROLE_ARN`** precisa ter write no bucket `lerian-casdoor-init-data` e ser provida (secret) aos repos consumidores.
- GC de manifesto órfão (serviço decomissionado deixa `{service}.yaml` no S3) — gap conhecido, baixa prioridade.
- Rollout: os plugins passam a publicar conforme fazem release; o `overlay` mode do tenant-manager cobre o catálogo incompleto na transição.

Relacionado: RI / #3944 (lmap). Par do tenant-manager#462.
