### PR TITLE
feat(pr-validation): block merges with unsigned or unverified commits

### DIFF
--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -113,6 +113,10 @@ on:
         description: 'Target branches that require source branch validation (pipe-separated)'
         type: string
         default: 'main'
+      require_verified_commits:
+        description: 'Block the PR when any of its commits is unsigned or has an unverified signature'
+        type: boolean
+        default: true
       pr_checks_summary_runner_type:
         description: 'Optional runner override for the PR Checks Summary job only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
         type: string
@@ -302,6 +306,7 @@ jobs:
       enforce_source_branches: ${{ inputs.enforce_source_branches }}
       allowed_source_branches: ${{ inputs.allowed_source_branches }}
       target_branches_for_source_check: ${{ inputs.target_branches_for_source_check }}
+      require_verified_commits: ${{ inputs.require_verified_commits }}
     secrets: inherit
 
   # ----------------- Change Detection (gate) -----------------

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -105,6 +105,10 @@ on:
         description: 'Target branches that require source branch validation (pipe-separated)'
         type: string
         default: 'main'
+      require_verified_commits:
+        description: 'Block the PR when any of its commits is unsigned or has an unverified signature'
+        type: boolean
+        default: true
 
       # ----------------- Frontend analysis (frontend-pr-analysis.yml) -----------------
       node_version:
@@ -459,6 +463,7 @@ jobs:
       enforce_source_branches: ${{ inputs.enforce_source_branches }}
       allowed_source_branches: ${{ inputs.allowed_source_branches }}
       target_branches_for_source_check: ${{ inputs.target_branches_for_source_check }}
+      require_verified_commits: ${{ inputs.require_verified_commits }}
     secrets: inherit
 
   # ----------------- Change Detection (gate) -----------------

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,7 +3,7 @@ name: "PR Validation"
 # Reusable workflow for pull_request events only.
 # A mandatory fail-closed breaking-change guard runs for every PR, including drafts, and is enforced
 # through Blocking Checks. Non-draft PRs also run the existing title, source branch, description,
-# advisory, reporting, and notification flow.
+# commit signature, advisory, reporting, and notification flow.
 
 on:
   workflow_call:
@@ -74,6 +74,10 @@ on:
         description: 'Target branches that require source branch validation (pipe-separated)'
         type: string
         default: 'main'
+      require_verified_commits:
+        description: 'Block the PR when any of its commits is unsigned or has an unverified signature'
+        type: boolean
+        default: true
     secrets:
       MANAGE_TOKEN:
         required: false
@@ -191,6 +195,7 @@ jobs:
       source-branch-result: ${{ steps.collect.outputs.source_branch }}
       title-result: ${{ steps.collect.outputs.title }}
       description-result: ${{ steps.collect.outputs.description }}
+      commit-signatures-result: ${{ steps.collect.outputs.commit_signatures }}
 
     steps:
       # The composite auto-skips when target branch is not in target_branches_for_source_check (default: main)
@@ -221,6 +226,15 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.draft != true
         continue-on-error: true
         uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-description@v1
+
+      - name: Validate commit signatures
+        id: commit-signatures
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft != true && inputs.require_verified_commits
+        continue-on-error: true
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-commit-signatures@v1
+        with:
+          github-token: ${{ github.token }}
+          dry-run: ${{ inputs.dry_run && 'true' || 'false' }}
 
       - name: Enforce breaking change guard
         if: always()
@@ -253,6 +267,7 @@ jobs:
           source-branch-outcome: ${{ steps.source-branch.outcome || 'skipped' }}
           title-outcome: ${{ steps.title.outcome }}
           description-outcome: ${{ steps.description.outcome }}
+          commit-signatures-outcome: ${{ steps.commit-signatures.outcome || 'skipped' }}
 
   # ----------------- Tier 2: Advisory Checks (shared checkout, depends on Tier 1) -----------------
   advisory-checks:
@@ -320,6 +335,7 @@ jobs:
           source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}
           title-result: ${{ needs.blocking-checks.outputs.title-result || 'skipped' }}
           description-result: ${{ needs.blocking-checks.outputs.description-result || 'skipped' }}
+          commit-signatures-result: ${{ needs.blocking-checks.outputs.commit-signatures-result || 'skipped' }}
           size-result: ${{ needs.advisory-checks.outputs.size-result || 'skipped' }}
           label-result: ${{ needs.advisory-checks.outputs.label-result || 'skipped' }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
@@ -433,6 +449,7 @@ jobs:
           source-branch-result: ${{ needs.blocking-checks.outputs.source-branch-result || 'skipped' }}
           title-result: ${{ needs.blocking-checks.outputs.title-result || 'skipped' }}
           description-result: ${{ needs.blocking-checks.outputs.description-result || 'skipped' }}
+          commit-signatures-result: ${{ needs.blocking-checks.outputs.commit-signatures-result || 'skipped' }}
           size-result: ${{ needs.advisory-checks.outputs.size-result || 'skipped' }}
           label-result: ${{ needs.advisory-checks.outputs.label-result || 'skipped' }}
           metadata-result: ${{ needs.advisory-checks.outputs.metadata-result || 'skipped' }}
@@ -447,8 +464,8 @@ jobs:
     if: always() && github.event_name == 'pull_request' && github.event.pull_request.draft != true && !inputs.dry_run
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/slack-notify.yml@v1.28.12
     with:
-      status: ${{ (needs.breaking-change-guard.result != 'success' || needs.breaking-change-guard.outputs.result != 'success' || needs.blocking-checks.result != 'success' || needs.blocking-checks.outputs.source-branch-result == 'failure' || needs.blocking-checks.outputs.title-result == 'failure' || needs.blocking-checks.outputs.description-result == 'failure') && 'failure' || 'success' }}
+      status: ${{ (needs.breaking-change-guard.result != 'success' || needs.breaking-change-guard.outputs.result != 'success' || needs.blocking-checks.result != 'success' || needs.blocking-checks.outputs.source-branch-result == 'failure' || needs.blocking-checks.outputs.title-result == 'failure' || needs.blocking-checks.outputs.description-result == 'failure' || needs.blocking-checks.outputs.commit-signatures-result == 'failure') && 'failure' || 'success' }}
       workflow_name: "PR Validation"
-      failed_jobs: ${{ (needs.breaking-change-guard.result != 'success' || needs.breaking-change-guard.outputs.result != 'success') && 'Breaking Change Guard, ' || '' }}${{ needs.blocking-checks.result != 'success' && 'Blocking Checks, ' || '' }}${{ needs.blocking-checks.outputs.source-branch-result == 'failure' && 'Source Branch, ' || '' }}${{ needs.blocking-checks.outputs.title-result == 'failure' && 'PR Title, ' || '' }}${{ needs.blocking-checks.outputs.description-result == 'failure' && 'PR Description' || '' }}
+      failed_jobs: ${{ (needs.breaking-change-guard.result != 'success' || needs.breaking-change-guard.outputs.result != 'success') && 'Breaking Change Guard, ' || '' }}${{ needs.blocking-checks.result != 'success' && 'Blocking Checks, ' || '' }}${{ needs.blocking-checks.outputs.source-branch-result == 'failure' && 'Source Branch, ' || '' }}${{ needs.blocking-checks.outputs.title-result == 'failure' && 'PR Title, ' || '' }}${{ needs.blocking-checks.outputs.description-result == 'failure' && 'PR Description, ' || '' }}${{ needs.blocking-checks.outputs.commit-signatures-result == 'failure' && 'Commit Signatures' || '' }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -90,6 +90,21 @@ jobs:
       - name: Run permission-manifest-publish behavioural tests
         run: python3 src/validate/permission-manifest-publish/test.py
 
+  # ----------------- Commit Signature Validation Tests -----------------
+  pr-commit-signatures-tests:
+    name: Commit Signature Validation Tests
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run pr-commit-signatures behavioural tests
+        run: python3 src/validate/pr-commit-signatures/test.py
+
   # ----------------- YAML Lint -----------------
   yamllint:
     name: YAML Lint

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -49,6 +49,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `enforce_source_branches` | Enforce source branches into protected branches | boolean | `true` |
 | `allowed_source_branches` | Allowed source branches (pipe-separated, `*` prefix) | string | `develop\|release-candidate\|hotfix/*` |
 | `target_branches_for_source_check` | Target branches requiring source validation | string | `main` |
+| `require_verified_commits` | Block the PR when any commit is unsigned or unverified | boolean | `true` |
 | `go_version` | Go version | string | `1.23` |
 | `golangci_lint_version` | GolangCI-Lint version | string | `v1.62.2` |
 | `golangci_lint_args` | Extra arguments passed to golangci-lint (e.g. `--timeout=5m`) | string | `--timeout=5m` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -35,6 +35,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `enforce_source_branches` | Enforce source branches into protected branches | boolean | `true` |
 | `allowed_source_branches` | Allowed source branches (pipe-separated, `*` prefix) | string | `develop\|release-candidate\|hotfix/*` |
 | `target_branches_for_source_check` | Target branches requiring source validation | string | `main` |
+| `require_verified_commits` | Block the PR when any commit is unsigned or unverified | boolean | `true` |
 | `node_version` | Node.js version | string | `22` |
 | `package_manager` | Package manager (`npm`, `yarn`, `pnpm`) | string | `npm` |
 | `eslint_args` | Additional arguments for ESLint | string | `''` |

--- a/docs/pr-validation.md
+++ b/docs/pr-validation.md
@@ -234,11 +234,11 @@ The check reads GitHub's own verification verdict (`commit.verification.verified
 | `require_verified_commits: false` | Step skipped, no row in summary or report |
 | `dry_run: true` | Findings reported, `Blocking Checks` not failed |
 
-Remediation (also printed in the job summary):
+Remediation (also printed in the job summary, with `<base-branch>` already resolved to the pull request's own base branch):
 
 ```bash
 git config --local commit.gpgsign true
-git rebase --exec 'git commit --amend --no-edit -S' origin/main
+git rebase --exec 'git commit --amend --no-edit -S' origin/<base-branch>
 git push --force-with-lease
 ```
 

--- a/docs/pr-validation.md
+++ b/docs/pr-validation.md
@@ -17,6 +17,7 @@ Comprehensive pull request validation workflow that enforces best practices, cod
 - **Draft PR support** — Runs and enforces the mandatory guard (and still writes the step summary) while deferring title, branch, description, advisory, PR comments, reporter output, guard comments, and Slack notifications until ready for review
 - **Source branch validation** — Enforce PRs to protected branches come from specific source branches
 - **Mandatory breaking change guard** — Detects breaking-change commits on every target branch and blocks breaking changes without PR author acknowledgement
+- **Commit signature validation** — Blocks the PR when any of its commits is unsigned or unverified, listing every offending commit
 - **Dry run mode** — Preview validations without posting comments or labels
 - **Summary report** — Aggregated validation status (step summary + idempotent PR comment)
 - **Idempotent feedback** — Source branch failures and the mergeability summary are upserted via stable markers (no stacked duplicates across commits)
@@ -35,7 +36,8 @@ pr-validation.yml (reusable workflow)
     ├── breaking-change enforcement     (also runs for drafts)
     ├── src/validate/pr-source-branch   (non-draft source branch check)
     ├── src/validate/pr-title           (non-draft semantic title check)
-    └── src/validate/pr-description     (non-draft description quality)
+    ├── src/validate/pr-description     (non-draft description quality)
+    └── src/validate/pr-commit-signatures (non-draft commit signature check)
               ↓ (only continues if all pass)
   Tier 2 — advisory-checks (shared checkout)
     ├── src/validate/pr-metadata        (assignee + linked issues)
@@ -134,6 +136,7 @@ jobs:
 | `enforce_source_branches` | boolean | `true` | Enforce source branch rules (auto-skips when target is not in `target_branches_for_source_check`) |
 | `allowed_source_branches` | string | `develop\|release-candidate\|hotfix/*` | Allowed source branches (pipe-separated, supports `*` wildcard) |
 | `target_branches_for_source_check` | string | `main` | Target branches that require source branch validation |
+| `require_verified_commits` | boolean | `true` | Block the PR when any of its commits is unsigned or has an unverified signature |
 
 The breaking change guard has no enable input, target-branch input, acknowledgement input, or opt-out. It applies to every caller and every PR target branch. `dry_run: true` remains a global preview mode without guard enforcement; it is not a guard-specific opt-out and does not change normal `dry_run: false` operation. Existing callers must migrate their `pull_request.types` list to include both `edited` and `ready_for_review`; otherwise body edits and draft-to-ready transitions do not rerun validation.
 
@@ -188,7 +191,7 @@ feat fix docs style refactor perf test chore ci build revert
 | Job | Tier | Composites | Condition |
 |-----|------|------------|-----------|
 | `breaking-change-guard` | mandatory detection | `breaking-change-guard@v1` | always, including drafts |
-| `blocking-checks` | 1 (fail-fast) | guard enforcement, `pr-source-branch`, `pr-title`, `pr-description` | always; drafts run guard enforcement only |
+| `blocking-checks` | 1 (fail-fast) | guard enforcement, `pr-source-branch`, `pr-title`, `pr-description`, `pr-commit-signatures` | always; drafts run guard enforcement only |
 | `advisory-checks` | 2 (informational) | `pr-metadata`, `pr-size`, `pr-labels` | non-draft, blocking-checks passed |
 | `pr-checks-summary` | — | `pr-checks-summary` | always (writes to step summary) |
 | `breaking-change-comment` | — | `actions/github-script` | every non-draft live run, including detector failure or cancellation |
@@ -198,8 +201,8 @@ feat fix docs style refactor perf test chore ci build revert
 ### Blocking checks (Tier 1)
 - Run without checkout (lightweight, ~5 seconds)
 - Always enforce both the guard job state and its normalized output, including on drafts
-- Skip existing source branch, title, description, and collector steps on drafts; their non-draft behavior is unchanged
-- On non-drafts, all three existing validations run even if one fails (`continue-on-error` per step)
+- Skip existing source branch, title, description, commit signature, and collector steps on drafts; their non-draft behavior is unchanged
+- On non-drafts, every validation runs even if one fails (`continue-on-error` per step)
 - Job fails if the guard job, normalized guard output, or **any** existing blocking check fails, preventing advisory checks from running
 - In dry-run mode, guard state is logged but does not fail `Blocking Checks`
 
@@ -217,6 +220,30 @@ The detection job can remain successful when normalization handles the fault. Li
 
 Summary and reporter inputs normalize the combined detector job and output state: only two `success` values produce guard success. They also receive the independent `Blocking Checks` job result. Slack treats every `Blocking Checks` state other than `success` as failure and reports it as `Blocking Checks`, not as a guard failure.
 
+### Commit signature validation
+
+Enabled by default (`require_verified_commits: true`) and enforced through the existing `Blocking Checks` job — no new branch-protection check is needed.
+
+The check reads GitHub's own verification verdict (`commit.verification.verified`) for **every** commit in the PR, not only `HEAD`, and uses `github.paginate` so PRs with more than 100 commits are fully evaluated. Every offending commit is reported at once — in the job summary as a table (short SHA + link, author, verification reason) and as `::error::` annotations — so a single run surfaces all findings instead of the first one.
+
+| Situation | Result |
+|-----------|--------|
+| Every commit verified | ✅ `Blocking Checks` passes |
+| One or more commits unsigned/unverified | ❌ `Blocking Checks` fails, merge blocked |
+| PR declares more commits than the API returns (250-commit cap) | ❌ fails closed — split the PR so all commits can be validated |
+| `require_verified_commits: false` | Step skipped, no row in summary or report |
+| `dry_run: true` | Findings reported, `Blocking Checks` not failed |
+
+Remediation (also printed in the job summary):
+
+```bash
+git config --local commit.gpgsign true
+git rebase --exec 'git commit --amend --no-edit -S' origin/main
+git push --force-with-lease
+```
+
+The step runs with read-only permissions and emits no commit metadata beyond what is already visible in the repository. See [`pr-commit-signatures`](../src/validate/pr-commit-signatures/README.md).
+
 ### Advisory checks (Tier 2)
 - Share a single `checkout` with `fetch-depth: 0`
 - Only run if all blocking checks passed
@@ -228,7 +255,8 @@ When `dry_run: true`:
 - Breaking-change detection still runs and emits deterministic outputs
 - The guard prints all resolved values but does not fail `Blocking Checks`
 - The breaking-change comment and validation report comments are not posted
-- Title, description, and metadata validations still run (read-only checks)
+- Title, description, commit signature, and metadata validations still run (read-only checks)
+- Unsigned/unverified commits are reported but do not fail `Blocking Checks`
 - Size is calculated and logged but **labels are not applied**
 - Source branch is validated but **the failure comment is not posted/updated**
 - Auto-labeling is **skipped entirely**
@@ -237,7 +265,7 @@ When `dry_run: true`:
 
 ## Draft PR Behavior
 
-When a PR is in draft mode, mandatory breaking-change detection and guard enforcement still run. `Blocking Checks` is the existing required check, so a breaking change without author acknowledgement or a detector failure blocks the draft without adding a new required check. Existing source branch, title, description, and collector steps remain skipped, and the step summary is still written. Advisory checks, PR comments, reporter output, guard comments, and Slack also remain skipped until the PR is marked ready for review.
+When a PR is in draft mode, mandatory breaking-change detection and guard enforcement still run. `Blocking Checks` is the existing required check, so a breaking change without author acknowledgement or a detector failure blocks the draft without adding a new required check. Existing source branch, title, description, commit signature, and collector steps remain skipped, and the step summary is still written. Advisory checks, PR comments, reporter output, guard comments, and Slack also remain skipped until the PR is marked ready for review.
 
 Every caller must include `ready_for_review` so deferred validation runs on that transition. Every caller must include `edited` so adding, changing, or removing the acknowledgement in the PR body reruns enforcement.
 

--- a/src/notify/pr-validation-reporter/README.md
+++ b/src/notify/pr-validation-reporter/README.md
@@ -18,9 +18,12 @@ Posts a single mergeability summary comment aggregating all PR validation check 
 | `size-result` | Result of PR size check | No | `skipped` |
 | `label-result` | Result of auto-label step | No | `skipped` |
 | `metadata-result` | Result of PR metadata check | No | `skipped` |
+| `commit-signatures-result` | Result of commit signature validation | No | `skipped` |
 | `breaking-change-result` | Result of the blocking breaking change guard | No | `skipped` |
 | `blocking-checks-result` | Runtime result of the blocking checks job | No | `skipped` |
 | `dry-run` | When `true`, skip posting the summary comment | No | `false` |
+
+When `commit-signatures-result` is `skipped` or omitted, the report omits the `Commit Signatures` row and preserves existing mergeability behavior. When supplied, `failure` blocks the verdict. See [`pr-commit-signatures`](../../validate/pr-commit-signatures/README.md).
 
 When `breaking-change-result` is `skipped` or omitted, the report omits the guard row and preserves existing mergeability behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out. When supplied, only `success` is mergeable.
 

--- a/src/notify/pr-validation-reporter/action.yml
+++ b/src/notify/pr-validation-reporter/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Result of PR metadata check (success/failure/skipped)
     required: false
     default: "skipped"
+  commit-signatures-result:
+    description: Result of commit signature validation (success/failure/skipped)
+    required: false
+    default: "skipped"
   breaking-change-result:
     description: Result of breaking change guard (success/failure/cancelled/skipped)
     required: false
@@ -82,6 +86,7 @@ runs:
         SIZE_RESULT: ${{ inputs.size-result }}
         LABEL_RESULT: ${{ inputs.label-result }}
         METADATA_RESULT: ${{ inputs.metadata-result }}
+        COMMIT_SIGNATURES_RESULT: ${{ inputs.commit-signatures-result }}
         BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
         BLOCKING_CHECKS_RESULT: ${{ inputs.blocking-checks-result }}
       with:
@@ -91,6 +96,9 @@ runs:
             { label: 'Source Branch',  result: process.env.SOURCE_BRANCH_RESULT, blocking: true  },
             { label: 'PR Title',       result: process.env.TITLE_RESULT,         blocking: true  },
             { label: 'PR Description', result: process.env.DESCRIPTION_RESULT,   blocking: true  },
+            ...(process.env.COMMIT_SIGNATURES_RESULT !== 'skipped'
+              ? [{ label: 'Commit Signatures', result: process.env.COMMIT_SIGNATURES_RESULT, blocking: true }]
+              : []),
             { label: 'PR Size',        result: process.env.SIZE_RESULT,          blocking: false },
             { label: 'Auto Labels',    result: process.env.LABEL_RESULT,         blocking: false },
             { label: 'PR Metadata',    result: process.env.METADATA_RESULT,      blocking: false },

--- a/src/validate/pr-blocking-collect/README.md
+++ b/src/validate/pr-blocking-collect/README.md
@@ -14,6 +14,7 @@ Collects outcomes from blocking validation checks, exposes them as step outputs,
 | `source-branch-outcome` | Outcome of the source branch validation step | No | `skipped` |
 | `title-outcome` | Outcome of the PR title validation step | Yes | |
 | `description-outcome` | Outcome of the PR description validation step | Yes | |
+| `commit-signatures-outcome` | Outcome of the commit signature validation step | No | `skipped` |
 
 ## Outputs
 
@@ -22,6 +23,7 @@ Collects outcomes from blocking validation checks, exposes them as step outputs,
 | `source_branch` | Outcome of source branch validation |
 | `title` | Outcome of PR title validation |
 | `description` | Outcome of PR description validation |
+| `commit_signatures` | Outcome of commit signature validation |
 
 ## Usage as composite step
 
@@ -33,6 +35,7 @@ Collects outcomes from blocking validation checks, exposes them as step outputs,
     source-branch-outcome: ${{ steps.source-branch.outcome || 'skipped' }}
     title-outcome: ${{ steps.title.outcome }}
     description-outcome: ${{ steps.description.outcome }}
+    commit-signatures-outcome: ${{ steps.commit-signatures.outcome || 'skipped' }}
 ```
 
 ## Required permissions

--- a/src/validate/pr-blocking-collect/action.yml
+++ b/src/validate/pr-blocking-collect/action.yml
@@ -12,6 +12,10 @@ inputs:
   description-outcome:
     description: Outcome of the PR description validation step
     required: true
+  commit-signatures-outcome:
+    description: Outcome of the commit signature validation step
+    required: false
+    default: skipped
 
 outputs:
   source_branch:
@@ -23,6 +27,9 @@ outputs:
   description:
     description: Outcome of PR description validation
     value: ${{ steps.collect.outputs.description }}
+  commit_signatures:
+    description: Outcome of commit signature validation
+    value: ${{ steps.collect.outputs.commit_signatures }}
 
 runs:
   using: composite
@@ -34,17 +41,20 @@ runs:
         SOURCE_BRANCH: ${{ inputs.source-branch-outcome }}
         TITLE: ${{ inputs.title-outcome }}
         DESCRIPTION: ${{ inputs.description-outcome }}
+        COMMIT_SIGNATURES: ${{ inputs.commit-signatures-outcome }}
       run: |
         {
           echo "source_branch=${SOURCE_BRANCH}"
           echo "title=${TITLE}"
           echo "description=${DESCRIPTION}"
+          echo "commit_signatures=${COMMIT_SIGNATURES}"
         } >> "$GITHUB_OUTPUT"
 
         FAILED=""
         if [ "${SOURCE_BRANCH}" = "failure" ]; then FAILED="${FAILED} source-branch"; fi
         if [ "${TITLE}" = "failure" ]; then FAILED="${FAILED} title"; fi
         if [ "${DESCRIPTION}" = "failure" ]; then FAILED="${FAILED} description"; fi
+        if [ "${COMMIT_SIGNATURES}" = "failure" ]; then FAILED="${FAILED} commit-signatures"; fi
 
         if [ -n "${FAILED}" ]; then
           echo "::error::Blocking checks failed:${FAILED}"

--- a/src/validate/pr-checks-summary/README.md
+++ b/src/validate/pr-checks-summary/README.md
@@ -17,9 +17,12 @@ Generates a summary table of all PR validation check results in the GitHub Actio
 | `size-result` | Result of PR size check | No | `skipped` |
 | `label-result` | Result of auto-label step | No | `skipped` |
 | `metadata-result` | Result of PR metadata check | No | `skipped` |
+| `commit-signatures-result` | Result of commit signature validation | No | `skipped` |
 | `breaking-change-result` | Result of the breaking change guard | No | `skipped` |
 | `blocking-checks-result` | Runtime result of the blocking checks job | No | `skipped` |
 | `dry-run` | Whether this is a dry run | No | `false` |
+
+When `commit-signatures-result` is `skipped` or omitted, the summary omits the `Commit Signatures` row and preserves existing behavior. See [`pr-commit-signatures`](../pr-commit-signatures/README.md).
 
 When `breaking-change-result` is `skipped` or omitted, the summary omits the guard row and preserves existing behavior. This optional default exists only for backward compatibility with direct action consumers. The mandatory `pr-validation` integration always supplies the guard result and offers no guard opt-out.
 

--- a/src/validate/pr-checks-summary/action.yml
+++ b/src/validate/pr-checks-summary/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Result of PR metadata check
     required: false
     default: skipped
+  commit-signatures-result:
+    description: Result of commit signature validation
+    required: false
+    default: skipped
   breaking-change-result:
     description: Result of breaking change guard
     required: false
@@ -78,6 +82,7 @@ runs:
         DESCRIPTION_RESULT: ${{ inputs.description-result }}
         LABEL_RESULT: ${{ inputs.label-result }}
         METADATA_RESULT: ${{ inputs.metadata-result }}
+        COMMIT_SIGNATURES_RESULT: ${{ inputs.commit-signatures-result }}
         BREAKING_CHANGE_RESULT: ${{ inputs.breaking-change-result }}
         BLOCKING_CHECKS_RESULT: ${{ inputs.blocking-checks-result }}
         DRY_RUN: ${{ inputs.dry-run }}
@@ -105,6 +110,9 @@ runs:
           echo "| Source Branch | $(icon "$SOURCE_BRANCH_RESULT") ${SOURCE_BRANCH_RESULT} |"
           echo "| PR Title | $(icon "$TITLE_RESULT") ${TITLE_RESULT} |"
           echo "| PR Description | $(icon "$DESCRIPTION_RESULT") ${DESCRIPTION_RESULT} |"
+          if [ "$COMMIT_SIGNATURES_RESULT" != "skipped" ]; then
+            echo "| Commit Signatures | $(icon "$COMMIT_SIGNATURES_RESULT") ${COMMIT_SIGNATURES_RESULT} |"
+          fi
           if [ "$BREAKING_CHANGE_RESULT" != "skipped" ]; then
             echo "| Breaking Change Guard | $(icon "$BREAKING_CHANGE_RESULT") ${BREAKING_CHANGE_RESULT} |"
           fi

--- a/src/validate/pr-commit-signatures/README.md
+++ b/src/validate/pr-commit-signatures/README.md
@@ -9,7 +9,7 @@ Fails the job when any commit in the pull request is unsigned or has an unverifi
 
 The check reads GitHub's own signature verification result (`commit.verification.verified`) for **every** commit in the PR — not only `HEAD` — and reports all offending commits at once in the job summary and as `::error::` annotations, with the short SHA, a link to the commit, the author, and the verification reason.
 
-Commits are fetched with `github.paginate`, so pull requests with more than 100 commits are fully evaluated. The Pull Request Commits API caps at 250 commits: when a PR declares more commits than the API returns, the check **fails closed** and asks for the PR to be split, rather than reporting a partial verdict.
+The composite wraps `actions/github-script` (pinned by SHA) rather than shelling out to `gh`: it needs `github.paginate` over `github.rest.pulls.listCommits` to walk every page of commits, and Octokit's typed response exposes `commit.verification` directly. Because of that pagination, pull requests with more than 100 commits are fully evaluated. The Pull Request Commits API caps at 250 commits: when a PR declares more commits than the API returns, the check **fails closed** and asks for the PR to be split, rather than reporting a partial verdict.
 
 No commit metadata beyond what is already visible in the repository is emitted, and the token is never printed.
 
@@ -26,6 +26,7 @@ No commit metadata beyond what is already visible in the repository is emitted, 
 |--------|-------------|
 | `total-commits` | Number of commits evaluated in the pull request |
 | `unverified-count` | Number of commits that are unsigned or unverified |
+| `has-signature-failures` | `true` when the check failed — any unverified commit, or a verdict that could not cover every commit. A truncated PR can report `unverified-count: 0` and still fail, which is why this output exists. |
 
 ## Behavior
 
@@ -38,14 +39,14 @@ No commit metadata beyond what is already visible in the repository is emitted, 
 
 ## Remediation
 
-Reported in the job summary and reproduced here:
+Reported in the job summary, where `<base-branch>` is already resolved to the pull request's own base branch:
 
 ```bash
 # 1. Make sure signing is configured (SSH or GPG key registered on GitHub)
 git config --local commit.gpgsign true
 
 # 2. Re-sign every commit of this branch on top of its base
-git rebase --exec 'git commit --amend --no-edit -S' origin/main
+git rebase --exec 'git commit --amend --no-edit -S' origin/<base-branch>
 
 # 3. Update the pull request
 git push --force-with-lease

--- a/src/validate/pr-commit-signatures/README.md
+++ b/src/validate/pr-commit-signatures/README.md
@@ -1,0 +1,97 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>pr-commit-signatures</h1></td>
+  </tr>
+</table>
+
+Fails the job when any commit in the pull request is unsigned or has an unverified signature.
+
+The check reads GitHub's own signature verification result (`commit.verification.verified`) for **every** commit in the PR — not only `HEAD` — and reports all offending commits at once in the job summary and as `::error::` annotations, with the short SHA, a link to the commit, the author, and the verification reason.
+
+Commits are fetched with `github.paginate`, so pull requests with more than 100 commits are fully evaluated. The Pull Request Commits API caps at 250 commits: when a PR declares more commits than the API returns, the check **fails closed** and asks for the PR to be split, rather than reporting a partial verdict.
+
+No commit metadata beyond what is already visible in the repository is emitted, and the token is never printed.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `github-token` | GitHub token with pull-requests read permission | Yes | |
+| `dry-run` | When true, report findings without failing the check | No | `false` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `total-commits` | Number of commits evaluated in the pull request |
+| `unverified-count` | Number of commits that are unsigned or unverified |
+
+## Behavior
+
+| Situation | Result |
+|-----------|--------|
+| Every commit verified | ✅ success |
+| One or more commits unsigned/unverified | ❌ failure — all offenders listed |
+| PR exceeds the 250-commit API cap | ❌ failure — verdict cannot be complete |
+| `dry-run: true` | Findings reported via `::notice::`, job does not fail |
+
+## Remediation
+
+Reported in the job summary and reproduced here:
+
+```bash
+# 1. Make sure signing is configured (SSH or GPG key registered on GitHub)
+git config --local commit.gpgsign true
+
+# 2. Re-sign every commit of this branch on top of its base
+git rebase --exec 'git commit --amend --no-edit -S' origin/main
+
+# 3. Update the pull request
+git push --force-with-lease
+```
+
+See [Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+
+## Usage as composite step
+
+```yaml
+jobs:
+  commit-signatures:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate commit signatures
+        uses: LerianStudio/github-actions-shared-workflows/src/validate/pr-commit-signatures@v1.x.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Usage as reusable workflow
+
+Called via the `pr-validation.yml` reusable workflow, where it runs as a blocking check (enabled by default):
+
+```yaml
+jobs:
+  validate:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@v1.x.x
+    with:
+      require_verified_commits: true
+    secrets: inherit
+```
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+```
+
+## Tests
+
+```bash
+python3 src/validate/pr-commit-signatures/test.py
+```

--- a/src/validate/pr-commit-signatures/action.yml
+++ b/src/validate/pr-commit-signatures/action.yml
@@ -1,0 +1,136 @@
+name: Validate PR Commit Signatures
+description: "Fails when any commit in the pull request is unsigned or has an unverified signature, listing every offending commit."
+
+inputs:
+  github-token:
+    description: GitHub token with pull-requests read permission
+    required: true
+  dry-run:
+    description: "When true, report findings without failing the check"
+    required: false
+    default: "false"
+
+outputs:
+  total-commits:
+    description: Number of commits evaluated in the pull request
+    value: ${{ steps.verify.outputs.total-commits }}
+  unverified-count:
+    description: Number of commits that are unsigned or unverified
+    value: ${{ steps.verify.outputs.unverified-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Verify commit signatures
+      id: verify
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      env:
+        DRY_RUN: ${{ inputs.dry-run }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const dryRun = process.env.DRY_RUN === 'true';
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            core.setFailed('Commit signature validation requires a pull_request event payload.');
+            return;
+          }
+
+          // github.paginate walks every page, so PRs with more than 100 commits are fully
+          // evaluated. The Pull Request Commits API itself caps at 250 commits; when the PR
+          // exceeds that, the check fails closed rather than reporting a partial verdict.
+          const commits = await github.paginate(github.rest.pulls.listCommits, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: pr.number,
+            per_page: 100,
+          });
+
+          const declared = typeof pr.commits === 'number' ? pr.commits : commits.length;
+          const truncated = commits.length < declared;
+
+          const offenders = commits
+            .filter(c => c.commit?.verification?.verified !== true)
+            .map(c => ({
+              sha: c.sha,
+              short: c.sha.slice(0, 7),
+              url: c.html_url,
+              author: c.author?.login || c.commit?.author?.name || 'unknown',
+              reason: c.commit?.verification?.reason || 'unknown',
+            }));
+
+          core.setOutput('total-commits', String(commits.length));
+          core.setOutput('unverified-count', String(offenders.length));
+
+          const remediation = [
+            '### How to fix',
+            '',
+            'Configure commit signing, then re-sign the commits in this branch:',
+            '',
+            '```bash',
+            '# 1. Make sure signing is configured (SSH or GPG key registered on GitHub)',
+            'git config --local commit.gpgsign true',
+            '',
+            '# 2. Re-sign every commit of this branch on top of its base',
+            `git rebase --exec 'git commit --amend --no-edit -S' origin/${pr.base?.ref || 'main'}`,
+            '',
+            '# 3. Update the pull request',
+            'git push --force-with-lease',
+            '```',
+            '',
+            'Docs: https://docs.github.com/en/authentication/managing-commit-signature-verification',
+          ].join('\n');
+
+          const lines = [`## Commit Signature Validation`, ''];
+
+          if (dryRun) {
+            lines.push('> **DRY RUN** — findings are reported but the check does not fail', '');
+          }
+
+          lines.push(`Commits evaluated: **${commits.length}**`, '');
+
+          if (truncated) {
+            lines.push(
+              `> ⚠️ This pull request declares ${declared} commits but the GitHub API returned only ${commits.length}.`,
+              '> The Pull Request Commits API caps at 250 commits, so the signature verdict cannot cover every commit.',
+              '> Split this pull request into smaller ones so all commits can be validated.',
+              '',
+            );
+          }
+
+          if (offenders.length > 0) {
+            lines.push(
+              `Unsigned or unverified commits: **${offenders.length}**`,
+              '',
+              '| Commit | Author | Status | Reason |',
+              '|--------|--------|--------|--------|',
+              ...offenders.map(o => `| [\`${o.short}\`](${o.url}) | ${o.author} | ❌ unverified | \`${o.reason}\` |`),
+              '',
+              remediation,
+            );
+          } else if (!truncated) {
+            lines.push('✅ Every commit in this pull request carries a verified signature.');
+          }
+
+          await core.summary.addRaw(lines.join('\n')).write();
+
+          for (const o of offenders) {
+            core.error(`Commit ${o.short} by ${o.author} is not verified (reason: ${o.reason}) — ${o.url}`);
+          }
+
+          if (offenders.length === 0 && !truncated) {
+            core.info(`✅ All ${commits.length} commit(s) are verified.`);
+            return;
+          }
+
+          const failure = truncated
+            ? `Commit signature validation could not evaluate all ${declared} commits (only ${commits.length} returned by the API); ${offenders.length} of those are unsigned or unverified.`
+            : `${offenders.length} of ${commits.length} commit(s) in this pull request are unsigned or unverified.`;
+
+          if (dryRun) {
+            core.notice(`DRY RUN — ${failure}`);
+            return;
+          }
+
+          core.setFailed(failure);

--- a/src/validate/pr-commit-signatures/action.yml
+++ b/src/validate/pr-commit-signatures/action.yml
@@ -17,6 +17,11 @@ outputs:
   unverified-count:
     description: Number of commits that are unsigned or unverified
     value: ${{ steps.verify.outputs.unverified-count }}
+  has-signature-failures:
+    description: >-
+      Whether the check failed (true/false). True when any commit is unverified or when the
+      verdict could not cover every commit, which unverified-count alone does not express.
+    value: ${{ steps.verify.outputs.has-signature-failures }}
 
 runs:
   using: composite
@@ -62,6 +67,7 @@ runs:
 
           core.setOutput('total-commits', String(commits.length));
           core.setOutput('unverified-count', String(offenders.length));
+          core.setOutput('has-signature-failures', String(offenders.length > 0 || truncated));
 
           const remediation = [
             '### How to fix',

--- a/src/validate/pr-commit-signatures/test.py
+++ b/src/validate/pr-commit-signatures/test.py
@@ -197,6 +197,7 @@ class CommitSignatureValidation(unittest.TestCase):
         self.assertFalse(record["failed"], msg=record["failedMessage"])
         self.assertEqual(record["outputs"]["total-commits"], "5")
         self.assertEqual(record["outputs"]["unverified-count"], "0")
+        self.assertEqual(record["outputs"]["has-signature-failures"], "false")
         self.assertEqual(record["errors"], [])
         self.assertIn("verified signature", record["summary"])
 
@@ -211,6 +212,7 @@ class CommitSignatureValidation(unittest.TestCase):
         record = run_script(commits)
         self.assertTrue(record["failed"])
         self.assertEqual(record["outputs"]["unverified-count"], "2")
+        self.assertEqual(record["outputs"]["has-signature-failures"], "true")
         self.assertEqual(len(record["errors"]), 2)
         joined = "\n".join(record["errors"])
         self.assertIn("unsigned", joined)
@@ -251,12 +253,17 @@ class CommitSignatureValidation(unittest.TestCase):
         self.assertFalse(record["failed"], msg=record["failedMessage"])
         self.assertEqual(record["outputs"]["total-commits"], "200")
         self.assertEqual(record["outputs"]["unverified-count"], "0")
+        self.assertEqual(record["outputs"]["has-signature-failures"], "false")
 
     # (f) Beyond the 250-commit API cap the verdict cannot be complete -> fail closed.
     def test_beyond_api_cap_fails_closed(self):
         record = run_script([commit(i, True) for i in range(1, 320)], declared=319)
         self.assertTrue(record["failed"])
         self.assertEqual(record["outputs"]["total-commits"], "250")
+        # Every returned commit is verified, so the count alone would read as a pass;
+        # has-signature-failures is what tells a caller the verdict is incomplete.
+        self.assertEqual(record["outputs"]["unverified-count"], "0")
+        self.assertEqual(record["outputs"]["has-signature-failures"], "true")
         self.assertIn("could not evaluate all 319", record["failedMessage"])
         self.assertIn("250 commits", record["summary"])
 

--- a/src/validate/pr-commit-signatures/test.py
+++ b/src/validate/pr-commit-signatures/test.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Behavioural tests for the pr-commit-signatures composite action.
+
+Same extract/execute/parse shape as
+src/validate/permission-manifest-publish/test.py, adapted to a `github-script`
+step: the embedded `script: |` body is pulled out of action.yml by step name and
+executed by a JS runtime inside an async wrapper that stubs `core`, `github`, and
+`context`. The stubbed `github.paginate` walks pages exactly like Octokit does,
+so pagination is exercised for real instead of being mocked away.
+
+The wrapper prints a single JSON blob on stdout; every assertion reads it.
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ACTION_PATH = Path(__file__).resolve().parent / "action.yml"
+ACTION = ACTION_PATH.read_text(encoding="utf-8")
+
+STEP_NAME = "Verify commit signatures"
+
+# node in CI; bun is accepted so the suite is runnable on workstations without node.
+RUNTIME = shutil.which("node") or shutil.which("bun")
+
+
+def indentation(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_step(text, step_name):
+    lines = text.splitlines()
+    marker = f"- name: {step_name}"
+    for start, line in enumerate(lines):
+        if line.strip() == marker:
+            step_indent = indentation(line)
+            break
+    else:
+        raise AssertionError(f"step not found: {step_name}")
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and indentation(line) <= step_indent:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def extract_script_body(text, step_name):
+    step = extract_step(text, step_name)
+    lines = step.splitlines()
+    for start, line in enumerate(lines):
+        if line.strip() == "script: |":
+            script_indent = indentation(line)
+            break
+    else:
+        raise AssertionError(f"script body not found for step: {step_name}")
+
+    body = []
+    for line in lines[start + 1:]:
+        if line.strip() and indentation(line) <= script_indent:
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body)).rstrip() + "\n"
+
+
+SCRIPT_BODY = extract_script_body(ACTION, STEP_NAME)
+
+HARNESS = """
+const FIXTURE = __FIXTURE__;
+const DECLARED = __DECLARED__;
+const DRY_RUN = __DRY_RUN__;
+const HAS_PR = __HAS_PR__;
+
+process.env.DRY_RUN = DRY_RUN;
+
+const record = {
+  failed: false,
+  failedMessage: null,
+  outputs: {},
+  summary: '',
+  errors: [],
+  notices: [],
+  infos: [],
+  listCommitsCalls: [],
+};
+
+const core = {
+  setFailed: (m) => { record.failed = true; record.failedMessage = String(m); },
+  setOutput: (k, v) => { record.outputs[k] = String(v); },
+  error: (m) => record.errors.push(String(m)),
+  notice: (m) => record.notices.push(String(m)),
+  warning: (m) => record.infos.push(String(m)),
+  info: (m) => record.infos.push(String(m)),
+  summary: {
+    addRaw(text) { record.summary += String(text); return this; },
+    async write() { return this; },
+  },
+};
+
+const context = {
+  repo: { owner: 'LerianStudio', repo: 'example' },
+  serverUrl: 'https://github.com',
+  runId: 42,
+  issue: { number: 7 },
+  payload: HAS_PR
+    ? { pull_request: { number: 7, commits: DECLARED, base: { ref: 'main' } } }
+    : {},
+};
+
+// Mirrors the Octokit endpoint: slices the fixture by page/per_page. The API caps
+// the endpoint at 250 commits, so anything beyond that is never returned.
+const listCommits = async (params) => {
+  record.listCommitsCalls.push({ page: params.page ?? 1, per_page: params.per_page });
+  const perPage = params.per_page ?? 30;
+  const page = params.page ?? 1;
+  const capped = FIXTURE.slice(0, 250);
+  const start = (page - 1) * perPage;
+  return { data: capped.slice(start, start + perPage) };
+};
+
+const github = {
+  rest: { pulls: { listCommits } },
+  // Octokit's paginate: keeps requesting pages until one comes back short.
+  paginate: async (endpoint, params) => {
+    const perPage = params.per_page ?? 30;
+    const all = [];
+    for (let page = 1; ; page += 1) {
+      const { data } = await endpoint({ ...params, page });
+      all.push(...data);
+      if (data.length < perPage) break;
+    }
+    return all;
+  },
+};
+
+(async () => {
+__SCRIPT__
+})()
+  .catch((err) => { record.failed = true; record.failedMessage = `threw: ${err && err.message}`; })
+  .then(() => { process.stdout.write(JSON.stringify(record)); });
+"""
+
+
+def commit(index, verified, reason="valid", login="dev"):
+    sha = f"{index:040x}"
+    return {
+        "sha": sha,
+        "html_url": f"https://github.com/LerianStudio/example/commit/{sha}",
+        "author": {"login": login} if login else None,
+        "commit": {
+            "author": {"name": "Dev Name"},
+            "verification": {"verified": verified, "reason": reason},
+        },
+    }
+
+
+def run_script(commits, declared=None, dry_run="false", has_pr=True):
+    if RUNTIME is None:
+        raise unittest.SkipTest("no JS runtime (node/bun) available")
+
+    harness = (
+        HARNESS.replace("__FIXTURE__", json.dumps(commits))
+        .replace("__DECLARED__", json.dumps(len(commits) if declared is None else declared))
+        .replace("__DRY_RUN__", json.dumps(dry_run))
+        .replace("__HAS_PR__", "true" if has_pr else "false")
+        .replace("__SCRIPT__", textwrap.indent(SCRIPT_BODY, "  "))
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        script_path = Path(temp_dir) / "harness.mjs"
+        script_path.write_text(harness, encoding="utf-8")
+        result = subprocess.run(
+            [RUNTIME, str(script_path)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    if result.returncode != 0:
+        raise AssertionError(
+            f"harness exited {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+@unittest.skipIf(RUNTIME is None, "no JS runtime (node/bun) available")
+class CommitSignatureValidation(unittest.TestCase):
+    # (a) Every commit verified -> success, no offenders reported.
+    def test_all_verified_passes(self):
+        record = run_script([commit(i, True) for i in range(1, 6)])
+        self.assertFalse(record["failed"], msg=record["failedMessage"])
+        self.assertEqual(record["outputs"]["total-commits"], "5")
+        self.assertEqual(record["outputs"]["unverified-count"], "0")
+        self.assertEqual(record["errors"], [])
+        self.assertIn("verified signature", record["summary"])
+
+    # (b) Mixed set -> failure, and EVERY offender is reported, not just the first.
+    def test_mixed_set_reports_every_offender(self):
+        commits = [
+            commit(1, True),
+            commit(2, False, "unsigned", login="alice"),
+            commit(3, True),
+            commit(4, False, "unknown_key", login="bob"),
+        ]
+        record = run_script(commits)
+        self.assertTrue(record["failed"])
+        self.assertEqual(record["outputs"]["unverified-count"], "2")
+        self.assertEqual(len(record["errors"]), 2)
+        joined = "\n".join(record["errors"])
+        self.assertIn("unsigned", joined)
+        self.assertIn("unknown_key", joined)
+        self.assertIn("alice", joined)
+        self.assertIn("bob", joined)
+        # Both offenders present in the summary table, with short SHA + link.
+        self.assertIn(f"[`{2:040x}"[:8], record["summary"])
+        self.assertIn(f"[`{4:040x}"[:8], record["summary"])
+        self.assertIn("How to fix", record["summary"])
+        self.assertIn("2 of 4 commit(s)", record["failedMessage"])
+
+    # (c) A missing verification block is treated as unverified, not as a pass.
+    def test_missing_verification_block_is_unverified(self):
+        broken = commit(1, True)
+        del broken["commit"]["verification"]
+        record = run_script([broken])
+        self.assertTrue(record["failed"])
+        self.assertEqual(record["outputs"]["unverified-count"], "1")
+        self.assertIn("unknown", record["errors"][0])
+
+    # (d) >100 commits: paginate must walk every page, per_page must be 100.
+    def test_paginated_set_is_fully_evaluated(self):
+        commits = [commit(i, True) for i in range(1, 250)]
+        commits[240] = commit(241, False, "unsigned")
+        record = run_script(commits)
+        self.assertTrue(record["failed"])
+        self.assertEqual(record["outputs"]["total-commits"], "249")
+        self.assertEqual(record["outputs"]["unverified-count"], "1")
+        self.assertEqual(
+            [call["page"] for call in record["listCommitsCalls"]], [1, 2, 3]
+        )
+        self.assertTrue(all(c["per_page"] == 100 for c in record["listCommitsCalls"]))
+
+    # (e) 200 verified commits across two pages -> still a pass.
+    def test_paginated_all_verified_passes(self):
+        record = run_script([commit(i, True) for i in range(1, 201)])
+        self.assertFalse(record["failed"], msg=record["failedMessage"])
+        self.assertEqual(record["outputs"]["total-commits"], "200")
+        self.assertEqual(record["outputs"]["unverified-count"], "0")
+
+    # (f) Beyond the 250-commit API cap the verdict cannot be complete -> fail closed.
+    def test_beyond_api_cap_fails_closed(self):
+        record = run_script([commit(i, True) for i in range(1, 320)], declared=319)
+        self.assertTrue(record["failed"])
+        self.assertEqual(record["outputs"]["total-commits"], "250")
+        self.assertIn("could not evaluate all 319", record["failedMessage"])
+        self.assertIn("250 commits", record["summary"])
+
+    # (g) dry-run reports findings but never fails the check.
+    def test_dry_run_does_not_fail(self):
+        record = run_script(
+            [commit(1, True), commit(2, False, "unsigned")], dry_run="true"
+        )
+        self.assertFalse(record["failed"], msg=record["failedMessage"])
+        self.assertEqual(record["outputs"]["unverified-count"], "1")
+        self.assertEqual(len(record["errors"]), 1)
+        self.assertEqual(len(record["notices"]), 1)
+        self.assertIn("DRY RUN", record["notices"][0])
+        self.assertIn("DRY RUN", record["summary"])
+
+    # (h) Non-pull_request payload fails instead of silently passing.
+    def test_missing_pull_request_payload_fails(self):
+        record = run_script([commit(1, True)], has_pr=False)
+        self.assertTrue(record["failed"])
+        self.assertIn("pull_request", record["failedMessage"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Pull requests could reach `main` carrying commits GitHub marks as unsigned or unverified — no blocking check made them visible or prevented the merge (recent example: LerianStudio/plugin-br-pix-indirect-btg#721).

This PR adds a reusable commit-signature validation step to the blocking PR checks.

**New composite — `src/validate/pr-commit-signatures`**

- Reads GitHub's own verification verdict (`commit.verification.verified`) for **every** commit in the PR, not only `HEAD`.
- Fetches commits with `github.paginate` (`per_page: 100`), so PRs with more than 100 commits are fully evaluated.
- Reports **all** offending commits at once — job summary table (short SHA + commit link, author, verification status and reason) plus `::error::` annotations — never just the first finding.
- Includes actionable remediation in the summary (`commit.gpgsign`, `git rebase --exec 'git commit --amend --no-edit -S'`, `git push --force-with-lease`).
- Exits 0 when every commit is verified; exits non-zero when any commit is unsigned or unverified.
- Fails **closed** when the PR declares more commits than the Pull Request Commits API returns (250-commit cap), instead of reporting a partial verdict.
- Least-privilege: `contents: read` + `pull-requests: read`; emits no commit metadata beyond what is already visible in the repository and never prints the token.

**Workflow integration**

- New `require_verified_commits` input on `pr-validation.yml` (default `true`), propagated through `go-pr-validation.yml` and `js-pr-validation.yml`.
- The step runs inside the existing **Blocking Checks** job, so consuming repositories inherit the protection with no new branch-protection check.
- Result flows into `pr-blocking-collect`, `pr-checks-summary`, `pr-validation-reporter` and the Slack notification. All new composite inputs default to `skipped`, so direct action consumers are unaffected.
- Skipped on drafts and reported-but-not-enforced under `dry_run: true`, matching the existing blocking checks.

**Affected workflows:** `pr-validation.yml`, `go-pr-validation.yml`, `js-pr-validation.yml`, `self-pr-validation.yml` (test job).

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [x] `test`: Adding or updating tests
- [x] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

`require_verified_commits` defaults to **`true`**, so enforcement is org-wide as soon as callers pick up the new tag. Open pull requests that contain historical unsigned or unverified commits will start failing **Blocking Checks**.

Migration — either re-sign the offending commits:

```bash
git config --local commit.gpgsign true
git rebase --exec 'git commit --amend --no-edit -S' origin/main
git push --force-with-lease
```

…or opt out per caller until the repository is ready:

```yaml
jobs:
  validate:
    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/pr-validation.yml@vX.Y.Z
    with:
      require_verified_commits: false
    secrets: inherit
```

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

`actionlint` clean on all four touched workflows. `src/validate/pr-commit-signatures/test.py` — 8/8 passing locally — extracts the embedded `script:` body from `action.yml` and runs it against a stubbed `core`/`github`/`context`, with an Octokit-faithful `paginate`. Cases: all-verified pass, mixed set reporting every offender, missing `verification` block treated as unverified, 249 commits across 3 pages, 200 verified commits across 2 pages, over-cap fail-closed, dry-run non-failing, and non-`pull_request` payload. Wired into `self-pr-validation.yml` as `Commit Signature Validation Tests`.

Note: the new step references `src/validate/pr-commit-signatures@v1` per the repo's internal pinning policy, so it only resolves once the `v1` major tag is moved by the release. On this PR itself the step will fail to resolve the action until then.

**Caller repo / workflow run:** <!-- pending: run on a caller repo once the tag is published -->

## Related Issues

Closes #688
