### PR TITLE
feat(composites): add golangci-lint and lifecycle-management-publish composites

### DIFF
--- a/src/deploy/lifecycle-management-publish/README.md
+++ b/src/deploy/lifecycle-management-publish/README.md
@@ -1,0 +1,49 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>lifecycle-management-publish</h1></td>
+  </tr>
+</table>
+
+Composite action that registers a Helm chart release with Lerian's Plugin Lifecycle Management platform (Distr):
+
+1. Resolves the chart's Application ID from the `application-ids` mapping (`chart:id,chart:id,...`, typically `vars.APPLICATION_IDS`).
+2. Reads the release version from the newest `<chart-name>-vX.Y.Z` git tag. If none exists yet, the publish step is skipped (not failed) — useful right after a chart's first commit, before any tag exists.
+3. Publishes the version to the platform via [`glasskube/distr-create-version-action`](https://github.com/glasskube/distr-create-version-action). This step is best-effort (`continue-on-error: true`): a Lifecycle Management outage should not fail a chart release.
+
+Charts that should never be registered (library charts, third-party dependency wrappers) are the caller's decision — gate the step itself with an `if:`, this composite has no chart-name allowlist/denylist baked in.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `chart-name` | Helm chart name (e.g. `plugin-access-manager`). Must have a matching entry in `application-ids` | Yes | — |
+| `application-ids` | Application ID mappings in `chart:id[,chart:id...]` format (typically `vars.APPLICATION_IDS`) | Yes | — |
+| `lifecycle-api-token` | API token for the Plugin Lifecycle Management platform | Yes | — |
+| `working-directory` | Path to the chart directory (used to locate `values-template.yaml`) | Yes | — |
+| `api-base` | Plugin Lifecycle Management API base URL | No | `https://lifecycle.lerian.studio/api/v1` |
+
+## Usage as composite step
+
+```yaml
+- name: Publish Release in Plugin Lifecycle Management
+  if: github.ref == 'refs/heads/main'
+  uses: LerianStudio/github-actions-shared-workflows/src/deploy/lifecycle-management-publish@develop
+  with:
+    chart-name: ${{ matrix.chart.name }}
+    application-ids: ${{ vars.APPLICATION_IDS }}
+    lifecycle-api-token: ${{ secrets.LIFECYCLE_API_TOKEN }}
+    working-directory: ${{ matrix.chart.working_dir }}
+```
+
+## Adding a new chart
+
+1. Find the chart's **Application ID** in the Lifecycle Management (Distr) UI.
+2. Add `chart-name:application-id` to the caller repository's `APPLICATION_IDS` repository variable (comma-separated if more than one chart).
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read # reads git tags for version resolution
+```

--- a/src/deploy/lifecycle-management-publish/README.md
+++ b/src/deploy/lifecycle-management-publish/README.md
@@ -28,7 +28,7 @@ Charts that should never be registered (library charts, third-party dependency w
 ```yaml
 - name: Publish Release in Plugin Lifecycle Management
   if: github.ref == 'refs/heads/main'
-  uses: LerianStudio/github-actions-shared-workflows/src/deploy/lifecycle-management-publish@develop
+  uses: LerianStudio/github-actions-shared-workflows/src/deploy/lifecycle-management-publish@v1.x.x
   with:
     chart-name: ${{ matrix.chart.name }}
     application-ids: ${{ vars.APPLICATION_IDS }}

--- a/src/deploy/lifecycle-management-publish/action.yml
+++ b/src/deploy/lifecycle-management-publish/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: API token for the Plugin Lifecycle Management platform
     required: true
   working-directory:
-    description: Path to the chart directory (used to locate values-template.yaml and to derive the release tag)
+    description: Path to the chart directory (used to locate values-template.yaml)
     required: true
   api-base:
     description: Plugin Lifecycle Management API base URL
@@ -22,11 +22,13 @@ inputs:
 runs:
   using: composite
   steps:
+    # ----------------- Setup -----------------
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
       with:
         fetch-depth: 0
 
+    # ----------------- Resolve metadata -----------------
     - name: Resolve application ID for chart
       id: map-app-id
       shell: bash
@@ -34,7 +36,9 @@ runs:
         APP_IDS: ${{ inputs.application-ids }}
         CHART_NAME: ${{ inputs.chart-name }}
       run: |
-        APP_ID=$(echo "$APP_IDS" | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep "^${CHART_NAME}:" | cut -d':' -f2)
+        # awk (not grep) so a chart with no matching entry doesn't trip `pipefail`
+        # and abort the script before the empty-APP_ID check below runs.
+        APP_ID=$(printf '%s' "$APP_IDS" | tr ',' '\n' | sed 's/^[[:space:]]*//' | awk -F: -v chart="$CHART_NAME" '$1 == chart { print $2 }')
 
         if [ -z "$APP_ID" ]; then
           echo "::error::Application ID not found for chart: $CHART_NAME (check the application-ids mapping)"
@@ -66,12 +70,13 @@ runs:
       env:
         CHART_NAME: ${{ inputs.chart-name }}
       run: |
-        if [ "$CHART_NAME" = "plugin-access-manager" ]; then
+        if [ "$CHART_NAME" = "plugin-access-manager" ] || [ "$CHART_NAME" = "otel-collector-lerian" ]; then
           echo "chart_url=oci://registry-1.docker.io/lerianstudio/${CHART_NAME}" >> "$GITHUB_OUTPUT"
         else
           echo "chart_url=oci://registry-1.docker.io/lerianstudio/${CHART_NAME}-helm" >> "$GITHUB_OUTPUT"
         fi
 
+    # ----------------- Publish -----------------
     - name: Publish version to Plugin Lifecycle Management
       if: steps.release-version.outputs.version != ''
       uses: glasskube/distr-create-version-action@13a9244a46f3d9019f1e2a6c0063f88908fafff3 # v1.6.2

--- a/src/deploy/lifecycle-management-publish/action.yml
+++ b/src/deploy/lifecycle-management-publish/action.yml
@@ -1,0 +1,88 @@
+name: Lifecycle Management Publish
+description: Registers a Helm chart release version with Lerian's Plugin Lifecycle Management platform (Distr).
+
+inputs:
+  chart-name:
+    description: Helm chart name (e.g. `plugin-access-manager`). Must have a matching entry in application-ids
+    required: true
+  application-ids:
+    description: 'Application ID mappings in "chart:id[,chart:id...]" format (typically `vars.APPLICATION_IDS`)'
+    required: true
+  lifecycle-api-token:
+    description: API token for the Plugin Lifecycle Management platform
+    required: true
+  working-directory:
+    description: Path to the chart directory (used to locate values-template.yaml and to derive the release tag)
+    required: true
+  api-base:
+    description: Plugin Lifecycle Management API base URL
+    required: false
+    default: 'https://lifecycle.lerian.studio/api/v1'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      with:
+        fetch-depth: 0
+
+    - name: Resolve application ID for chart
+      id: map-app-id
+      shell: bash
+      env:
+        APP_IDS: ${{ inputs.application-ids }}
+        CHART_NAME: ${{ inputs.chart-name }}
+      run: |
+        APP_ID=$(echo "$APP_IDS" | tr ',' '\n' | sed 's/^[[:space:]]*//' | grep "^${CHART_NAME}:" | cut -d':' -f2)
+
+        if [ -z "$APP_ID" ]; then
+          echo "::error::Application ID not found for chart: $CHART_NAME (check the application-ids mapping)"
+          exit 1
+        fi
+
+        echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve release version from git tag
+      id: release-version
+      shell: bash
+      env:
+        CHART_NAME: ${{ inputs.chart-name }}
+      run: |
+        TAG=$(git tag --list "${CHART_NAME}-v*" | grep -E "${CHART_NAME}-v[0-9]+\.[0-9]+\.[0-9]+$" | sort -Vr | head -n 1)
+
+        if [ -z "$TAG" ]; then
+          echo "::warning::No release tag found matching ${CHART_NAME}-v*.*.* — skipping publish"
+          echo "version=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "version=${TAG#${CHART_NAME}-v}" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve OCI chart URL
+      id: chart-url
+      if: steps.release-version.outputs.version != ''
+      shell: bash
+      env:
+        CHART_NAME: ${{ inputs.chart-name }}
+      run: |
+        if [ "$CHART_NAME" = "plugin-access-manager" ]; then
+          echo "chart_url=oci://registry-1.docker.io/lerianstudio/${CHART_NAME}" >> "$GITHUB_OUTPUT"
+        else
+          echo "chart_url=oci://registry-1.docker.io/lerianstudio/${CHART_NAME}-helm" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Publish version to Plugin Lifecycle Management
+      if: steps.release-version.outputs.version != ''
+      uses: glasskube/distr-create-version-action@13a9244a46f3d9019f1e2a6c0063f88908fafff3 # v1.6.2
+      continue-on-error: true
+      with:
+        api-base: ${{ inputs.api-base }}
+        api-token: ${{ inputs.lifecycle-api-token }}
+        application-id: ${{ steps.map-app-id.outputs.app_id }}
+        version-name: ${{ steps.release-version.outputs.version }}
+        chart-type: 'oci'
+        chart-name: ${{ inputs.chart-name }}
+        chart-version: ${{ steps.release-version.outputs.version }}
+        chart-url: ${{ steps.chart-url.outputs.chart_url }}
+        template-file: '${{ inputs.working-directory }}/values-template.yaml'

--- a/src/lint/golangci-lint/README.md
+++ b/src/lint/golangci-lint/README.md
@@ -1,0 +1,67 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>golangci-lint</h1></td>
+  </tr>
+</table>
+
+Composite action that runs `golangci-lint` on a Go repository, branching on whether the triggering PR comes from a fork:
+
+- **Non-fork PRs**: lints via [`reviewdog/action-golangci-lint`](https://github.com/reviewdog/action-golangci-lint), posting inline PR review annotations authenticated with a GitHub App token (a fork's `GITHUB_TOKEN` cannot mint this).
+- **Fork PRs**: falls back to the plain [`golangci/golangci-lint-action`](https://github.com/golangci/golangci-lint-action), which only needs the default `GITHUB_TOKEN` and prints findings to the job log instead of PR comments.
+
+Supports private `LerianStudio/*` Go modules via `GOPRIVATE`/`.netrc`, configured from `manage-token`.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `lerian-studio-push-bot-app-id` | GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs | Yes | — |
+| `lerian-studio-push-bot-private-key` | GitHub App private key paired with `lerian-studio-push-bot-app-id` | Yes | — |
+| `lerian-ci-cd-user-gpg-key` | GPG private key for signing the reviewdog bot identity | Yes | — |
+| `lerian-ci-cd-user-gpg-key-password` | Passphrase for `lerian-ci-cd-user-gpg-key` | Yes | — |
+| `lerian-ci-cd-user-name` | Git author/committer name used for the reviewdog GPG identity | Yes | — |
+| `lerian-ci-cd-user-email` | Git author/committer email used for the reviewdog GPG identity | Yes | — |
+| `go-version` | Go version to set up before linting | No | `1.23` |
+| `golangci-lint-version` | golangci-lint version to run | No | `v1.64.8` |
+| `reviewdog-level` | Minimum reviewdog annotation level (non-fork PRs only) | No | `error` |
+| `fail-level` | Reviewdog level that fails the check (non-fork PRs only) | No | `any` |
+| `reporter` | Reviewdog reporter type (non-fork PRs only) | No | `github-pr-review` |
+| `filter-mode` | Reviewdog diff filter mode (non-fork PRs only) | No | `diff_context` |
+| `cache` | Enable golangci-lint caching (non-fork PRs only) | No | `false` |
+| `manage-token` | Token for `go mod download` access to private LerianStudio Go modules | No | — |
+
+## Usage as composite step
+
+```yaml
+name: Go Lint
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+jobs:
+  golangci-lint:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Run golangci-lint
+        uses: LerianStudio/github-actions-shared-workflows/src/lint/golangci-lint@develop
+        with:
+          lerian-studio-push-bot-app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
+          lerian-studio-push-bot-private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+          lerian-ci-cd-user-gpg-key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
+          lerian-ci-cd-user-gpg-key-password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
+          lerian-ci-cd-user-name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
+          lerian-ci-cd-user-email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
+          manage-token: ${{ secrets.MANAGE_TOKEN }}
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write # reviewdog PR review comments
+  checks: write         # reviewdog check annotations
+```

--- a/src/lint/golangci-lint/README.md
+++ b/src/lint/golangci-lint/README.md
@@ -16,12 +16,12 @@ Supports private `LerianStudio/*` Go modules via `GOPRIVATE`/`.netrc`, configure
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `lerian-studio-push-bot-app-id` | GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs | Yes | — |
-| `lerian-studio-push-bot-private-key` | GitHub App private key paired with `lerian-studio-push-bot-app-id` | Yes | — |
-| `lerian-ci-cd-user-gpg-key` | GPG private key for signing the reviewdog bot identity | Yes | — |
-| `lerian-ci-cd-user-gpg-key-password` | Passphrase for `lerian-ci-cd-user-gpg-key` | Yes | — |
-| `lerian-ci-cd-user-name` | Git author/committer name used for the reviewdog GPG identity | Yes | — |
-| `lerian-ci-cd-user-email` | Git author/committer email used for the reviewdog GPG identity | Yes | — |
+| `lerian-studio-push-bot-app-id` | GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs. Required only when the triggering PR is not a fork | No | `''` |
+| `lerian-studio-push-bot-private-key` | GitHub App private key paired with `lerian-studio-push-bot-app-id`. Required only when the triggering PR is not a fork | No | `''` |
+| `lerian-ci-cd-user-gpg-key` | GPG private key for signing the reviewdog bot identity. Required only when the triggering PR is not a fork | No | `''` |
+| `lerian-ci-cd-user-gpg-key-password` | Passphrase for `lerian-ci-cd-user-gpg-key`. Required only when the triggering PR is not a fork | No | `''` |
+| `lerian-ci-cd-user-name` | Git author/committer name used for the reviewdog GPG identity. Required only when the triggering PR is not a fork | No | `''` |
+| `lerian-ci-cd-user-email` | Git author/committer email used for the reviewdog GPG identity. Required only when the triggering PR is not a fork | No | `''` |
 | `go-version` | Go version to set up before linting | No | `1.23` |
 | `golangci-lint-version` | golangci-lint version to run | No | `v1.64.8` |
 | `reviewdog-level` | Minimum reviewdog annotation level (non-fork PRs only) | No | `error` |
@@ -29,7 +29,7 @@ Supports private `LerianStudio/*` Go modules via `GOPRIVATE`/`.netrc`, configure
 | `reporter` | Reviewdog reporter type (non-fork PRs only) | No | `github-pr-review` |
 | `filter-mode` | Reviewdog diff filter mode (non-fork PRs only) | No | `diff_context` |
 | `cache` | Enable golangci-lint caching (non-fork PRs only) | No | `false` |
-| `manage-token` | Token for `go mod download` access to private LerianStudio Go modules | No | — |
+| `manage-token` | Token for `go mod download` access to private LerianStudio Go modules | No | `''` |
 
 ## Usage as composite step
 

--- a/src/lint/golangci-lint/README.md
+++ b/src/lint/golangci-lint/README.md
@@ -46,7 +46,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Run golangci-lint
-        uses: LerianStudio/github-actions-shared-workflows/src/lint/golangci-lint@develop
+        uses: LerianStudio/github-actions-shared-workflows/src/lint/golangci-lint@v1.x.x
         with:
           lerian-studio-push-bot-app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           lerian-studio-push-bot-private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}

--- a/src/lint/golangci-lint/README.md
+++ b/src/lint/golangci-lint/README.md
@@ -10,7 +10,7 @@ Composite action that runs `golangci-lint` on a Go repository, branching on whet
 - **Non-fork PRs**: lints via [`reviewdog/action-golangci-lint`](https://github.com/reviewdog/action-golangci-lint), posting inline PR review annotations authenticated with a GitHub App token (a fork's `GITHUB_TOKEN` cannot mint this).
 - **Fork PRs**: falls back to the plain [`golangci/golangci-lint-action`](https://github.com/golangci/golangci-lint-action), which only needs the default `GITHUB_TOKEN` and prints findings to the job log instead of PR comments.
 
-Supports private `LerianStudio/*` Go modules via `GOPRIVATE`/`.netrc`, configured from `manage-token`.
+Supports private Go modules via `GOPRIVATE`/`.netrc`, configured from `manage-token` and `private-module-pattern` (defaults to `github.com/LerianStudio/*`).
 
 ## Inputs
 
@@ -30,6 +30,7 @@ Supports private `LerianStudio/*` Go modules via `GOPRIVATE`/`.netrc`, configure
 | `filter-mode` | Reviewdog diff filter mode (non-fork PRs only) | No | `diff_context` |
 | `cache` | Enable golangci-lint caching (non-fork PRs only) | No | `false` |
 | `manage-token` | Token for `go mod download` access to private LerianStudio Go modules | No | `''` |
+| `private-module-pattern` | GOPRIVATE/GONOSUMDB pattern for private Go modules | No | `github.com/LerianStudio/*` |
 
 ## Usage as composite step
 

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -89,8 +89,17 @@ runs:
         MANAGE_TOKEN: ${{ inputs.manage-token }}
         PRIVATE_MODULE_PATTERN: ${{ inputs.private-module-pattern }}
       run: |
-        echo "GOPRIVATE=${PRIVATE_MODULE_PATTERN}" >> "$GITHUB_ENV"
-        echo "GONOSUMDB=${PRIVATE_MODULE_PATTERN}" >> "$GITHUB_ENV"
+        # Multi-line-safe GITHUB_ENV write: PRIVATE_MODULE_PATTERN is caller-supplied
+        # and a naive `NAME=$value` line could inject extra env vars if it ever
+        # contained a newline.
+        delimiter="EOF_$(uuidgen)"
+        for name in GOPRIVATE GONOSUMDB; do
+          {
+            echo "${name}<<${delimiter}"
+            printf '%s\n' "$PRIVATE_MODULE_PATTERN"
+            echo "$delimiter"
+          } >> "$GITHUB_ENV"
+        done
         if [ -n "$MANAGE_TOKEN" ]; then
           # Never clobber a caller-owned ~/.netrc: back it up if one already
           # exists so the cleanup step can restore it instead of deleting it.

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -86,6 +86,14 @@ runs:
         echo "GOPRIVATE=github.com/LerianStudio/*" >> "$GITHUB_ENV"
         echo "GONOSUMDB=github.com/LerianStudio/*" >> "$GITHUB_ENV"
         if [ -n "$MANAGE_TOKEN" ]; then
+          # Never clobber a caller-owned ~/.netrc: back it up if one already
+          # exists so the cleanup step can restore it instead of deleting it.
+          if [ -f ~/.netrc ]; then
+            cp ~/.netrc "$RUNNER_TEMP/golangci-lint-netrc.bak"
+            echo "GOLANGCI_NETRC_BACKUP=$RUNNER_TEMP/golangci-lint-netrc.bak" >> "$GITHUB_ENV"
+          else
+            echo "GOLANGCI_NETRC_CREATED=true" >> "$GITHUB_ENV"
+          fi
           echo -e "machine github.com\nlogin oauth2\npassword ${MANAGE_TOKEN}" > ~/.netrc
           chmod 600 ~/.netrc
         fi
@@ -141,7 +149,12 @@ runs:
         version: ${{ inputs.golangci-lint-version }}
 
     # ----------------- Cleanup -----------------
-    - name: Remove persisted netrc credential
+    - name: Restore or remove netrc credential
       if: always()
       shell: bash
-      run: rm -f ~/.netrc
+      run: |
+        if [ -n "${GOLANGCI_NETRC_BACKUP:-}" ]; then
+          mv -f "$GOLANGCI_NETRC_BACKUP" ~/.netrc
+        elif [ "${GOLANGCI_NETRC_CREATED:-false}" = "true" ]; then
+          rm -f ~/.netrc
+        fi

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -3,23 +3,29 @@ description: Runs golangci-lint via reviewdog inline PR annotations on non-fork 
 
 inputs:
   lerian-studio-push-bot-app-id:
-    description: GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs
-    required: true
+    description: GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   lerian-studio-push-bot-private-key:
-    description: GitHub App private key paired with lerian-studio-push-bot-app-id
-    required: true
+    description: GitHub App private key paired with lerian-studio-push-bot-app-id. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   lerian-ci-cd-user-gpg-key:
-    description: GPG private key for signing the reviewdog bot identity
-    required: true
+    description: GPG private key for signing the reviewdog bot identity. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   lerian-ci-cd-user-gpg-key-password:
-    description: Passphrase for lerian-ci-cd-user-gpg-key
-    required: true
+    description: Passphrase for lerian-ci-cd-user-gpg-key. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   lerian-ci-cd-user-name:
-    description: Git author/committer name used for the reviewdog GPG identity
-    required: true
+    description: Git author/committer name used for the reviewdog GPG identity. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   lerian-ci-cd-user-email:
-    description: Git author/committer email used for the reviewdog GPG identity
-    required: true
+    description: Git author/committer email used for the reviewdog GPG identity. Only required when the triggering PR is not a fork
+    required: false
+    default: ''
   go-version:
     description: Go version to set up before linting
     required: false
@@ -58,15 +64,19 @@ runs:
   steps:
     # ----------------- Setup -----------------
     - name: Checkout repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setup Go
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
 
+    # ----------------- Non-Fork PRs (reviewdog annotations) -----------------
+    # manage-token / GOPRIVATE are only configured here — never on the fork path,
+    # so a fork PR's job can't read a persisted credential off disk.
     - name: Configure GOPRIVATE and .netrc for private modules
+      if: github.event.pull_request.head.repo.fork == false
       shell: bash
       env:
         MANAGE_TOKEN: ${{ inputs.manage-token }}
@@ -79,10 +89,10 @@ runs:
         fi
 
     - name: Download Go modules
+      if: github.event.pull_request.head.repo.fork == false
       shell: bash
       run: go mod download
 
-    # ----------------- Non-Fork PRs (reviewdog annotations) -----------------
     - name: Create GitHub App token
       if: github.event.pull_request.head.repo.fork == false
       id: app-token
@@ -126,4 +136,4 @@ runs:
       if: github.event.pull_request.head.repo.fork == true
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
-        version: latest
+        version: ${{ inputs.golangci-lint-version }}

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -65,6 +65,8 @@ runs:
     # ----------------- Setup -----------------
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -137,3 +139,9 @@ runs:
       uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         version: ${{ inputs.golangci-lint-version }}
+
+    # ----------------- Cleanup -----------------
+    - name: Remove persisted netrc credential
+      if: always()
+      shell: bash
+      run: rm -f ~/.netrc

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -79,6 +79,7 @@ runs:
     # so a fork PR's job can't read a persisted credential off disk.
     - name: Configure GOPRIVATE and .netrc for private modules
       if: github.event.pull_request.head.repo.fork == false
+      id: configure-netrc
       shell: bash
       env:
         MANAGE_TOKEN: ${{ inputs.manage-token }}
@@ -88,14 +89,16 @@ runs:
         if [ -n "$MANAGE_TOKEN" ]; then
           # Never clobber a caller-owned ~/.netrc: back it up if one already
           # exists so the cleanup step can restore it instead of deleting it.
-          if [ -f ~/.netrc ]; then
-            cp ~/.netrc "$RUNNER_TEMP/golangci-lint-netrc.bak"
-            echo "GOLANGCI_NETRC_BACKUP=$RUNNER_TEMP/golangci-lint-netrc.bak" >> "$GITHUB_ENV"
+          # Step outputs (not GITHUB_ENV) so this stays scoped to this one
+          # invocation and can't leak into a second call in the same job.
+          if [ -f "$HOME/.netrc" ]; then
+            cp -- "$HOME/.netrc" "$RUNNER_TEMP/golangci-lint-netrc.bak"
+            echo "netrc-backup=$RUNNER_TEMP/golangci-lint-netrc.bak" >> "$GITHUB_OUTPUT"
           else
-            echo "GOLANGCI_NETRC_CREATED=true" >> "$GITHUB_ENV"
+            echo "netrc-created=true" >> "$GITHUB_OUTPUT"
           fi
-          echo -e "machine github.com\nlogin oauth2\npassword ${MANAGE_TOKEN}" > ~/.netrc
-          chmod 600 ~/.netrc
+          echo -e "machine github.com\nlogin oauth2\npassword ${MANAGE_TOKEN}" > "$HOME/.netrc"
+          chmod 600 "$HOME/.netrc"
         fi
 
     - name: Download Go modules
@@ -152,9 +155,12 @@ runs:
     - name: Restore or remove netrc credential
       if: always()
       shell: bash
+      env:
+        NETRC_BACKUP: ${{ steps.configure-netrc.outputs.netrc-backup }}
+        NETRC_CREATED: ${{ steps.configure-netrc.outputs.netrc-created }}
       run: |
-        if [ -n "${GOLANGCI_NETRC_BACKUP:-}" ]; then
-          mv -f "$GOLANGCI_NETRC_BACKUP" ~/.netrc
-        elif [ "${GOLANGCI_NETRC_CREATED:-false}" = "true" ]; then
-          rm -f ~/.netrc
+        if [ -n "$NETRC_BACKUP" ]; then
+          mv -f -- "$NETRC_BACKUP" "$HOME/.netrc"
+        elif [ "$NETRC_CREATED" = "true" ]; then
+          rm -f -- "$HOME/.netrc"
         fi

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: Token for `go mod download` access to private LerianStudio Go modules
     required: false
     default: ''
+  private-module-pattern:
+    description: GOPRIVATE/GONOSUMDB pattern for private Go modules
+    required: false
+    default: 'github.com/LerianStudio/*'
 
 runs:
   using: composite
@@ -83,9 +87,10 @@ runs:
       shell: bash
       env:
         MANAGE_TOKEN: ${{ inputs.manage-token }}
+        PRIVATE_MODULE_PATTERN: ${{ inputs.private-module-pattern }}
       run: |
-        echo "GOPRIVATE=github.com/LerianStudio/*" >> "$GITHUB_ENV"
-        echo "GONOSUMDB=github.com/LerianStudio/*" >> "$GITHUB_ENV"
+        echo "GOPRIVATE=${PRIVATE_MODULE_PATTERN}" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=${PRIVATE_MODULE_PATTERN}" >> "$GITHUB_ENV"
         if [ -n "$MANAGE_TOKEN" ]; then
           # Never clobber a caller-owned ~/.netrc: back it up if one already
           # exists so the cleanup step can restore it instead of deleting it.

--- a/src/lint/golangci-lint/action.yml
+++ b/src/lint/golangci-lint/action.yml
@@ -1,0 +1,129 @@
+name: GolangCI-Lint
+description: Runs golangci-lint via reviewdog inline PR annotations on non-fork PRs, falling back to the plain golangci-lint-action on forks (which cannot receive a bot-authenticated reviewdog token).
+
+inputs:
+  lerian-studio-push-bot-app-id:
+    description: GitHub App ID used to authenticate reviewdog PR annotations on non-fork PRs
+    required: true
+  lerian-studio-push-bot-private-key:
+    description: GitHub App private key paired with lerian-studio-push-bot-app-id
+    required: true
+  lerian-ci-cd-user-gpg-key:
+    description: GPG private key for signing the reviewdog bot identity
+    required: true
+  lerian-ci-cd-user-gpg-key-password:
+    description: Passphrase for lerian-ci-cd-user-gpg-key
+    required: true
+  lerian-ci-cd-user-name:
+    description: Git author/committer name used for the reviewdog GPG identity
+    required: true
+  lerian-ci-cd-user-email:
+    description: Git author/committer email used for the reviewdog GPG identity
+    required: true
+  go-version:
+    description: Go version to set up before linting
+    required: false
+    default: '1.23'
+  golangci-lint-version:
+    description: golangci-lint version to run
+    required: false
+    default: 'v1.64.8'
+  reviewdog-level:
+    description: Minimum reviewdog annotation level (non-fork PRs only)
+    required: false
+    default: 'error'
+  fail-level:
+    description: Reviewdog level that fails the check (non-fork PRs only)
+    required: false
+    default: 'any'
+  reporter:
+    description: Reviewdog reporter type (non-fork PRs only)
+    required: false
+    default: 'github-pr-review'
+  filter-mode:
+    description: Reviewdog diff filter mode (non-fork PRs only)
+    required: false
+    default: 'diff_context'
+  cache:
+    description: Enable golangci-lint caching (non-fork PRs only)
+    required: false
+    default: 'false'
+  manage-token:
+    description: Token for `go mod download` access to private LerianStudio Go modules
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # ----------------- Setup -----------------
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+    - name: Setup Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: false
+
+    - name: Configure GOPRIVATE and .netrc for private modules
+      shell: bash
+      env:
+        MANAGE_TOKEN: ${{ inputs.manage-token }}
+      run: |
+        echo "GOPRIVATE=github.com/LerianStudio/*" >> "$GITHUB_ENV"
+        echo "GONOSUMDB=github.com/LerianStudio/*" >> "$GITHUB_ENV"
+        if [ -n "$MANAGE_TOKEN" ]; then
+          echo -e "machine github.com\nlogin oauth2\npassword ${MANAGE_TOKEN}" > ~/.netrc
+          chmod 600 ~/.netrc
+        fi
+
+    - name: Download Go modules
+      shell: bash
+      run: go mod download
+
+    # ----------------- Non-Fork PRs (reviewdog annotations) -----------------
+    - name: Create GitHub App token
+      if: github.event.pull_request.head.repo.fork == false
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        app-id: ${{ inputs.lerian-studio-push-bot-app-id }}
+        private-key: ${{ inputs.lerian-studio-push-bot-private-key }}
+
+    - name: Import GPG key
+      if: github.event.pull_request.head.repo.fork == false
+      uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+      with:
+        gpg_private_key: ${{ inputs.lerian-ci-cd-user-gpg-key }}
+        passphrase: ${{ inputs.lerian-ci-cd-user-gpg-key-password }}
+        git_committer_name: ${{ inputs.lerian-ci-cd-user-name }}
+        git_committer_email: ${{ inputs.lerian-ci-cd-user-email }}
+        git_config_global: true
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+
+    - name: Run golangci-lint via reviewdog
+      if: github.event.pull_request.head.repo.fork == false
+      uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
+      with:
+        go_version: ${{ inputs.go-version }}
+        tool_name: golint
+        level: ${{ inputs.reviewdog-level }}
+        fail_level: ${{ inputs.fail-level }}
+        reporter: ${{ inputs.reporter }}
+        filter_mode: ${{ inputs.filter-mode }}
+        golangci_lint_version: ${{ inputs.golangci-lint-version }}
+        reviewdog_github_api_token: ${{ steps.app-token.outputs.token }}
+        git_author_name: ${{ inputs.lerian-ci-cd-user-name }}
+        git_author_email: ${{ inputs.lerian-ci-cd-user-email }}
+        git_committer_name: ${{ inputs.lerian-ci-cd-user-name }}
+        git_committer_email: ${{ inputs.lerian-ci-cd-user-email }}
+        cache: ${{ inputs.cache }}
+
+    # ----------------- Fork PRs (no bot token available) -----------------
+    - name: Run golangci-lint (fork)
+      if: github.event.pull_request.head.repo.fork == true
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+      with:
+        version: latest


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Adds two new composite actions as part of the org-wide consolidation of standalone `github-actions-*` repos into this monorepo:

- `src/lint/golangci-lint` — replaces `LerianStudio/github-actions-golangci-lint` (archived). Runs golangci-lint via reviewdog on non-fork PRs (bot-authenticated inline annotations) and falls back to plain `golangci-lint-action` on fork PRs. Preserves the original's private-module `GOPRIVATE`/`.netrc` support.
- `src/deploy/lifecycle-management-publish` — replaces `LerianStudio/github-actions-lifecycle-management` (still active, to be archived after callers migrate). Registers a Helm chart release with the Plugin Lifecycle Management (Distr) platform. Dropped the original's hardcoded `otel-collector-lerian` chart exemption — that's caller policy (the one live caller, `LerianStudio/helm`, already has its own generic exemption for library/dependency-wrapper charts at the call site).

Both composites pin third-party actions by commit SHA per this repo's security policy (the originals used mutable tags).

Live callers found for these two standalone repos (verified via recent workflow run history, not just `uses:` search):
- golangci-lint: `midaz-sdk-golang`, `lerian-sdk-golang`, `plugin-br-pix-switch` (via `github-actions-go-pipeline-template`)
- lifecycle-management: `LerianStudio/helm`

Caller migration and archiving the two standalone repos are follow-ups, not part of this PR.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Net-new composites; no existing workflow/composite is modified.

## Testing

- [x] YAML syntax validated locally (Ruby/PyYAML parse + a local run of the `composite-schema` lint rules against both `action.yml` files — 8 and 5 steps respectively, all input/kebab-case/reserved-prefix checks pass)
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values (mapped 1:1 against the archived standalone actions' input contracts)
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected (net-new files only)

**Caller repo / workflow run:** N/A yet — caller migration is a follow-up PR per repo.

## Related Issues

Part of the github-actions-* consolidation effort (no tracked issue number).