### PR TITLE
fix(helm-upgrade-doc): raise curl --max-time 90s -> 180s

### DIFF
--- a/src/docs/helm-upgrade-doc/scripts/generate-doc.sh
+++ b/src/docs/helm-upgrade-doc/scripts/generate-doc.sh
@@ -113,7 +113,7 @@ if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
     --arg prompt "$PROMPT" \
     '{model: "claude-sonnet-4-6", max_tokens: 8000, messages: [{role: "user", content: $prompt}]}')
 
-  HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 90 --connect-timeout 10 \
+  HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 180 --connect-timeout 10 \
     -o /tmp/upgrade_doc_response.json \
     https://api.anthropic.com/v1/messages \
     -H "content-type: application/json" \
@@ -131,7 +131,7 @@ elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
     --arg prompt "$PROMPT" \
     '{model: $model, messages: [{role: "user", content: $prompt}], temperature: 0.3, max_tokens: 8000}')
 
-  HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 90 --connect-timeout 10 \
+  HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 180 --connect-timeout 10 \
     -o /tmp/upgrade_doc_response.json \
     https://openrouter.ai/api/v1/chat/completions \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- Investigated `LerianStudio/helm` workflow run [32596994164](https://github.com/LerianStudio/helm/actions/runs/32596994164) (`product-console-v4.0.0`) failing with `Process completed with exit code 28` (curl's `CURLE_OPERATION_TIMEDOUT`), and the same failure on [32500286766](https://github.com/LerianStudio/helm/actions/runs/32500286766) (`lerian-common-v2.0.0`).
- Both are **major** version bumps, which produce the largest prompts (fuller diffs + "Configuration Reference" section instructions). A prior successful major-bump run (`9.0.0`, run 32378103183) already took ~83s against the 90s ceiling — the budget was marginal even before any latency regression.
- `ANTHROPIC_API_KEY` has been unset in the org for at least the last several days (confirmed on an older successful run too) — the script already falls back to OpenRouter cleanly in that case, so this is unrelated to the timeout itself. Flagging it separately since restoring it may also help (direct Anthropic API vs. the OpenRouter proxy), but it isn't this PR's fix.

## Change
Raise `curl --max-time` from 90s to 180s on both the Anthropic and OpenRouter request paths in `generate-doc.sh`. A genuinely hung/dead request still fails (just after 180s instead of 90s) — this isn't hiding a real outage, it's giving headroom for large major-bump diffs.

## Test plan
- [x] `bash -n` syntax check
- [ ] Next major-version-bump release in a consumer repo (e.g. `LerianStudio/helm`) succeeds within the new budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)