### PR TITLE
fix(go-pr-coverage-comment): reject stale runs before writing the comment

### DIFF
--- a/.github/workflows/go-pr-coverage-comment.yml
+++ b/.github/workflows/go-pr-coverage-comment.yml
@@ -92,21 +92,34 @@ jobs:
             const threshold = process.env.THRESHOLD;
             const baseDir = 'coverage-reports';
 
+            const { data: sourceRun } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: sourceRunId,
+            });
+
             // pull_requests is empty on github.event.workflow_run for fork PRs
             // (GitHub's documented behavior), so the PR is resolved from the
             // head commit instead — this API works for fork commits too.
+            // listPullRequestsAssociatedWithCommit doesn't guarantee ordering
+            // and the same commit SHA can be associated with more than one PR
+            // (e.g. a mirror/testing PR), so match on sourceRun's own head
+            // repo + branch and only proceed on an unambiguous single match —
+            // never guess with an .find(open) || [0] fallback.
             const { data: associatedPRs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: headSha,
             });
-            const targetPR = associatedPRs.find(pr => pr.state === 'open') || associatedPRs[0];
-            if (!targetPR) {
-              console.log(`No pull request associated with commit ${headSha}; nothing to comment.`);
+            const matchingPRs = associatedPRs.filter(pr =>
+              pr.head?.repo?.full_name === sourceRun.head_repository?.full_name &&
+              pr.head?.ref === sourceRun.head_branch);
+            if (matchingPRs.length !== 1) {
+              console.log(`::notice::Found ${matchingPRs.length} PR(s) matching commit ${headSha} on ${sourceRun.head_repository?.full_name}:${sourceRun.head_branch} (need exactly 1); nothing to comment.`);
               core.setOutput('has_comments', 'false');
               return;
             }
-            const prNumber = targetPR.number;
+            const prNumber = matchingPRs[0].number;
 
             if (dryRun) {
               console.log(`::notice::dry_run — pr_number=${prNumber} threshold=${threshold}%`);
@@ -121,24 +134,25 @@ jobs:
             // same fork branch already exists, so a delayed stale run can't
             // overwrite a fresher comment. Matched by head repo + head branch
             // rather than PR number, since list-runs results carry the same
-            // empty pull_requests gap for fork-originated runs.
-            const { data: sourceRun } = await github.rest.actions.getWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: sourceRunId,
-            });
-            const { data: { workflow_runs: candidateRuns } } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: sourceRun.workflow_id,
-              event: 'pull_request',
-              per_page: 20,
-            });
-            const latestForBranch = candidateRuns
-              .filter(run =>
+            // empty pull_requests gap for fork-originated runs. Runs come back
+            // newest-first, so the first match found while paginating IS the
+            // latest for this branch — sourceRun itself guarantees a match
+            // exists, bounding the scan to a sane number of pages.
+            let latestForBranch = null;
+            for (let page = 1; page <= 10 && !latestForBranch; page++) {
+              const { data: { workflow_runs: candidateRuns } } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: sourceRun.workflow_id,
+                event: 'pull_request',
+                per_page: 100,
+                page,
+              });
+              if (candidateRuns.length === 0) break;
+              latestForBranch = candidateRuns.find(run =>
                 run.head_repository?.full_name === sourceRun.head_repository?.full_name &&
-                run.head_branch === sourceRun.head_branch)
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+                run.head_branch === sourceRun.head_branch);
+            }
             if (latestForBranch && latestForBranch.id !== sourceRunId) {
               console.log(`::notice::Skipping — run ${sourceRunId} is stale; run ${latestForBranch.id} is the latest PR Validation run for this branch`);
               core.setOutput('has_comments', 'false');

--- a/.github/workflows/go-pr-coverage-comment.yml
+++ b/.github/workflows/go-pr-coverage-comment.yml
@@ -66,6 +66,7 @@ jobs:
         id: post
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
           PR_NUMBER: ${{ inputs.pr_number }}
           THRESHOLD: ${{ inputs.coverage_threshold }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -76,6 +77,7 @@ jobs:
             const path = require('path');
 
             const dryRun = process.env.DRY_RUN === 'true';
+            const sourceRunId = parseInt(process.env.SOURCE_RUN_ID, 10);
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             if (!Number.isInteger(prNumber) || prNumber <= 0) {
               core.setFailed(`Invalid pr_number input: ${JSON.stringify(process.env.PR_NUMBER)}`);
@@ -86,6 +88,35 @@ jobs:
 
             if (dryRun) {
               console.log(`::notice::dry_run — pr_number=${prNumber} threshold=${threshold}%`);
+            }
+
+            // Freshness guard: workflow_run delivery isn't strictly ordered
+            // (GitHub docs: "actual start time... can vary due to infrastructure
+            // factors"), and a caller's concurrency group only cancels a run
+            // that's still in flight when a newer one starts — it can't reject
+            // a late-delivered event for a run that finishes after everything
+            // else already settled. Skip if a newer PR Validation run for the
+            // same PR already exists, so a delayed stale run can't overwrite a
+            // fresher comment.
+            const { data: sourceRun } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: sourceRunId,
+            });
+            const { data: { workflow_runs: candidateRuns } } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: sourceRun.workflow_id,
+              event: 'pull_request',
+              per_page: 20,
+            });
+            const latestForPr = candidateRuns
+              .filter(run => (run.pull_requests || []).some(pr => pr.number === prNumber))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+            if (latestForPr && latestForPr.id !== sourceRunId) {
+              console.log(`::notice::Skipping — run ${sourceRunId} is stale; run ${latestForPr.id} is the latest PR Validation run for PR #${prNumber}`);
+              core.setOutput('has_comments', 'false');
+              return;
             }
 
             if (!fs.existsSync(baseDir)) {

--- a/.github/workflows/go-pr-coverage-comment.yml
+++ b/.github/workflows/go-pr-coverage-comment.yml
@@ -9,10 +9,12 @@ name: "Go PR Coverage Comment (fork fallback)"
 #
 # Callers wire this to a `workflow_run` trigger in their OWN repo (workflow_run
 # is not a fork-restricted event, so its GITHUB_TOKEN is write-scoped), passing
-# the analysis run's run_id and the PR number. This job never checks out the
-# PR's code — it only downloads the coverage-report-* artifacts the analysis
-# run already produced, so a fork PR's untrusted code never runs with a
-# write-scoped token.
+# the analysis run's run_id and its head commit SHA (not a PR number —
+# github.event.workflow_run.pull_requests is empty for fork-originated runs,
+# so the PR is resolved from the commit instead). This job never checks out
+# the PR's code — it only downloads the coverage-report-* artifacts the
+# analysis run already produced, so a fork PR's untrusted code never runs
+# with a write-scoped token.
 
 on:
   workflow_call:
@@ -21,8 +23,16 @@ on:
         description: 'run_id of the workflow run (the one that ran go-pr-analysis.yml) that produced the coverage-report-* artifacts'
         type: string
         required: true
-      pr_number:
-        description: 'Pull request number to comment on'
+      head_sha:
+        description: >-
+          Head commit SHA of the pull request to comment on (e.g.
+          github.event.workflow_run.head_sha). Used instead of a caller-supplied
+          PR number because github.event.workflow_run.pull_requests is
+          documented by GitHub to be empty when the run comes from a forked
+          repository — exactly the case this workflow exists for. The PR is
+          resolved server-side from the commit via the
+          "list pull requests associated with a commit" API, which works
+          for fork commits too.
         type: string
         required: true
       coverage_threshold:
@@ -67,7 +77,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
           THRESHOLD: ${{ inputs.coverage_threshold }}
           DRY_RUN: ${{ inputs.dry_run }}
         with:
@@ -78,13 +88,25 @@ jobs:
 
             const dryRun = process.env.DRY_RUN === 'true';
             const sourceRunId = parseInt(process.env.SOURCE_RUN_ID, 10);
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid pr_number input: ${JSON.stringify(process.env.PR_NUMBER)}`);
-              return;
-            }
+            const headSha = process.env.HEAD_SHA;
             const threshold = process.env.THRESHOLD;
             const baseDir = 'coverage-reports';
+
+            // pull_requests is empty on github.event.workflow_run for fork PRs
+            // (GitHub's documented behavior), so the PR is resolved from the
+            // head commit instead — this API works for fork commits too.
+            const { data: associatedPRs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+            const targetPR = associatedPRs.find(pr => pr.state === 'open') || associatedPRs[0];
+            if (!targetPR) {
+              console.log(`No pull request associated with commit ${headSha}; nothing to comment.`);
+              core.setOutput('has_comments', 'false');
+              return;
+            }
+            const prNumber = targetPR.number;
 
             if (dryRun) {
               console.log(`::notice::dry_run — pr_number=${prNumber} threshold=${threshold}%`);
@@ -95,9 +117,11 @@ jobs:
             // factors"), and a caller's concurrency group only cancels a run
             // that's still in flight when a newer one starts — it can't reject
             // a late-delivered event for a run that finishes after everything
-            // else already settled. Skip if a newer PR Validation run for the
-            // same PR already exists, so a delayed stale run can't overwrite a
-            // fresher comment.
+            // else already settled. Skip if a newer PR Validation run on the
+            // same fork branch already exists, so a delayed stale run can't
+            // overwrite a fresher comment. Matched by head repo + head branch
+            // rather than PR number, since list-runs results carry the same
+            // empty pull_requests gap for fork-originated runs.
             const { data: sourceRun } = await github.rest.actions.getWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -110,11 +134,13 @@ jobs:
               event: 'pull_request',
               per_page: 20,
             });
-            const latestForPr = candidateRuns
-              .filter(run => (run.pull_requests || []).some(pr => pr.number === prNumber))
+            const latestForBranch = candidateRuns
+              .filter(run =>
+                run.head_repository?.full_name === sourceRun.head_repository?.full_name &&
+                run.head_branch === sourceRun.head_branch)
               .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
-            if (latestForPr && latestForPr.id !== sourceRunId) {
-              console.log(`::notice::Skipping — run ${sourceRunId} is stale; run ${latestForPr.id} is the latest PR Validation run for PR #${prNumber}`);
+            if (latestForBranch && latestForBranch.id !== sourceRunId) {
+              console.log(`::notice::Skipping — run ${sourceRunId} is stale; run ${latestForBranch.id} is the latest PR Validation run for this branch`);
               core.setOutput('has_comments', 'false');
               return;
             }

--- a/.github/workflows/go-pr-coverage-comment.yml
+++ b/.github/workflows/go-pr-coverage-comment.yml
@@ -106,10 +106,11 @@ jobs:
             // (e.g. a mirror/testing PR), so match on sourceRun's own head
             // repo + branch and only proceed on an unambiguous single match —
             // never guess with an .find(open) || [0] fallback.
-            const { data: associatedPRs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            const associatedPRs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: headSha,
+              per_page: 100,
             });
             const matchingPRs = associatedPRs.filter(pr =>
               pr.head?.repo?.full_name === sourceRun.head_repository?.full_name &&
@@ -136,10 +137,13 @@ jobs:
             // rather than PR number, since list-runs results carry the same
             // empty pull_requests gap for fork-originated runs. Runs come back
             // newest-first, so the first match found while paginating IS the
-            // latest for this branch — sourceRun itself guarantees a match
-            // exists, bounding the scan to a sane number of pages.
+            // latest for this branch. sourceRun itself is a run of this exact
+            // workflow_id + event, so it's guaranteed to appear somewhere in
+            // this listing — the loop is bounded by its position, not by an
+            // arbitrary page cap (a fixed cap could stop before reaching a
+            // busy repo's genuinely-latest run for this branch).
             let latestForBranch = null;
-            for (let page = 1; page <= 10 && !latestForBranch; page++) {
+            for (let page = 1; !latestForBranch; page++) {
               const { data: { workflow_runs: candidateRuns } } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/docs/go-pr-coverage-comment.md
+++ b/docs/go-pr-coverage-comment.md
@@ -9,6 +9,8 @@ Reusable workflow that posts/updates the sticky coverage comment on a pull reque
 
 This workflow never checks out the PR's code — it only downloads the `coverage-report-*` artifacts the analysis run already produced, so a fork PR's untrusted code never runs with a write-scoped token.
 
+Before writing the comment, it checks whether `source_run_id` is still the latest analysis run for that PR and skips (no-op) if a newer one already exists — a caller's `workflow_run` events aren't guaranteed to arrive in order, so a delayed, stale run could otherwise overwrite a fresher comment.
+
 ## Wiring it up
 
 Callers wire this to a `workflow_run` trigger in **their own repository** (`workflow_run` is not a fork-restricted event, so its `GITHUB_TOKEN` is write-scoped):

--- a/docs/go-pr-coverage-comment.md
+++ b/docs/go-pr-coverage-comment.md
@@ -28,17 +28,19 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/go-pr-coverage-comment.yml@v1.0.0
     with:
       source_run_id: ${{ github.event.workflow_run.id }}
-      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
       coverage_threshold: 80
     secrets: inherit
 ```
+
+`pr_number` is deliberately not an input here: `github.event.workflow_run.pull_requests` is documented by GitHub to be empty when the run comes from a forked repository — exactly the case this workflow exists for. `head_sha` is always populated, and the workflow resolves the PR from it server-side via the "list pull requests associated with a commit" API.
 
 ## Inputs
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `source_run_id` | `run_id` of the workflow run (the one that ran `go-pr-analysis.yml`) that produced the `coverage-report-*` artifacts | Yes | — |
-| `pr_number` | Pull request number to comment on | Yes | — |
+| `head_sha` | Head commit SHA of the pull request to comment on (e.g. `github.event.workflow_run.head_sha`) | Yes | — |
 | `coverage_threshold` | Minimum coverage percentage required (0-100). Used only for the PASS/BELOW THRESHOLD label — must match the value passed to `go-pr-analysis.yml` for the same run | No | `80` |
 | `dry_run` | Preview the resolved comment(s) without creating or updating anything | No | `false` |
 


### PR DESCRIPTION
## Summary
- `go-pr-coverage-comment.yml` (added in #679) posts/updates a sticky coverage comment for fork PRs, gated on the caller's own `workflow_run`-scoped `concurrency` group.
- CodeRabbit review on `LerianStudio/midaz#2355` correctly pointed out that `cancel-in-progress: true` concurrency does not guarantee execution order — it only cancels a run that's still in flight when a newer one starts. `workflow_run` event delivery isn't strictly ordered (per GitHub's own docs: "the actual start time of a job or run can vary due to infrastructure factors"), so a delayed event for an *older* PR Validation run could still arrive and post *after* a newer run already finished and commented — overwriting the fresh comment with stale coverage numbers. The concurrency group can't catch that case because, by the time the stale run starts, nothing else is in flight to cancel it against.
- Added a freshness check in the "Post or update coverage comments" step: before writing anything, it looks up the latest `PR Validation`-equivalent run for the same branch and skips as a no-op if `source_run_id` isn't that latest run.
- **Live-test fix (commit c232b04):** running this against the actual fork PR that motivated all of this (`LerianStudio/midaz#2352`, via midaz#2355's `@develop`-tracking stub) failed with `Invalid pr_number input: ""`. Root cause: `github.event.workflow_run.pull_requests` is documented by GitHub to be **empty when the run comes from a forked repository** — exactly the case this workflow exists for, so no caller could ever supply a working `pr_number` that way. Replaced the `pr_number` input with `head_sha` (always populated regardless of fork status) and resolve the PR server-side via "list pull requests associated with a commit", which works for fork commits too. The freshness check had the same latent gap (list-runs results carry the same empty `pull_requests`), so it now matches candidate runs by `head_repository` + `head_branch` instead.

This is a breaking input-contract change (`pr_number` → `head_sha`) on a workflow added earlier this same day with no other known consumers yet, so making it now rather than patching around it seemed better than carrying a broken/unusable input forward.

## Context
Follow-up to #679, flagged during CodeRabbit review of `LerianStudio/midaz#2355`: https://github.com/LerianStudio/midaz/pull/2355#discussion_r3825204200

Confirmed broken via the real fork PR: https://github.com/LerianStudio/midaz/actions/runs/32416851883

## Test plan
- [x] Confirmed broken against a real fork-PR `workflow_run` event (empty `pr_number`) before the `head_sha` fix.
- [ ] Re-run against the same fork PR (#2352) after this merges to `develop` and confirm the sticky comment posts successfully.
- [ ] Confirm normal (non-stale) runs still post/update the comment as before.