### PR TITLE
fix(release): develop to main

### DIFF
--- a/.github/workflows/go-pr-analysis.yml
+++ b/.github/workflows/go-pr-analysis.yml
@@ -330,7 +330,7 @@ jobs:
 
       - name: Upload Gosec SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           sarif_file: gosec-${{ matrix.app.name }}.sarif
           category: gosec-${{ matrix.app.name }}

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Gosec SARIF
         if: always() && inputs.upload_sarif
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           sarif_file: gosec-results.sarif
           category: gosec
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always() && inputs.upload_sarif
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+        uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -334,7 +334,7 @@ jobs:
 
       - name: Autobuild
         if: steps.codeql-config.outputs.skip != 'true'
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
 
       - name: Perform CodeQL Analysis
         if: steps.codeql-config.outputs.skip != 'true'

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -1,0 +1,182 @@
+name: "Terraform Plan/Apply"
+
+# Reusable Terraform plan/apply pipeline with AWS OIDC auth and Slack
+# notifications. Plans (and comments on the PR) on pull_request, applies on
+# push — unless dry_run forces plan-only.
+#
+# Example:
+#   uses: LerianStudio/github-actions-shared-workflows/.github/workflows/terraform-plan-apply.yml@v1.58.0
+#   with:
+#     aws_region: us-east-2
+#     environment: audit
+#     terraform_version: "1.9.8"
+#     working_directory: src/terraform/boundary-policy
+#     terraform_resource_name: boundary-policy
+#     backend_bucket: terraform-security-foundation
+#   secrets:
+#     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_GH_OICD_TERRAFORM_ROLE }}
+#     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+on:
+  workflow_call:
+    inputs:
+      runner_type:
+        description: 'Runner to use for the workflow'
+        type: string
+        default: 'blacksmith-4vcpu-ubuntu-2404'
+      aws_region:
+        description: 'AWS region to assume the OIDC role in'
+        type: string
+        required: true
+      environment:
+        description: 'Environment name (used in the backend state key and tfvars lookup)'
+        type: string
+        required: true
+      terraform_version:
+        description: 'Terraform version to install'
+        type: string
+        required: true
+      working_directory:
+        description: 'Path to the Terraform module, relative to the repo root'
+        type: string
+        required: true
+      terraform_resource_name:
+        description: 'Resource name segment used in the backend state key'
+        type: string
+        required: true
+      backend_bucket:
+        description: 'S3 bucket that stores the Terraform state'
+        type: string
+        required: true
+      backend_region:
+        description: 'AWS region of the state bucket and lock table'
+        type: string
+        default: 'us-east-2'
+      backend_dynamodb_table:
+        description: 'DynamoDB table used for state locking'
+        type: string
+        default: 'terraform-lock-state'
+      var_file:
+        description: 'Explicit path to a tfvars file. Defaults to <working_directory>/tfvars/<environment>.tfvars when present'
+        type: string
+        default: ''
+      enable_slack_notify:
+        description: 'Send a Slack notification with the pipeline result'
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Force plan-only, even on a push event (never applies)'
+        type: boolean
+        default: false
+    secrets:
+      AWS_ROLE_TO_ASSUME:
+        description: 'ARN of the IAM role to assume via OIDC'
+        required: true
+      SLACK_WEBHOOK_URL:
+        description: 'Slack webhook for pipeline notifications'
+        required: false
+    outputs:
+      has_plan:
+        description: 'true when mode=plan (a Terraform plan was executed)'
+        value: ${{ jobs.terraform.outputs.has_plan }}
+      has_apply:
+        description: 'true when mode=apply (a Terraform apply was executed)'
+        value: ${{ jobs.terraform.outputs.has_apply }}
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    outputs:
+      has_plan: ${{ steps.tf.outputs.has-plan }}
+      has_apply: ${{ steps.tf.outputs.has-apply }}
+    steps:
+      - name: Checkout (pull_request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Checkout (push)
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine mode
+        id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "pull_request" || "${DRY_RUN}" == "true" ]]; then
+            echo "mode=plan" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=apply" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dry run summary
+        if: inputs.dry_run
+        env:
+          MODE: ${{ steps.mode.outputs.mode }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          WORKING_DIRECTORY: ${{ inputs.working_directory }}
+          BACKEND_BUCKET: ${{ inputs.backend_bucket }}
+          TERRAFORM_RESOURCE_NAME: ${{ inputs.terraform_resource_name }}
+          VAR_FILE: ${{ inputs.var_file }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          echo "::notice::DRY RUN — Terraform will only plan, never apply"
+          echo "  mode               : ${MODE}"
+          echo "  environment        : ${ENVIRONMENT}"
+          echo "  working_directory  : ${WORKING_DIRECTORY}"
+          echo "  backend_bucket     : ${BACKEND_BUCKET}"
+          echo "  backend_key        : ${ENVIRONMENT}/${REPO_NAME}/${TERRAFORM_RESOURCE_NAME}/terraform-state"
+          echo "  var_file           : ${VAR_FILE:-<auto>}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ inputs.aws_region }}
+          role-session-name: GITHUB-OIDC-TERRAFORM
+
+      - name: Terraform Plan/Apply
+        id: tf
+        uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@v1
+        with:
+          working-directory: ${{ inputs.working_directory }}
+          environment: ${{ inputs.environment }}
+          terraform-version: ${{ inputs.terraform_version }}
+          mode: ${{ steps.mode.outputs.mode }}
+          backend-bucket: ${{ inputs.backend_bucket }}
+          backend-key: ${{ inputs.environment }}/${{ github.event.repository.name }}/${{ inputs.terraform_resource_name }}/terraform-state
+          backend-region: ${{ inputs.backend_region }}
+          backend-dynamodb-table: ${{ inputs.backend_dynamodb_table }}
+          var-file: ${{ inputs.var_file }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+
+  notify:
+    name: Notify
+    needs: terraform
+    if: always() && inputs.enable_slack_notify
+    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    permissions:
+      contents: read
+    steps:
+      - name: Slack Notification
+        uses: LerianStudio/github-actions-shared-workflows/src/notify/slack-notify@v1
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ needs.terraform.result }}
+          workflow-name: "Terraform Plan/Apply (${{ inputs.environment }})"

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -60,6 +60,10 @@ on:
         description: 'Explicit path to a tfvars file. Defaults to <working_directory>/tfvars/<environment>.tfvars when present'
         type: string
         default: ''
+      pre_terraform_command:
+        description: 'Optional shell command run in the repo root after checkout, before AWS auth and Terraform (e.g. building a Lambda deployment package referenced by the Terraform config).'
+        type: string
+        default: ''
       enable_slack_notify:
         description: 'Send a Slack notification with the pipeline result'
         type: boolean
@@ -133,6 +137,7 @@ jobs:
           TERRAFORM_RESOURCE_NAME: ${{ inputs.terraform_resource_name }}
           VAR_FILE: ${{ inputs.var_file }}
           REPO_NAME: ${{ github.event.repository.name }}
+          PRE_TERRAFORM_COMMAND_SET: ${{ inputs.pre_terraform_command != '' }}
         run: |
           set -euo pipefail
           echo "::notice::DRY RUN — Terraform will only plan, never apply"
@@ -142,6 +147,20 @@ jobs:
           echo "  backend_bucket     : ${BACKEND_BUCKET}"
           echo "  backend_key        : ${ENVIRONMENT}/${REPO_NAME}/${TERRAFORM_RESOURCE_NAME}/terraform-state"
           echo "  var_file           : ${VAR_FILE:-<auto>}"
+          if [[ "${PRE_TERRAFORM_COMMAND_SET}" == "true" ]]; then
+            echo "  pre_terraform_command : set (not printed — may contain secrets)"
+          else
+            echo "  pre_terraform_command : unset"
+          fi
+
+      - name: Pre-terraform build
+        if: inputs.pre_terraform_command != ''
+        shell: bash
+        env:
+          PRE_TERRAFORM_COMMAND: ${{ inputs.pre_terraform_command }}
+        run: |
+          set -euo pipefail
+          bash -euo pipefail -c "$PRE_TERRAFORM_COMMAND"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/docs/terraform-plan-apply.md
+++ b/docs/terraform-plan-apply.md
@@ -1,0 +1,101 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>terraform-plan-apply</h1></td>
+  </tr>
+</table>
+
+Reusable Terraform plan/apply pipeline with AWS OIDC authentication and Slack
+notifications. Replaces `LerianStudio/github-actions-terraform-pipeline-template`.
+
+- On `pull_request`: runs `fmt`/`init`/`validate`/`plan` and comments the plan
+  output on the PR.
+- On `push` with `dry_run: false` (the default): runs `fmt`/`init`/`validate`/`apply`.
+- `dry_run: true` forces plan-only on any event — it never applies, even on `push`.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `runner_type` | Runner to use for the workflow | No | `blacksmith-4vcpu-ubuntu-2404` |
+| `aws_region` | AWS region to assume the OIDC role in | Yes | - |
+| `environment` | Environment name (used in the backend state key and tfvars lookup) | Yes | - |
+| `terraform_version` | Terraform version to install | Yes | - |
+| `working_directory` | Path to the Terraform module, relative to the repo root | Yes | - |
+| `terraform_resource_name` | Resource name segment used in the backend state key | Yes | - |
+| `backend_bucket` | S3 bucket that stores the Terraform state | Yes | - |
+| `backend_region` | AWS region of the state bucket and lock table | No | `us-east-2` |
+| `backend_dynamodb_table` | DynamoDB table used for state locking | No | `terraform-lock-state` |
+| `var_file` | Explicit tfvars path. Defaults to `<working_directory>/tfvars/<environment>.tfvars` when present | No | `''` |
+| `enable_slack_notify` | Send a Slack notification with the pipeline result | No | `true` |
+| `dry_run` | Force plan-only, even on a push event (never applies) | No | `false` |
+
+## Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `AWS_ROLE_TO_ASSUME` | ARN of the IAM role to assume via OIDC | Yes |
+| `SLACK_WEBHOOK_URL` | Slack webhook for pipeline notifications | No |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has_plan` | `true` when `mode=plan` (a Terraform plan was executed) |
+| `has_apply` | `true` when `mode=apply` (a Terraform apply was executed) |
+
+## Backend state key
+
+The state object key is computed as:
+
+```text
+<environment>/<repo-name>/<terraform_resource_name>/terraform-state
+```
+
+matching the layout used by `github-actions-terraform-pipeline-template`, so
+existing state files are picked up without an import/move.
+
+## Usage
+
+```yaml
+name: "Terraform pipeline - audit"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  boundary-policy:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/terraform-plan-apply.yml@v1.58.0
+    with:
+      aws_region: us-east-2
+      environment: audit
+      terraform_version: "1.9.8"
+      working_directory: src/terraform/boundary-policy
+      terraform_resource_name: boundary-policy
+      backend_bucket: terraform-security-foundation
+    secrets:
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_GH_OICD_TERRAFORM_ROLE }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+## Migrating from `github-actions-terraform-pipeline-template`
+
+The old composite also supported building a Lambda artifact first (`runtime:
+golang | python`, via `github-actions-go-lambda-module` /
+`github-actions-python-lambda-module`). That concern is out of scope for this
+workflow — if a caller needs it, build the Lambda artifact in a separate step
+(or job) before calling `terraform-plan-apply.yml`, or use `go-lambda-release.yml`
+for Go Lambdas.
+
+The old composite required a `service-github-token` input for the PR comment.
+This workflow uses the caller's ambient `GITHUB_TOKEN` instead (granted
+`pull-requests: write` via the `permissions:` block above) — no extra secret
+needed.

--- a/docs/terraform-plan-apply.md
+++ b/docs/terraform-plan-apply.md
@@ -27,6 +27,7 @@ notifications. Replaces `LerianStudio/github-actions-terraform-pipeline-template
 | `backend_region` | AWS region of the state bucket and lock table | No | `us-east-2` |
 | `backend_dynamodb_table` | DynamoDB table used for state locking | No | `terraform-lock-state` |
 | `var_file` | Explicit tfvars path. Defaults to `<working_directory>/tfvars/<environment>.tfvars` when present | No | `''` |
+| `pre_terraform_command` | Shell command run in the repo root after checkout, before AWS auth and Terraform (e.g. building a Lambda deployment package the Terraform config references) | No | `''` |
 | `enable_slack_notify` | Send a Slack notification with the pipeline result | No | `true` |
 | `dry_run` | Force plan-only, even on a push event (never applies) | No | `false` |
 
@@ -88,12 +89,27 @@ jobs:
 
 ## Migrating from `github-actions-terraform-pipeline-template`
 
-The old composite also supported building a Lambda artifact first (`runtime:
-golang | python`, via `github-actions-go-lambda-module` /
-`github-actions-python-lambda-module`). That concern is out of scope for this
-workflow — if a caller needs it, build the Lambda artifact in a separate step
-(or job) before calling `terraform-plan-apply.yml`, or use `go-lambda-release.yml`
-for Go Lambdas.
+The old composite also supported building a Go Lambda artifact first
+(`runtime: golang`, via `github-actions-go-lambda-module`). Replicate that with
+`pre_terraform_command` — it runs in the same job, after checkout and before
+Terraform, so any file it produces (e.g. a `function.zip` a
+`data`/`filebase64sha256(...)` reads at plan time) is present when Terraform
+runs. It must run in the same job as Terraform — a separate job would checkout
+on a different runner and lose the build output.
+
+```yaml
+with:
+  pre_terraform_command: |
+    mkdir -p build src/terraform/infra
+    cd src/code
+    GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags lambda.norpc -o ../../build/bootstrap main.go
+    cd ../../build && zip function.zip bootstrap
+    mv function.zip ../src/terraform/infra
+```
+
+(The old template also had a `runtime: python` option via
+`github-actions-python-lambda-module`, but that action no longer exists and
+its only caller has been retired — not covered here.)
 
 The old composite required a `service-github-token` input for the PR comment.
 This workflow uses the caller's ambient `GITHUB_TOKEN` instead (granted

--- a/src/deploy/terraform-plan-apply/README.md
+++ b/src/deploy/terraform-plan-apply/README.md
@@ -1,0 +1,109 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>terraform-plan-apply</h1></td>
+  </tr>
+</table>
+
+Composite action that runs `terraform fmt/init/validate` against a remote S3
+backend, then either plans (posting the output as a PR comment) or applies.
+Does not perform AWS authentication or notifications — those are the caller's
+responsibility (see the `terraform-plan-apply.yml` reusable workflow for the
+full orchestration).
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `working-directory` | Path to the Terraform module, relative to the repo root | Yes | - |
+| `environment` | Environment name, used to look up the default tfvars file | Yes | - |
+| `terraform-version` | Terraform version to install | Yes | - |
+| `mode` | `plan` or `apply` | Yes | - |
+| `backend-bucket` | S3 bucket that stores the Terraform state | Yes | - |
+| `backend-key` | Full state object key within the backend bucket | Yes | - |
+| `backend-region` | AWS region of the state bucket and lock table | No | `us-east-2` |
+| `backend-dynamodb-table` | DynamoDB table used for state locking | No | `terraform-lock-state` |
+| `var-file` | Explicit tfvars path. Defaults to `<working-directory>/tfvars/<environment>.tfvars` when present | No | `""` |
+| `github-token` | Token used to comment the plan output on the pull request | Yes | - |
+| `pr-number` | Pull request number to comment on. Comment step is skipped when empty | No | `""` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `has-plan` | `true` when `mode=plan` (a Terraform plan was executed) |
+| `has-apply` | `true` when `mode=apply` (a Terraform apply was executed) |
+
+Plan/apply failures also surface via the step exit code.
+
+## Usage as composite step
+
+```yaml
+jobs:
+  terraform:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-2
+
+      - uses: LerianStudio/github-actions-shared-workflows/src/deploy/terraform-plan-apply@v1
+        with:
+          working-directory: src/terraform/boundary-policy
+          environment: audit
+          terraform-version: "1.9.8"
+          mode: ${{ github.event_name == 'pull_request' && 'plan' || 'apply' }}
+          backend-bucket: terraform-security-foundation
+          backend-key: audit/${{ github.event.repository.name }}/boundary-policy/terraform-state
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+```
+
+## Usage via reusable workflow
+
+```yaml
+jobs:
+  boundary-policy:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/terraform-plan-apply.yml@v1
+    with:
+      aws_region: us-east-2
+      environment: audit
+      terraform_version: "1.9.8"
+      working_directory: src/terraform/boundary-policy
+      terraform_resource_name: boundary-policy
+      backend_bucket: terraform-security-foundation
+    secrets: inherit
+```
+
+Prefer the reusable workflow over calling this composite directly — it handles
+checkout, AWS OIDC auth, mode selection and Slack notification (see
+`docs/terraform-plan-apply.md`).
+
+## Why `hashicorp/setup-terraform`
+
+It is the Terraform team's own action, keeps the binary version pinned per
+caller (via `terraform-version`) instead of relying on whatever the runner
+image ships, and is already the de facto standard across the org's Terraform
+callers being migrated to this composite.
+
+## Required permissions
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+```
+
+`id-token: write` is required by the caller's AWS OIDC step (not by this
+composite directly). `pull-requests: write` is required only when `pr-number`
+is set.

--- a/src/deploy/terraform-plan-apply/action.yml
+++ b/src/deploy/terraform-plan-apply/action.yml
@@ -1,0 +1,226 @@
+name: Terraform Plan/Apply
+description: Runs terraform fmt/init/validate, then plans (with a PR comment) or applies against a remote S3 backend.
+
+inputs:
+  working-directory:
+    description: Path to the Terraform module, relative to the repo root.
+    required: true
+  environment:
+    description: Environment name. Used to look up the default tfvars file.
+    required: true
+  terraform-version:
+    description: Terraform version to install.
+    required: true
+  mode:
+    description: 'Either "plan" or "apply".'
+    required: true
+  backend-bucket:
+    description: S3 bucket that stores the Terraform state.
+    required: true
+  backend-key:
+    description: Full state object key within the backend bucket.
+    required: true
+  backend-region:
+    description: AWS region of the state bucket and lock table.
+    required: false
+    default: "us-east-2"
+  backend-dynamodb-table:
+    description: DynamoDB table used for state locking.
+    required: false
+    default: "terraform-lock-state"
+  var-file:
+    description: Explicit path to a tfvars file. Defaults to "<working-directory>/tfvars/<environment>.tfvars" when that file exists.
+    required: false
+    default: ""
+  github-token:
+    description: Token used to comment the plan output on the pull request.
+    required: true
+  pr-number:
+    description: Pull request number to comment on. Skips the comment step when empty.
+    required: false
+    default: ""
+
+outputs:
+  has-plan:
+    description: "true when mode=plan (a Terraform plan was executed)."
+    value: ${{ steps.outputs.outputs.has-plan }}
+  has-apply:
+    description: "true when mode=apply (a Terraform apply was executed)."
+    value: ${{ steps.outputs.outputs.has-apply }}
+
+runs:
+  using: composite
+  steps:
+    # ----------------- Setup -----------------
+    - name: Validate mode
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        case "${MODE}" in
+          plan|apply) ;;
+          *) echo "::error::mode must be 'plan' or 'apply' (got '${MODE}')"; exit 1 ;;
+        esac
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+
+    - name: Terraform Format
+      id: fmt
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform fmt -check
+
+    - name: Terraform Init
+      id: init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BACKEND_BUCKET: ${{ inputs.backend-bucket }}
+        BACKEND_KEY: ${{ inputs.backend-key }}
+        BACKEND_REGION: ${{ inputs.backend-region }}
+        BACKEND_DYNAMODB_TABLE: ${{ inputs.backend-dynamodb-table }}
+      run: |
+        set -euo pipefail
+        terraform init \
+          -backend-config="bucket=${BACKEND_BUCKET}" \
+          -backend-config="key=${BACKEND_KEY}" \
+          -backend-config="region=${BACKEND_REGION}" \
+          -backend-config="dynamodb_table=${BACKEND_DYNAMODB_TABLE}"
+
+    - name: Terraform Validate
+      id: validate
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform validate -no-color
+
+    - name: Resolve tfvars file
+      id: varfile
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        VAR_FILE: ${{ inputs.var-file }}
+        ENVIRONMENT: ${{ inputs.environment }}
+      run: |
+        set -euo pipefail
+        if [[ -n "${VAR_FILE}" ]]; then
+          echo "path=${VAR_FILE}" >> "$GITHUB_OUTPUT"
+        elif [[ -f "tfvars/${ENVIRONMENT}.tfvars" ]]; then
+          echo "path=tfvars/${ENVIRONMENT}.tfvars" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=" >> "$GITHUB_OUTPUT"
+        fi
+
+    # ----------------- Plan -----------------
+    - name: Terraform Plan
+      if: inputs.mode == 'plan'
+      id: plan
+      continue-on-error: true
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        VAR_FILE_PATH: ${{ steps.varfile.outputs.path }}
+      run: |
+        set -euo pipefail
+        PLAN_FILE="${RUNNER_TEMP}/terraform-plan-output.txt"
+        if [[ -n "${VAR_FILE_PATH}" ]]; then
+          terraform plan -no-color -var-file="${VAR_FILE_PATH}" 2>&1 | tee "${PLAN_FILE}"
+        else
+          terraform plan -no-color 2>&1 | tee "${PLAN_FILE}"
+        fi
+
+    - name: Comment Plan on PR
+      if: inputs.mode == 'plan' && inputs.pr-number != ''
+      uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        FMT_OUTCOME: ${{ steps.fmt.outcome }}
+        INIT_OUTCOME: ${{ steps.init.outcome }}
+        VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+        PLAN_OUTCOME: ${{ steps.plan.outcome }}
+        ACTOR: ${{ github.actor }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
+          if (!Number.isInteger(prNumber) || prNumber <= 0) {
+            core.setFailed(`Invalid pr-number: "${process.env.PR_NUMBER}"`);
+            return;
+          }
+
+          const MAX_LEN = 60000;
+          const planFile = path.join(process.env.RUNNER_TEMP, 'terraform-plan-output.txt');
+          let plan = '(no plan output captured)';
+          if (fs.existsSync(planFile)) {
+            plan = fs.readFileSync(planFile, 'utf8');
+            if (plan.length > MAX_LEN) {
+              plan = plan.slice(0, MAX_LEN) + '\n... (truncated)';
+            }
+          }
+
+          const output = `#### Terraform Environment \`${process.env.ENVIRONMENT}\`
+          #### Terraform Format and Style 🖌 \`${process.env.FMT_OUTCOME}\`
+          #### Terraform Initialization ⚙️ \`${process.env.INIT_OUTCOME}\`
+          #### Terraform Validation 🤖 \`${process.env.VALIDATE_OUTCOME}\`
+          #### Terraform Plan 📖 \`${process.env.PLAN_OUTCOME}\`
+
+          <details><summary>Show Plan</summary>
+
+          \`\`\`
+          ${plan}
+          \`\`\`
+
+          </details>
+
+          *Pusher: @${process.env.ACTOR}, Action: \`${process.env.EVENT_NAME}\`*`;
+
+          github.rest.issues.createComment({
+            issue_number: prNumber,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+          })
+
+    - name: Fail if Plan Failed
+      if: inputs.mode == 'plan' && steps.plan.outcome == 'failure'
+      shell: bash
+      run: exit 1
+
+    # ----------------- Apply -----------------
+    - name: Terraform Apply
+      if: inputs.mode == 'apply'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        VAR_FILE_PATH: ${{ steps.varfile.outputs.path }}
+      run: |
+        set -euo pipefail
+        if [[ -n "${VAR_FILE_PATH}" ]]; then
+          terraform apply -auto-approve -var-file="${VAR_FILE_PATH}"
+        else
+          terraform apply -auto-approve
+        fi
+
+    # ----------------- Outputs -----------------
+    - name: Set outputs
+      id: outputs
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        if [[ "${MODE}" == "plan" ]]; then
+          echo "has-plan=true" >> "$GITHUB_OUTPUT"
+          echo "has-apply=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-plan=false" >> "$GITHUB_OUTPUT"
+          echo "has-apply=true" >> "$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION
Promotes develop to main to cut a stable release including the new terraform-plan-apply workflow/composite (#685, #686), needed to update the floating @v1 tag before migrating real callers off github-actions-terraform-pipeline-template.