### PR TITLE
feat(composites): add pre_terraform_command input to terraform-plan-apply

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -137,6 +137,7 @@ jobs:
           TERRAFORM_RESOURCE_NAME: ${{ inputs.terraform_resource_name }}
           VAR_FILE: ${{ inputs.var_file }}
           REPO_NAME: ${{ github.event.repository.name }}
+          PRE_TERRAFORM_COMMAND_SET: ${{ inputs.pre_terraform_command != '' }}
         run: |
           set -euo pipefail
           echo "::notice::DRY RUN — Terraform will only plan, never apply"
@@ -146,11 +147,20 @@ jobs:
           echo "  backend_bucket     : ${BACKEND_BUCKET}"
           echo "  backend_key        : ${ENVIRONMENT}/${REPO_NAME}/${TERRAFORM_RESOURCE_NAME}/terraform-state"
           echo "  var_file           : ${VAR_FILE:-<auto>}"
+          if [[ "${PRE_TERRAFORM_COMMAND_SET}" == "true" ]]; then
+            echo "  pre_terraform_command : set (not printed — may contain secrets)"
+          else
+            echo "  pre_terraform_command : unset"
+          fi
 
       - name: Pre-terraform build
         if: inputs.pre_terraform_command != ''
         shell: bash
-        run: ${{ inputs.pre_terraform_command }}
+        env:
+          PRE_TERRAFORM_COMMAND: ${{ inputs.pre_terraform_command }}
+        run: |
+          set -euo pipefail
+          bash -euo pipefail -c "$PRE_TERRAFORM_COMMAND"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Terraform Plan/Apply
         id: tf
-        uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@feat/terraform-pre-command
         with:
           working-directory: ${{ inputs.working_directory }}
           environment: ${{ inputs.environment }}
@@ -194,7 +194,7 @@ jobs:
       contents: read
     steps:
       - name: Slack Notification
-        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@feat/terraform-pre-command
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ needs.terraform.result }}

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -60,6 +60,10 @@ on:
         description: 'Explicit path to a tfvars file. Defaults to <working_directory>/tfvars/<environment>.tfvars when present'
         type: string
         default: ''
+      pre_terraform_command:
+        description: 'Optional shell command run in the repo root after checkout, before AWS auth and Terraform (e.g. building a Lambda deployment package referenced by the Terraform config).'
+        type: string
+        default: ''
       enable_slack_notify:
         description: 'Send a Slack notification with the pipeline result'
         type: boolean
@@ -142,6 +146,11 @@ jobs:
           echo "  backend_bucket     : ${BACKEND_BUCKET}"
           echo "  backend_key        : ${ENVIRONMENT}/${REPO_NAME}/${TERRAFORM_RESOURCE_NAME}/terraform-state"
           echo "  var_file           : ${VAR_FILE:-<auto>}"
+
+      - name: Pre-terraform build
+        if: inputs.pre_terraform_command != ''
+        shell: bash
+        run: ${{ inputs.pre_terraform_command }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Terraform Plan/Apply
         id: tf
-        uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@feat/terraform-pre-command
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@v1
         with:
           working-directory: ${{ inputs.working_directory }}
           environment: ${{ inputs.environment }}
@@ -194,7 +194,7 @@ jobs:
       contents: read
     steps:
       - name: Slack Notification
-        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@feat/terraform-pre-command
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ needs.terraform.result }}

--- a/docs/terraform-plan-apply.md
+++ b/docs/terraform-plan-apply.md
@@ -27,6 +27,7 @@ notifications. Replaces `LerianStudio/github-actions-terraform-pipeline-template
 | `backend_region` | AWS region of the state bucket and lock table | No | `us-east-2` |
 | `backend_dynamodb_table` | DynamoDB table used for state locking | No | `terraform-lock-state` |
 | `var_file` | Explicit tfvars path. Defaults to `<working_directory>/tfvars/<environment>.tfvars` when present | No | `''` |
+| `pre_terraform_command` | Shell command run in the repo root after checkout, before AWS auth and Terraform (e.g. building a Lambda deployment package the Terraform config references) | No | `''` |
 | `enable_slack_notify` | Send a Slack notification with the pipeline result | No | `true` |
 | `dry_run` | Force plan-only, even on a push event (never applies) | No | `false` |
 
@@ -90,10 +91,20 @@ jobs:
 
 The old composite also supported building a Lambda artifact first (`runtime:
 golang | python`, via `github-actions-go-lambda-module` /
-`github-actions-python-lambda-module`). That concern is out of scope for this
-workflow — if a caller needs it, build the Lambda artifact in a separate step
-(or job) before calling `terraform-plan-apply.yml`, or use `go-lambda-release.yml`
-for Go Lambdas.
+`github-actions-python-lambda-module`). Replicate that with `pre_terraform_command`
+— it runs in the same job, after checkout and before Terraform, so any file it
+produces (e.g. a `function.zip` a `data`/`filebase64sha256(...)` reads at plan
+time) is present when Terraform runs. It must run in the same job as Terraform
+— a separate job would checkout on a different runner and lose the build output.
+
+```yaml
+with:
+  pre_terraform_command: |
+    cd src/code
+    GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags lambda.norpc -o ../../build/bootstrap main.go
+    cd ../../build && zip function.zip bootstrap
+    mv function.zip ../src/terraform/infra
+```
 
 The old composite required a `service-github-token` input for the PR comment.
 This workflow uses the caller's ambient `GITHUB_TOKEN` instead (granted

--- a/docs/terraform-plan-apply.md
+++ b/docs/terraform-plan-apply.md
@@ -89,22 +89,27 @@ jobs:
 
 ## Migrating from `github-actions-terraform-pipeline-template`
 
-The old composite also supported building a Lambda artifact first (`runtime:
-golang | python`, via `github-actions-go-lambda-module` /
-`github-actions-python-lambda-module`). Replicate that with `pre_terraform_command`
-— it runs in the same job, after checkout and before Terraform, so any file it
-produces (e.g. a `function.zip` a `data`/`filebase64sha256(...)` reads at plan
-time) is present when Terraform runs. It must run in the same job as Terraform
-— a separate job would checkout on a different runner and lose the build output.
+The old composite also supported building a Go Lambda artifact first
+(`runtime: golang`, via `github-actions-go-lambda-module`). Replicate that with
+`pre_terraform_command` — it runs in the same job, after checkout and before
+Terraform, so any file it produces (e.g. a `function.zip` a
+`data`/`filebase64sha256(...)` reads at plan time) is present when Terraform
+runs. It must run in the same job as Terraform — a separate job would checkout
+on a different runner and lose the build output.
 
 ```yaml
 with:
   pre_terraform_command: |
+    mkdir -p build src/terraform/infra
     cd src/code
     GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags lambda.norpc -o ../../build/bootstrap main.go
     cd ../../build && zip function.zip bootstrap
     mv function.zip ../src/terraform/infra
 ```
+
+(The old template also had a `runtime: python` option via
+`github-actions-python-lambda-module`, but that action no longer exists and
+its only caller has been retired — not covered here.)
 
 The old composite required a `service-github-token` input for the PR comment.
 This workflow uses the caller's ambient `GITHUB_TOKEN` instead (granted


### PR DESCRIPTION
## Summary
- Adds `pre_terraform_command` (optional string) to `.github/workflows/terraform-plan-apply.yml` — runs in the repo root, after checkout, before AWS OIDC auth and Terraform.
- Documents the input and a migration recipe for `runtime: golang` callers of the old `github-actions-terraform-pipeline-template` (e.g. building a Lambda `function.zip` referenced by `filebase64sha256(...)` at plan time).

## Why
Testing the new `terraform-plan-apply.yml` against a real caller (`plugin-license-validate-go`) surfaced a gap: the old template built a Lambda artifact inline (`runtime: golang|python`) in the same job/runner as the Terraform steps, so the file was present on disk when Terraform ran. The new workflow has no equivalent hook. A separate job wouldn't work — it would checkout on a different runner and lose the build output — so this needs to run in the same job, which only the reusable workflow itself can do.

## Test plan
- [x] `actionlint` clean on the modified workflow
- [ ] Real caller validation: `plugin-license-validate-go` PR pinning `@feat/terraform-pre-command` to confirm the Lambda build + terraform plan actually work end-to-end (in progress, follow-up PR)