### PR TITLE
feat(release): cut v1.56.0 stable RI multi-manifest publisher + move floating v1

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -689,7 +689,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
-          aws-region: us-east-2
+          aws-region: sa-east-1
 
       # ----------------- Publish manifest to the RI catalog -----------------
       # Publish when there are real creds, or preview when dry-running; otherwise

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -75,6 +75,21 @@ jobs:
       - name: Run breaking-change workflow integration tests
         run: python3 src/validate/breaking-change-guard/test-workflow.py
 
+  # ----------------- Permission Manifest Publish Tests -----------------
+  permission-manifest-publish-tests:
+    name: Permission Manifest Publish Tests
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run permission-manifest-publish behavioural tests
+        run: python3 src/validate/permission-manifest-publish/test.py
+
   # ----------------- YAML Lint -----------------
   yamllint:
     name: YAML Lint

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -7,27 +7,39 @@
 
 Publishes a Go plugin/service's **own** permission manifest (`permissions.yaml`) to the shared Access-Manager **Inversão de Responsabilidade (RI)** catalog in S3, **on release**.
 
-This is the **upstream half** of the RI: each service publishes exactly **one** object and the tenant-manager aggregates at **read time** by listing the prefix. There is **no merge / no aggregation** on write — one service overwrites only its own file. It is the release-time counterpart to [`permission-manifest-nudge`](../permission-manifest-nudge/README.md) (the PR reminder) and **reuses the same detection**, so the two always agree on what a manifest is.
+This is the **upstream half** of the RI: each **service identity** publishes exactly **one** object and the tenant-manager aggregates at **read time** by listing the prefix. There is **no merge / no aggregation** on write — one service overwrites only its own file. It is the release-time counterpart to [`permission-manifest-nudge`](../permission-manifest-nudge/README.md) (the PR reminder) and **reuses the same detection**, so the two always agree on what a manifest is.
+
+A repo may host **several** app identities. A monorepo like **midaz** ships four (`midaz`, `routing`, `plugin-fees`, `tracer`); `br-sfn` and `br-pix` are similar. Each qualifying `permissions.yaml` is published as its **own** S3 object keyed by its `service:` value — the action publishes **every** qualifying manifest, not just the first.
 
 The action:
 
 1. **Scope gate** — identical to the nudge: only acts when `go.mod` has a **direct** dependency on `github.com/LerianStudio/lib-auth`. No `go.mod`, or an only-transitive (`// indirect`) dependency → `state=skip`.
-2. **Manifest presence** — globs every `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and keeps only a file with top-level `service:` **and** `permissions:` keys. No qualifying manifest → `state=skip`.
-3. **Service name** — extracts the manifest's top-level `service:` value; that is the **S3 object basename**.
-4. **Publish** — `aws s3 cp <manifest> s3://<bucket>/<environment>/<prefix>/<service>.yaml --content-type application/yaml`. On `dry-run` it logs the exact target key + command and calls no AWS.
+2. **Manifest presence** — globs **every** `permissions.yaml` (excluding `vendor/`, `node_modules/`, `.git/`) and **collects** each file with top-level `service:` **and** `permissions:` keys (results are `sort`ed for a deterministic first-published). No qualifying manifest → `state=skip`.
+3. **Per-manifest publish** — for **each** collected manifest it extracts that manifest's own top-level `service:` value (the **S3 object basename**) and runs `aws s3 cp <manifest> s3://<bucket>/<environment>/<prefix>/<service>.yaml --content-type application/yaml`. On `dry-run` it logs the exact target key + command per manifest and calls no AWS.
+4. **Anti-clobber guard** — if two manifests declare the **same** `service:` value they would resolve to the same S3 key and overwrite each other. That is a real repo error: the action logs a **loud `::warning`** naming the service and the offending file and **skips the duplicate** (the first one still publishes) rather than silently picking one. Consistent with the best-effort contract, this never fails the release.
+
+> **Multiple identities, one object each.** A repo that hosts several app identities (like midaz) publishes one S3 object per `service:`.
+>
+> **Placement caveat.** Detection matches the **basename** `permissions.yaml` exactly, so each service's manifest must currently live in its **own directory** (e.g. `components/onboarding/permissions.yaml`, `components/transaction/permissions.yaml`). You **cannot** put `midaz.yaml` + `routing.yaml` side by side in one folder. Supporting multiple `service:` documents in a single multi-document YAML file is a possible **future** enhancement and is **not** implemented today.
 
 > **Best-effort by contract.** Every path exits 0; an upload hiccup logs `::warning` (not a failure). AWS credentials are assumed by the **caller** job (mirroring the `go-release` `s3_upload` job) before this composite runs. Pair it with `continue-on-error: true` on the calling job so a publish hiccup can never gate a release.
 
 ## S3 key layout
 
-Per-service, env-scoped — one object per service:
+Per-service, env-scoped — **one object per `service:` value**, and a repo publishes **N** of them (one per qualifying manifest):
 
 ```
 s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
-# e.g. s3://lerian-casdoor-init-data/development/permissions/br-sisbajud.yaml
+# single-identity repo:
+#   s3://lerian-casdoor-init-data/development/permissions/br-sisbajud.yaml
+# multi-identity monorepo (midaz), one object each:
+#   s3://lerian-casdoor-init-data/development/permissions/midaz.yaml
+#   s3://lerian-casdoor-init-data/development/permissions/routing.yaml
+#   s3://lerian-casdoor-init-data/development/permissions/plugin-fees.yaml
+#   s3://lerian-casdoor-init-data/development/permissions/tracer.yaml
 ```
 
-`{environment}` (`development` | `staging` | `production`) is passed in by the caller, derived from the tag suffix exactly like the S3 upload job (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production). `{service}` is the manifest's `service:` value. The tenant-manager lists the `{environment}/{s3-prefix}/` prefix to aggregate every service's declaration.
+`{environment}` (`development` | `staging` | `production`) is passed in by the caller, derived from the tag suffix exactly like the S3 upload job (`-beta` → development, `-rc` → staging, `vX.Y.Z` → production). `{service}` is each manifest's `service:` value. The tenant-manager lists the `{environment}/{s3-prefix}/` prefix to aggregate every service's declaration. Because the key is derived from `service:` (not the file path), each service's manifest must live in its **own directory** — see the placement caveat above.
 
 ## Inputs
 
@@ -43,11 +55,16 @@ s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
 
 ## Outputs
 
-| Output    | Description                                                                                  |
-|-----------|----------------------------------------------------------------------------------------------|
-| `state`   | `skip` (out of scope / no manifest / no environment / upload hiccup), `published` (uploaded), or `dryrun` (previewed). |
-| `service` | The `service:` value extracted from the manifest — the S3 object basename (empty when skipped). |
-| `s3_key`  | The full S3 object key it published (or would publish), e.g. `development/permissions/br-sisbajud.yaml`. |
+| Output            | Description                                                                                  |
+|-------------------|----------------------------------------------------------------------------------------------|
+| `state`           | `skip` (out of scope / no manifest / no environment / nothing landed), `published` (≥1 uploaded), or `dryrun` (≥1 previewed). |
+| `service`         | **Backward-compat.** The **first** published `service:` value — the S3 object basename (empty when skipped). See `services` for the full set. |
+| `s3_key`          | **Backward-compat.** The **first** published S3 object key, e.g. `development/permissions/midaz.yaml` (empty when skipped). See `s3_keys` for the full set. |
+| `services`        | Comma-separated list of **every** service published (or previewed), e.g. `midaz,routing,plugin-fees,tracer` (empty when skipped). |
+| `s3_keys`         | Comma-separated list of **every** S3 object key published (or previewed), e.g. `development/permissions/midaz.yaml,development/permissions/routing.yaml` (empty when skipped). |
+| `published_count` | How many manifests were published (or, on dry-run, previewed). `0` when skipped. |
+
+> **Backward compatibility.** Existing consumers that read only `service` / `s3_key` keep working — those now carry the **first** published entry (the manifests are `sort`ed so "first" is deterministic). New consumers should prefer `services` / `s3_keys` / `published_count` to see the whole set.
 
 ## Behavior matrix
 
@@ -56,11 +73,12 @@ s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
 | `go.mod` not found at `go-mod-path`                           | `skip` — `::notice`, no upload, exit 0                     |
 | `go.mod` has no **direct** `lib-auth` dependency              | `skip` — `::notice`, no upload, exit 0                     |
 | In scope + no qualifying `permissions.yaml`                   | `skip` — `::notice`, no upload, exit 0                     |
-| Manifest has an empty `service:` value                        | `skip` — `::warning`, no upload, exit 0                    |
-| `environment` empty (tag matched no env)                      | `skip` — `::warning`, no upload, exit 0                    |
-| In scope + manifest + `dry-run: true`                         | `dryrun` — logs target key + command, no AWS call, exit 0  |
-| In scope + manifest + real upload succeeds                    | `published` — `aws s3 cp`, `::notice` with the key, exit 0 |
-| Upload fails (AWS hiccup)                                      | `skip` — `::warning`, exit 0 (never fails the release)     |
+| `environment` empty (tag matched no env)                      | `skip` — `::warning`, no upload, exit 0 (short-circuits the whole action) |
+| In scope + N manifests + `dry-run: true`                      | `dryrun` — logs one target key + command **per manifest**, no AWS call, exit 0 |
+| In scope + N manifests + real uploads succeed                 | `published` — one `aws s3 cp` per manifest, `::notice` per key + a summary, `published_count=N`, exit 0 |
+| A single manifest has an empty `service:` value               | that manifest is **skipped** (`::warning`); others still publish. All-empty → `skip` |
+| Two manifests declare the **same** `service:`                 | duplicate **skipped** with a loud `::warning`; the first still publishes (anti-clobber) |
+| One manifest's upload fails (AWS hiccup)                       | that manifest `::warning`, not counted; others still publish; all-fail → `skip` — exit 0 (never fails the release) |
 
 ## Usage as composite step
 
@@ -106,6 +124,8 @@ The composite itself uses none — it is pure Bash + the AWS CLI. The two extern
 ## Implementation notes
 
 - Pure Bash + the AWS CLI (pre-installed on the runners). No extra runtime required.
-- **Detection is copied verbatim from `permission-manifest-nudge`** (scope grep + `service:`/`permissions:` content check) so the nudge and the publisher never disagree on "what is a manifest". Keep them in sync if either changes.
-- One object per service, keyed by `service:` — a rename of the service creates a **new** object; the old key is not garbage-collected here.
+- **Detection is copied verbatim from `permission-manifest-nudge`** (scope grep + `service:`/`permissions:` content check) so the nudge and the publisher never disagree on "what is a manifest". Keep them in sync if either changes. (The nudge only needs a yes/no answer so it stops at the first match; the publisher **collects them all**, but the qualifying grep is identical.)
+- **One object per `service:`, N per repo** — the action iterates over every qualifying manifest. A rename of a service creates a **new** object; the old key is not garbage-collected here. Two manifests with the same `service:` collide and the duplicate is skipped with a `::warning`.
+- **Placement**: matching is on the basename `permissions.yaml`, so co-locating two services' manifests in one directory is not supported today — give each service its own directory. A single multi-document YAML per repo is a possible future enhancement (not implemented).
 - Credentials are the caller's responsibility (as with the `s3_upload` job): the composite runs `aws s3 cp` against whatever role the caller assumed.
+- **Tests**: `test.py` (Python `unittest`, run in CI by `self-pr-validation.yml`) extracts the embedded `run:` block and exercises it in throwaway workspaces via dry-run (and a stubbed `aws` for the real success/failure branches): multi-manifest publish, duplicate-service collision, single manifest, and the skip cases.

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -49,7 +49,7 @@ s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
 | `go-mod-path`  | Path to `go.mod` (relative to repo root). Used only for the lib-auth scope gate.               | No       | `go.mod`                     |
 | `s3-bucket`    | Target S3 bucket (without the `s3://` prefix). Same bucket as the Casdoor `init_data`.          | No       | `lerian-casdoor-init-data`   |
 | `s3-prefix`    | Prefix inside the environment folder — the key is `{environment}/{s3-prefix}/{service}.yaml`.   | No       | `permissions`                |
-| `aws-region`   | AWS region for the `aws s3 cp` call.                                                             | No       | `us-east-2`                  |
+| `aws-region`   | AWS region for the `aws s3 cp` call.                                                             | No       | `sa-east-1`                  |
 | `github-token` | Optional. Reserved for future summary/annotation use; no PR side effects.                       | No       | `""`                         |
 | `dry-run`      | Preview mode. When `true`, logs the exact target key and `aws s3 cp` command WITHOUT calling AWS. | No       | `false`                      |
 
@@ -103,7 +103,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_INIT_DATA_ROLE_ARN }}
-          aws-region: us-east-2
+          aws-region: sa-east-1
 
       - uses: LerianStudio/github-actions-shared-workflows/src/validate/permission-manifest-publish@v1
         with:

--- a/src/validate/permission-manifest-publish/README.md
+++ b/src/validate/permission-manifest-publish/README.md
@@ -21,14 +21,14 @@ The action:
 > **Multiple identities, one object each.** A repo that hosts several app identities (like midaz) publishes one S3 object per `service:`.
 >
 > **Placement caveat.** Detection matches the **basename** `permissions.yaml` exactly, so each service's manifest must currently live in its **own directory** (e.g. `components/onboarding/permissions.yaml`, `components/transaction/permissions.yaml`). You **cannot** put `midaz.yaml` + `routing.yaml` side by side in one folder. Supporting multiple `service:` documents in a single multi-document YAML file is a possible **future** enhancement and is **not** implemented today.
-
+>
 > **Best-effort by contract.** Every path exits 0; an upload hiccup logs `::warning` (not a failure). AWS credentials are assumed by the **caller** job (mirroring the `go-release` `s3_upload` job) before this composite runs. Pair it with `continue-on-error: true` on the calling job so a publish hiccup can never gate a release.
 
 ## S3 key layout
 
 Per-service, env-scoped — **one object per `service:` value**, and a repo publishes **N** of them (one per qualifying manifest):
 
-```
+```text
 s3://{s3-bucket}/{environment}/{s3-prefix}/{service}.yaml
 # single-identity repo:
 #   s3://lerian-casdoor-init-data/development/permissions/br-sisbajud.yaml

--- a/src/validate/permission-manifest-publish/action.yml
+++ b/src/validate/permission-manifest-publish/action.yml
@@ -41,7 +41,7 @@ inputs:
   aws-region:
     description: AWS region for the aws s3 cp call.
     required: false
-    default: "us-east-2"
+    default: "sa-east-1"
   environment:
     description: Resolved environment folder (development|staging|production), derived by the caller from the tag suffix.
     required: true

--- a/src/validate/permission-manifest-publish/action.yml
+++ b/src/validate/permission-manifest-publish/action.yml
@@ -3,10 +3,14 @@ description: |
   Publishes a Go plugin/service's OWN permission manifest (`permissions.yaml`) to the
   shared Access-Manager "Inversão de Responsabilidade" (RI) catalog in S3, ON RELEASE.
 
-  This is the UPSTREAM half of the RI: each service publishes exactly ONE object,
+  This is the UPSTREAM half of the RI: each service identity publishes ONE object,
   `s3://{bucket}/{environment}/{prefix}/{service}.yaml`, keyed by the `service:` value in
-  its manifest. There is NO aggregation — the tenant-manager aggregates at read time by
-  listing the prefix. One service overwrites only its own file.
+  its manifest. A repo publishes EVERY qualifying `permissions.yaml` — a monorepo that
+  hosts several identities (e.g. midaz -> midaz/routing/plugin-fees/tracer; br-sfn, br-pix
+  similar) yields one object per `service:`. There is NO aggregation on write — the
+  tenant-manager aggregates at read time by listing the prefix; each service overwrites
+  only its own file. Two manifests with the SAME `service:` are a collision: the duplicate
+  is skipped with a loud `::warning` (best-effort — never fails the release).
 
   Scope gate (identical to `permission-manifest-nudge`): only acts when the repo has a
   DIRECT dependency on `github.com/LerianStudio/lib-auth` in go.mod AND ships a qualifying
@@ -48,14 +52,23 @@ inputs:
 
 outputs:
   state:
-    description: "One of: skip (out of scope / no manifest / no environment), published (uploaded), dryrun (previewed)."
+    description: "One of: skip (out of scope / no manifest / no environment / nothing landed), published (>=1 uploaded), dryrun (>=1 previewed)."
     value: ${{ steps.publish.outputs.state }}
   service:
-    description: "The service name extracted from the manifest — the S3 object basename."
+    description: "Backward-compat: the FIRST published service name — the S3 object basename. Empty when skipped. See `services` for the full set."
     value: ${{ steps.publish.outputs.service }}
   s3_key:
-    description: "The full S3 object key it published (or would publish), e.g. development/permissions/br-sisbajud.yaml."
+    description: "Backward-compat: the FIRST published S3 object key, e.g. development/permissions/midaz.yaml. Empty when skipped. See `s3_keys` for the full set."
     value: ${{ steps.publish.outputs.s3_key }}
+  services:
+    description: "Comma-separated list of every service published (or previewed), e.g. `midaz,routing,plugin-fees,tracer`. Empty when skipped."
+    value: ${{ steps.publish.outputs.services }}
+  s3_keys:
+    description: "Comma-separated list of every S3 object key published (or previewed), e.g. `development/permissions/midaz.yaml,development/permissions/routing.yaml`. Empty when skipped."
+    value: ${{ steps.publish.outputs.s3_keys }}
+  published_count:
+    description: "How many manifests were published (or, on dry-run, previewed). 0 when skipped."
+    value: ${{ steps.publish.outputs.published_count }}
 
 runs:
   using: composite
@@ -82,6 +95,9 @@ runs:
         # blank on an early exit.
         emit service ""
         emit s3_key ""
+        emit services ""
+        emit s3_keys ""
+        emit published_count "0"
 
         # ---------------------------------------------------------------------------
         # 1. SCOPE GATE — identical to permission-manifest-nudge so the nudge and the
@@ -109,47 +125,40 @@ runs:
 
         # ---------------------------------------------------------------------------
         # 2. MANIFEST PRESENCE — identical detection to the nudge: glob every
-        #    permissions.yaml (excluding vendor / node_modules / .git) and keep only a
-        #    file with top-level `service:` AND `permissions:` keys.
+        #    permissions.yaml (excluding vendor / node_modules / .git) and COLLECT
+        #    every file with top-level `service:` AND `permissions:` keys. A monorepo
+        #    that hosts several app identities (e.g. midaz -> midaz/routing/plugin-fees/
+        #    tracer; br-sfn, br-pix similar) ships one qualifying manifest per identity,
+        #    and each is published on its own (section 4). Results are `sort`ed so the
+        #    first-published (the backward-compat scalar outputs) is deterministic.
+        #    NOTE: the qualifying grep below is copied VERBATIM from
+        #    permission-manifest-nudge — keep the two in agreement.
         # ---------------------------------------------------------------------------
-        QUALIFYING=""
+        QUALIFYING_MANIFESTS=()
         while IFS= read -r f; do
           [[ -z "${f}" ]] && continue
           if grep -qE '^service:[[:space:]]*' "${f}" 2>/dev/null \
              && grep -qE '^permissions:[[:space:]]*' "${f}" 2>/dev/null; then
-            QUALIFYING="${f}"
-            break
+            QUALIFYING_MANIFESTS+=("${f}")
           fi
         done < <(find . -type f -name 'permissions.yaml' \
                    -not -path '*/vendor/*' \
                    -not -path '*/node_modules/*' \
-                   -not -path '*/.git/*' 2>/dev/null)
+                   -not -path '*/.git/*' 2>/dev/null | sort)
 
-        if [[ -z "${QUALIFYING}" ]]; then
+        if [[ ${#QUALIFYING_MANIFESTS[@]} -eq 0 ]]; then
           echo "::notice title=Permission manifest publish::No qualifying permissions.yaml manifest found — nothing to publish, skipping."
           emit state skip
           exit 0
         fi
-        echo "Qualifying permission manifest found: ${QUALIFYING}"
+        echo "Qualifying permission manifest(s) found: ${#QUALIFYING_MANIFESTS[@]}"
+        printf '  - %s\n' "${QUALIFYING_MANIFESTS[@]#./}"
 
         # ---------------------------------------------------------------------------
-        # 3. SERVICE NAME — the `service:` value is the S3 object basename. Take the
-        #    first top-level `service:` line, strip the key, surrounding quotes, an
-        #    inline `# comment`, and whitespace.
-        # ---------------------------------------------------------------------------
-        SERVICE="$(grep -m1 -E '^service:[[:space:]]*' "${QUALIFYING}" \
-          | sed -E 's/^service:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^["'"'"']//; s/["'"'"']$//; s/[[:space:]]+$//')"
-        if [[ -z "${SERVICE}" ]]; then
-          echo "::warning title=Permission manifest publish::Manifest '${QUALIFYING}' has an empty service: value — skipping."
-          emit state skip
-          exit 0
-        fi
-        emit service "${SERVICE}"
-
-        # ---------------------------------------------------------------------------
-        # 4. ENVIRONMENT — the caller resolves it from the tag suffix (beta ->
+        # 3. ENVIRONMENT — the caller resolves it from the tag suffix (beta ->
         #    development, rc -> staging, release -> production). An empty value means
-        #    the tag matched no environment: skip rather than write to the bucket root.
+        #    the tag matched no environment: skip the WHOLE action rather than write to
+        #    the bucket root. This short-circuits before any publish.
         # ---------------------------------------------------------------------------
         if [[ -z "${ENVIRONMENT}" ]]; then
           echo "::warning title=Permission manifest publish::No environment resolved (tag matched none) — skipping."
@@ -157,29 +166,106 @@ runs:
           exit 0
         fi
 
-        S3_KEY="${ENVIRONMENT}/${S3_PREFIX}/${SERVICE}.yaml"
-        S3_URI="s3://${S3_BUCKET}/${S3_KEY}"
-        emit s3_key "${S3_KEY}"
+        # ---------------------------------------------------------------------------
+        # 4. PUBLISH EVERY MANIFEST — one S3 object per `service:` value, each
+        #    overwriting only its own file. For each manifest: extract its OWN
+        #    `service:` value, guard an empty value, guard against two manifests that
+        #    declare the SAME service (a real collision — they would clobber each other
+        #    under one S3 key), then upload. Dry-run logs the target + command and calls
+        #    no AWS. A real upload failure logs ::warning (best-effort) and never fails
+        #    the release. `service`/`s3_key` keep their scalar first-published meaning
+        #    for backward compatibility; `services`/`s3_keys`/`published_count` describe
+        #    the full set (see section 5).
+        # ---------------------------------------------------------------------------
+        SEEN_LIST=""              # newline-delimited services already published this run
+        SERVICES_CSV=""           # comma-joined published service names
+        S3_KEYS_CSV=""            # comma-joined published S3 keys
+        PUBLISHED_COUNT=0
+        FIRST_SERVICE=""
+        FIRST_S3_KEY=""
+
+        # Membership test without bash-4 associative arrays (runners + local shells vary).
+        is_seen() {
+          case $'\n'"${SEEN_LIST}"$'\n' in
+            *$'\n'"$1"$'\n'*) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        for MANIFEST in "${QUALIFYING_MANIFESTS[@]}"; do
+          # 4a. SERVICE NAME — the `service:` value is the S3 object basename. Take the
+          #     first top-level `service:` line, strip the key, surrounding quotes, an
+          #     inline `# comment`, and whitespace (extraction unchanged from before).
+          SERVICE="$(grep -m1 -E '^service:[[:space:]]*' "${MANIFEST}" \
+            | sed -E 's/^service:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^["'"'"']//; s/["'"'"']$//; s/[[:space:]]+$//')"
+
+          if [[ -z "${SERVICE}" ]]; then
+            echo "::warning title=Permission manifest publish::Manifest '${MANIFEST#./}' has an empty service: value — skipping this manifest."
+            continue
+          fi
+
+          # 4b. ANTI-CLOBBER — two manifests with the same `service:` value resolve to
+          #     the SAME S3 key and would overwrite each other. That is a real repo
+          #     error; make it LOUD (::warning) and skip the duplicate rather than
+          #     silently pick one. Best-effort contract: warn + skip, never fail the
+          #     release. The first manifest for a given service still publishes.
+          if is_seen "${SERVICE}"; then
+            echo "::warning title=Permission manifest publish::Duplicate service '${SERVICE}' declared by '${MANIFEST#./}' — already published this run; skipping the duplicate to avoid clobbering ${ENVIRONMENT}/${S3_PREFIX}/${SERVICE}.yaml. Give each service a unique service: value."
+            continue
+          fi
+          SEEN_LIST="${SEEN_LIST}"$'\n'"${SERVICE}"
+
+          S3_KEY="${ENVIRONMENT}/${S3_PREFIX}/${SERVICE}.yaml"
+          S3_URI="s3://${S3_BUCKET}/${S3_KEY}"
+
+          # 4c. PUBLISH — dry-run previews; real upload is best-effort. On a real upload
+          #     failure, warn and move on (this manifest is NOT counted as published).
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "::notice title=Permission manifest publish::[dry-run] would publish ${MANIFEST#./} -> ${S3_URI}"
+            echo "  [dry-run] aws s3 cp ${MANIFEST} ${S3_URI} --content-type application/yaml --region ${AWS_REGION}"
+          elif aws s3 cp "${MANIFEST}" "${S3_URI}" \
+               --content-type application/yaml \
+               --region "${AWS_REGION}"; then
+            echo "::notice title=Permission manifest publish::Published ${SERVICE} manifest to ${S3_KEY} (bucket ${S3_BUCKET})."
+          else
+            echo "::warning title=Permission manifest publish::aws s3 cp to ${S3_URI} failed (non-blocking) — the release is unaffected."
+            continue
+          fi
+
+          # Record the publish (previewed or real) for the outputs.
+          PUBLISHED_COUNT=$((PUBLISHED_COUNT + 1))
+          if [[ -z "${FIRST_SERVICE}" ]]; then
+            FIRST_SERVICE="${SERVICE}"
+            FIRST_S3_KEY="${S3_KEY}"
+          fi
+          if [[ -z "${SERVICES_CSV}" ]]; then SERVICES_CSV="${SERVICE}"; else SERVICES_CSV="${SERVICES_CSV},${SERVICE}"; fi
+          if [[ -z "${S3_KEYS_CSV}" ]]; then S3_KEYS_CSV="${S3_KEY}"; else S3_KEYS_CSV="${S3_KEYS_CSV},${S3_KEY}"; fi
+        done
 
         # ---------------------------------------------------------------------------
-        # 5. PUBLISH — one object per service, overwriting only its own file. Dry-run
-        #    logs the exact target + command and stops before any AWS call. A real
-        #    upload failure logs ::warning (best-effort) and still exits 0.
+        # 5. OUTPUTS + STATE — scalar `service`/`s3_key` stay backward-compatible (the
+        #    FIRST published); `services`/`s3_keys` list every publish (comma-separated)
+        #    and `published_count` is how many objects landed (or were previewed).
+        #    state=published when >=1 real upload, dryrun when >=1 preview, else skip
+        #    (every qualifying manifest was empty-service, a duplicate, or failed).
         # ---------------------------------------------------------------------------
-        if [[ "${DRY_RUN}" == "true" ]]; then
-          echo "::notice title=Permission manifest publish::[dry-run] would publish ${QUALIFYING#./} -> ${S3_URI}"
-          echo "  [dry-run] aws s3 cp ${QUALIFYING} ${S3_URI} --content-type application/yaml --region ${AWS_REGION}"
-          emit state dryrun
+        emit service "${FIRST_SERVICE}"
+        emit s3_key "${FIRST_S3_KEY}"
+        emit services "${SERVICES_CSV}"
+        emit s3_keys "${S3_KEYS_CSV}"
+        emit published_count "${PUBLISHED_COUNT}"
+
+        if [[ "${PUBLISHED_COUNT}" -eq 0 ]]; then
+          echo "::notice title=Permission manifest publish::No manifest published (all qualifying manifests were empty-service, duplicate, or failed to upload) — skipping."
+          emit state skip
           exit 0
         fi
 
-        if aws s3 cp "${QUALIFYING}" "${S3_URI}" \
-             --content-type application/yaml \
-             --region "${AWS_REGION}"; then
-          echo "::notice title=Permission manifest publish::Published ${SERVICE} manifest to ${S3_KEY} (bucket ${S3_BUCKET})."
-          emit state published
+        if [[ "${DRY_RUN}" == "true" ]]; then
+          echo "::notice title=Permission manifest publish::[dry-run] previewed ${PUBLISHED_COUNT} manifest(s): ${S3_KEYS_CSV}"
+          emit state dryrun
         else
-          echo "::warning title=Permission manifest publish::aws s3 cp to ${S3_URI} failed (non-blocking) — the release is unaffected."
-          emit state skip
+          echo "::notice title=Permission manifest publish::Published ${PUBLISHED_COUNT} manifest(s): ${S3_KEYS_CSV} (bucket ${S3_BUCKET})."
+          emit state published
         fi
         exit 0

--- a/src/validate/permission-manifest-publish/test.py
+++ b/src/validate/permission-manifest-publish/test.py
@@ -12,6 +12,7 @@ exercise the real success / failure branches.
 """
 
 import os
+import re
 import stat
 import subprocess
 import tempfile
@@ -333,6 +334,37 @@ class PublishEveryManifest(unittest.TestCase):
         self.assertEqual(out.get("state"), "skip")
         self.assertEqual(out.get("published_count"), "0")
         self.assertIn("::warning", result.stdout)
+
+
+class RegionConfiguration(unittest.TestCase):
+    """The RI catalog bucket lives in sa-east-1, so the publisher must target
+    that region. test.py runs the extracted bash body directly and injects
+    AWS_REGION itself, bypassing the Actions input-defaulting layer — so the
+    metadata default is asserted against action.yml text (guarding a silent
+    revert), while the caller-override passthrough is exercised end-to-end
+    through the dry-run command.
+    """
+
+    def test_action_default_region_is_sa_east_1(self):
+        # The `aws-region` input default is what every caller that omits the
+        # input inherits; it MUST be the bucket's real region (sa-east-1).
+        m = re.search(r'aws-region:.*?default:\s*"([^"]+)"', ACTION, re.DOTALL)
+        self.assertIsNotNone(m, "aws-region input default not found in action.yml")
+        self.assertEqual(m.group(1), "sa-east-1")
+
+    def test_explicit_region_override_passes_through(self):
+        # A caller-supplied region must reach the `aws s3 cp` command verbatim,
+        # never silently replaced by the default.
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "permissions.yaml": manifest("br-sisbajud"),
+            },
+            env_overrides={"AWS_REGION": "eu-west-1"},
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(out.get("state"), "dryrun")
+        self.assertIn("--region eu-west-1", result.stdout)
 
 
 if __name__ == "__main__":

--- a/src/validate/permission-manifest-publish/test.py
+++ b/src/validate/permission-manifest-publish/test.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Behavioural tests for the permission-manifest-publish composite action.
+
+Mirrors the extract/execute/parse harness used by
+src/validate/breaking-change-guard/test-workflow.py: the embedded `run: |`
+script is pulled out of action.yml by step name, executed in a throwaway
+workspace with a controlled env, and its GITHUB_OUTPUT + stdout are asserted.
+
+All publish assertions run in dry-run (DRY_RUN=true) so no AWS call is made,
+except the two cases that deliberately stub a fake `aws` binary on PATH to
+exercise the real success / failure branches.
+"""
+
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ACTION_PATH = Path(__file__).resolve().parent / "action.yml"
+ACTION = ACTION_PATH.read_text(encoding="utf-8")
+
+STEP_NAME = "Detect manifest and publish to the RI catalog"
+
+# A go.mod with a DIRECT lib-auth dependency clears the scope gate.
+GO_MOD_IN_SCOPE = textwrap.dedent(
+    """\
+    module github.com/LerianStudio/example
+
+    go 1.26
+
+    require github.com/LerianStudio/lib-auth/v2 v2.0.0
+    """
+)
+
+# A go.mod with no lib-auth dependency is out of scope.
+GO_MOD_OUT_OF_SCOPE = textwrap.dedent(
+    """\
+    module github.com/LerianStudio/example
+
+    go 1.26
+
+    require github.com/LerianStudio/lib-commons/v5 v5.0.0
+    """
+)
+
+
+def manifest(service):
+    return textwrap.dedent(
+        f"""\
+        service: {service}
+        permissions:
+          - resource: account
+            actions: [read]
+        """
+    )
+
+
+def indentation(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_step(text, step_name):
+    lines = text.splitlines()
+    marker = f"- name: {step_name}"
+    for start, line in enumerate(lines):
+        if line.strip() == marker:
+            step_indent = indentation(line)
+            break
+    else:
+        raise AssertionError(f"step not found: {step_name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and indentation(line) <= step_indent:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def extract_run_body(text, step_name):
+    step = extract_step(text, step_name)
+    lines = step.splitlines()
+    for start, line in enumerate(lines):
+        if line.strip() == "run: |":
+            run_indent = indentation(line)
+            break
+    else:
+        raise AssertionError(f"run body not found for step: {step_name}")
+
+    body = []
+    for line in lines[start + 1:]:
+        if line.strip() and indentation(line) <= run_indent:
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body)).rstrip() + "\n"
+
+
+def parse_github_output(output):
+    values = {}
+    for line in output.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value  # last write wins, matching GitHub Actions
+    return values
+
+
+RUN_BODY = extract_run_body(ACTION, STEP_NAME)
+
+
+def write_fake_aws(bin_dir, exit_code):
+    """Drop a fake `aws` on PATH so the non-dry-run branches are deterministic."""
+    aws = bin_dir / "aws"
+    aws.write_text(f'#!/usr/bin/env bash\nexit {exit_code}\n', encoding="utf-8")
+    aws.chmod(aws.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_publish(files, env_overrides=None, fake_aws=None):
+    """Run the extracted publish script in a fresh workspace.
+
+    files: {relative_path: contents} written into the workspace.
+    env_overrides: extra/override env for the action.
+    fake_aws: None (rely on dry-run), or an int exit code for a stubbed `aws`.
+    Returns (CompletedProcess, outputs_dict).
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workspace = Path(temp_dir)
+        for rel, contents in files.items():
+            path = workspace / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(contents, encoding="utf-8")
+
+        output_path = workspace / "github-output"
+        output_path.write_text("", encoding="utf-8")
+
+        path_value = os.environ.get("PATH", "/usr/bin:/bin")
+        if fake_aws is not None:
+            bin_dir = workspace / ".fakebin"
+            bin_dir.mkdir()
+            write_fake_aws(bin_dir, fake_aws)
+            path_value = f"{bin_dir}:{path_value}"
+
+        env = {
+            "PATH": path_value,
+            "HOME": str(workspace),
+            "GITHUB_OUTPUT": str(output_path),
+            "GO_MOD_PATH": "go.mod",
+            "S3_BUCKET": "lerian-casdoor-init-data",
+            "S3_PREFIX": "permissions",
+            "AWS_REGION": "us-east-2",
+            "ENVIRONMENT": "development",
+            "DRY_RUN": "true",
+        }
+        if env_overrides:
+            env.update(env_overrides)
+
+        result = subprocess.run(
+            ["bash", "-c", RUN_BODY],
+            cwd=workspace,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        outputs = parse_github_output(output_path.read_text(encoding="utf-8"))
+        return result, outputs
+
+
+class PublishEveryManifest(unittest.TestCase):
+    def assertExitZero(self, result):
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"expected exit 0 (best-effort)\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    # (a) Two manifests in different dirs -> two publishes, correct per-service keys.
+    def test_two_manifests_publish_both(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "components/onboarding/permissions.yaml": manifest("midaz"),
+                "components/transaction/permissions.yaml": manifest("routing"),
+            }
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "dryrun")
+        self.assertEqual(out.get("published_count"), "2")
+        self.assertEqual(out.get("services"), "midaz,routing")
+        self.assertEqual(
+            out.get("s3_keys"),
+            "development/permissions/midaz.yaml,development/permissions/routing.yaml",
+        )
+        # Backward-compat scalars reflect the FIRST (sorted) publish.
+        self.assertEqual(out.get("service"), "midaz")
+        self.assertEqual(out.get("s3_key"), "development/permissions/midaz.yaml")
+        # Two distinct dry-run targets logged.
+        self.assertIn(
+            "would publish components/onboarding/permissions.yaml -> "
+            "s3://lerian-casdoor-init-data/development/permissions/midaz.yaml",
+            result.stdout,
+        )
+        self.assertIn(
+            "would publish components/transaction/permissions.yaml -> "
+            "s3://lerian-casdoor-init-data/development/permissions/routing.yaml",
+            result.stdout,
+        )
+
+    # (b) Duplicate service across two manifests -> loud collision, dup skipped.
+    def test_duplicate_service_is_loud_and_skipped(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "components/a/permissions.yaml": manifest("midaz"),
+                "components/b/permissions.yaml": manifest("midaz"),
+            }
+        )
+        self.assertExitZero(result)
+        # Only the first landed; the duplicate is not double-counted.
+        self.assertEqual(out.get("published_count"), "1")
+        self.assertEqual(out.get("services"), "midaz")
+        self.assertEqual(out.get("state"), "dryrun")
+        # Collision is visible in the log as a warning naming the service.
+        self.assertIn("::warning", result.stdout)
+        self.assertIn("Duplicate service 'midaz'", result.stdout)
+
+    # (c) Single manifest -> unchanged behavior + backward-compat scalars.
+    def test_single_manifest_unchanged(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "permissions.yaml": manifest("br-sisbajud"),
+            }
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "dryrun")
+        self.assertEqual(out.get("published_count"), "1")
+        self.assertEqual(out.get("service"), "br-sisbajud")
+        self.assertEqual(out.get("s3_key"), "development/permissions/br-sisbajud.yaml")
+        self.assertEqual(out.get("services"), "br-sisbajud")
+        self.assertEqual(out.get("s3_keys"), "development/permissions/br-sisbajud.yaml")
+
+    # (d) Zero qualifying manifests -> skip.
+    def test_zero_manifests_skip(self):
+        result, out = run_publish({"go.mod": GO_MOD_IN_SCOPE})
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "skip")
+        self.assertEqual(out.get("published_count"), "0")
+        self.assertEqual(out.get("service"), "")
+        self.assertEqual(out.get("services"), "")
+
+    def test_out_of_scope_no_lib_auth_skip(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_OUT_OF_SCOPE,
+                "permissions.yaml": manifest("midaz"),
+            }
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "skip")
+
+    def test_empty_environment_skips_before_publish(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "permissions.yaml": manifest("midaz"),
+            },
+            env_overrides={"ENVIRONMENT": ""},
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "skip")
+        self.assertEqual(out.get("published_count"), "0")
+
+    def test_empty_service_value_skipped(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "permissions.yaml": "service:\npermissions:\n  - resource: account\n",
+            }
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "skip")
+        self.assertEqual(out.get("published_count"), "0")
+
+    # Real (non-dry-run) success branch via a stubbed `aws` that exits 0.
+    def test_real_publish_success_two_manifests(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "components/a/permissions.yaml": manifest("midaz"),
+                "components/b/permissions.yaml": manifest("tracer"),
+            },
+            env_overrides={"DRY_RUN": "false"},
+            fake_aws=0,
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "published")
+        self.assertEqual(out.get("published_count"), "2")
+        self.assertEqual(out.get("services"), "midaz,tracer")
+
+    # Upload hiccup on every manifest -> best-effort skip, never fails the release.
+    def test_real_publish_all_fail_degrades_to_skip(self):
+        result, out = run_publish(
+            {
+                "go.mod": GO_MOD_IN_SCOPE,
+                "components/a/permissions.yaml": manifest("midaz"),
+                "components/b/permissions.yaml": manifest("tracer"),
+            },
+            env_overrides={"DRY_RUN": "false"},
+            fake_aws=1,
+        )
+        self.assertExitZero(result)
+        self.assertEqual(out.get("state"), "skip")
+        self.assertEqual(out.get("published_count"), "0")
+        self.assertIn("::warning", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/validate/permission-manifest-publish/test.py
+++ b/src/validate/permission-manifest-publish/test.py
@@ -136,6 +136,13 @@ def run_publish(files, env_overrides=None, fake_aws=None):
 
         output_path = workspace / "github-output"
         output_path.write_text("", encoding="utf-8")
+        # Provision GITHUB_ENV / GITHUB_STEP_SUMMARY too: if a future edit to the
+        # action appends to either, an unset var would be an ambiguous redirect and
+        # fail the assertions for the wrong reason. Point both at workspace files.
+        env_path = workspace / "github-env"
+        env_path.write_text("", encoding="utf-8")
+        summary_path = workspace / "github-step-summary"
+        summary_path.write_text("", encoding="utf-8")
 
         path_value = os.environ.get("PATH", "/usr/bin:/bin")
         if fake_aws is not None:
@@ -148,6 +155,8 @@ def run_publish(files, env_overrides=None, fake_aws=None):
             "PATH": path_value,
             "HOME": str(workspace),
             "GITHUB_OUTPUT": str(output_path),
+            "GITHUB_ENV": str(env_path),
+            "GITHUB_STEP_SUMMARY": str(summary_path),
             "GO_MOD_PATH": "go.mod",
             "S3_BUCKET": "lerian-casdoor-init-data",
             "S3_PREFIX": "permissions",
@@ -179,34 +188,38 @@ class PublishEveryManifest(unittest.TestCase):
         )
 
     # (a) Two manifests in different dirs -> two publishes, correct per-service keys.
+    #     Path order (components/a, components/z) is deliberately the REVERSE of
+    #     service-name order (zeta, alpha) so the assertions pin the sort key to the
+    #     manifest PATH, not the service name.
     def test_two_manifests_publish_both(self):
         result, out = run_publish(
             {
                 "go.mod": GO_MOD_IN_SCOPE,
-                "components/onboarding/permissions.yaml": manifest("midaz"),
-                "components/transaction/permissions.yaml": manifest("routing"),
+                "components/a/permissions.yaml": manifest("zeta"),
+                "components/z/permissions.yaml": manifest("alpha"),
             }
         )
         self.assertExitZero(result)
         self.assertEqual(out.get("state"), "dryrun")
         self.assertEqual(out.get("published_count"), "2")
-        self.assertEqual(out.get("services"), "midaz,routing")
+        # Ordered by PATH (components/a before components/z), NOT by service name.
+        self.assertEqual(out.get("services"), "zeta,alpha")
         self.assertEqual(
             out.get("s3_keys"),
-            "development/permissions/midaz.yaml,development/permissions/routing.yaml",
+            "development/permissions/zeta.yaml,development/permissions/alpha.yaml",
         )
-        # Backward-compat scalars reflect the FIRST (sorted) publish.
-        self.assertEqual(out.get("service"), "midaz")
-        self.assertEqual(out.get("s3_key"), "development/permissions/midaz.yaml")
+        # Backward-compat scalars reflect the FIRST (path-sorted) publish.
+        self.assertEqual(out.get("service"), "zeta")
+        self.assertEqual(out.get("s3_key"), "development/permissions/zeta.yaml")
         # Two distinct dry-run targets logged.
         self.assertIn(
-            "would publish components/onboarding/permissions.yaml -> "
-            "s3://lerian-casdoor-init-data/development/permissions/midaz.yaml",
+            "would publish components/a/permissions.yaml -> "
+            "s3://lerian-casdoor-init-data/development/permissions/zeta.yaml",
             result.stdout,
         )
         self.assertIn(
-            "would publish components/transaction/permissions.yaml -> "
-            "s3://lerian-casdoor-init-data/development/permissions/routing.yaml",
+            "would publish components/z/permissions.yaml -> "
+            "s3://lerian-casdoor-init-data/development/permissions/alpha.yaml",
             result.stdout,
         )
 
@@ -224,6 +237,9 @@ class PublishEveryManifest(unittest.TestCase):
         self.assertEqual(out.get("published_count"), "1")
         self.assertEqual(out.get("services"), "midaz")
         self.assertEqual(out.get("state"), "dryrun")
+        # Compat scalars must point at the ACCEPTED manifest, not the skipped dup.
+        self.assertEqual(out.get("service"), "midaz")
+        self.assertEqual(out.get("s3_key"), "development/permissions/midaz.yaml")
         # Collision is visible in the log as a warning naming the service.
         self.assertIn("::warning", result.stdout)
         self.assertIn("Duplicate service 'midaz'", result.stdout)


### PR DESCRIPTION
## Purpose

Promote `develop` → `main` to cut the next **stable** release (**v1.56.0**, from `v1.55.0`) and, on merge, **advance the floating `v1` major tag** (`enable_major_tag` is true on `main`).

## Why this matters (Access-Manager RI)

The stable cut is what actually **enables release-time publishing of permission manifests** for the RI rollout:

- **#673 — `permission-manifest-publish` multi-manifest loop** (`QUALIFYING_MANIFESTS`) is on `develop` but **not yet in any stable release**; `v1.55.0` predates it.
- Downstream repos invoke the composite via **`@v1`** (the floating major tag). Today `v1` → `39bec9c` (a commit **without** the loop), so even repos that pinned `go-release.yml@v1.56.0-beta.1` don't get multi-manifest behavior. **Merging this PR moves `v1`** to the new stable commit → the loop goes live for every `@v1` consumer.
- Net effect: monorepos (midaz = 3 identities, br-sfn = 10, plugin-br-pix-switch = 3) can publish **one S3 object per `service:`** instead of only the first.

## What's in the delta (`main..develop`)

- `feat: publish every service manifest, not just the first (#673)` + its review fixups + backmerge.

## On merge (automatic)

1. `semantic-release` cuts **v1.56.0** stable (feat → minor).
2. `update_major_tag` re-points **`v1`** at the new release.
3. `propagate-version` bumps the `@vX.Y.Z` pin in downstream repos listed in `config/version-propagation.yml` (currently `go-boilerplate-ddd` only).

## Notes for review

- A companion fix (**#675**, publisher default region → `sa-east-1`, the real bucket region) is landing on `develop`; since this is a `develop→main` PR it will **auto-include #675** if that merges before this one — no re-cut needed.
- CI on the org is currently intermittently red on GitHub `429` (codeload rate-limit) when downloading `actions/checkout` — transient, unrelated to the diff; re-run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)