### PR TITLE
fix(permission-manifest-publish): default region to sa-east-1 for the RI catalog bucket

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -689,7 +689,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
-          aws-region: us-east-2
+          aws-region: sa-east-1
 
       # ----------------- Publish manifest to the RI catalog -----------------
       # Publish when there are real creds, or preview when dry-running; otherwise

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -49,7 +49,7 @@ s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
 | `go-mod-path`  | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.               | No       | `go.mod`                     |
 | `s3-bucket`    | Target S3 bucket (without the `s3://` prefix). Same bucket as the Casdoor `init_data`.          | No       | `lerian-casdoor-init-data`   |
 | `s3-prefix`    | Prefix inside the environment folder — the key is `{environment}/{s3-prefix}/{service}.yaml`.   | No       | `permissions`                |
-| `aws-region`   | AWS region for the `aws s3 cp` call.                                                             | No       | `us-east-2`                  |
+| `aws-region`   | AWS region for the `aws s3 cp` call.                                                             | No       | `sa-east-1`                  |
 | `github-token` | Optional. Reserved for future summary/annotation use; no PR side effects.                       | No       | `""`                         |
 | `dry-run`      | Preview mode. When `true`, logs the exact target key and `aws s3 cp` command WITHOUT calling AWS. | No       | `false`                      |
 
@@ -103,7 +103,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
-          aws-region: us-east-2
+          aws-region: sa-east-1
 
       - uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-publish@v1
         with:

--- a/src/validate/permission-manifest-publish/action.yml
+++ b/src/validate/permission-manifest-publish/action.yml
@@ -41,7 +41,7 @@ inputs:
   aws-region:
     description: AWS region for the aws s3 cp call.
     required: false
-    default: "us-east-2"
+    default: "sa-east-1"
   environment:
     description: Resolved environment folder (development|staging|production), derived by the caller from the tag suffix.
     required: true

--- a/src/validate/permission-manifest-publish/test.py
+++ b/src/validate/permission-manifest-publish/test.py
@@ -12,6 +12,7 @@ exercise the real success / failure branches.
 """
 
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -333,6 +334,37 @@ class PublishEveryManifest(unittest.TestCase):
         self.assertEqual(out.get("state"), "skip")
         self.assertEqual(out.get("published_count"), "0")
         self.assertIn("::warning", result.stdout)
+
+
+class RegionConfiguration(unittest.TestCase):
+    """The RI catalog bucket lives in sa-east-1, so the publisher must target
+    that region. test.py runs the extracted bash body directly and injects
+    AWS_REGION itself, bypassing the Actions input-defaulting layer — so the
+    metadata default is asserted against action.yml text (guarding a silent
+    revert), while the caller-override passthrough is exercised end-to-end
+    through the dry-run command.
+    """
+
+    def test_action_default_region_is_sa_east_1(self):
+        # The `aws-region` input default is what every caller that omits the
+        # input inherits; it MUST be the bucket's real region (sa-east-1).
+        m = re.search(r'aws-region:.*?default:\s*"([^"]+)"', ACTION, re.DOTALL)
+        self.assertIsNotNone(m, "aws-region input default not found in action.yml")
+        self.assertEqual(m.group(1), "sa-east-1")
+
+    def test_explicit_region_override_passes_through(self):
+        # A caller-supplied region must reach the `aws s3 cp` command verbatim,
+        # never silently replaced by the default.
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "permissions.yaml": manifest("br-sisbajud"),
+            },
+            env_overrides={"AWS_REGION": "eu-west-1"},
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(out.get("state"), "dryrun")
+        self.assertIn("--region eu-west-1", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Change the publisher's default `aws-region` from `us-east-2` to **`sa-east-1`** in three places:

- `src/validate/permission-manifest-publish/action.yml` — the `aws-region` input default
- `.github/workflows/go-release.yml` — the **`permission_manifest_publish`** job's `configure-aws-credentials` (role `AWS_INIT_DATA_ROLE_ARN`)
- `src/validate/permission-manifest-publish/README.md` — inputs table + usage snippet

## Why

The RI catalog bucket `lerian-casdoor-init-data` lives in **sa-east-1** — confirmed in `lerian-internal-gitops` tenant-manager values (`CASDOOR_TEMPLATE_S3_REGION: sa-east-1`), the same bucket the tenant-manager reads from. With the old `us-east-2` default a release-time `aws s3 cp` would target the wrong region.

## Scope / safety

- The **migrations** job (`AWS_MIGRATIONS_ROLE_ARN`, go-release L538/545) is **NOT** touched — different role/bucket, stays `us-east-2`.
- `test.py`'s `AWS_REGION` is an arbitrary test-harness input to the dry-run stub (it doesn't assert the action default), so it's left as-is.

## Follow-up

Depends on the DevOps write-role provisioning (org secret `AWS_INIT_DATA_ROLE_ARN` + GitHub OIDC role, sa-east-1). A shared-workflows beta auto-cuts from `develop` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)