### PR TITLE
docs(js-pr-validation): fix opt-in wording for default-enabled pipelines

### DIFF
--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -10,8 +10,8 @@ Umbrella reusable workflow for JavaScript/TypeScript repositories. A caller refe
 1. **PR metadata** — title, source branch, size, labels (delegates to `pr-validation.yml`).
 2. **Breaking Change Guard** — mandatory detection and enforcement inherited from `pr-validation.yml` for every PR target branch, whenever the metadata pipeline runs (see `run_metadata`).
 3. **Change gate** — detects whether the PR touches anything beyond docs/meta (`src/config/non-doc-changes`); documentation-only PRs skip the heavy pipelines.
-4. **Frontend analysis** — lint, typecheck, npm audit, tests, coverage and build (delegates to `frontend-pr-analysis.yml`), opt-in via `run_frontend_analysis`.
-5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`), opt-in via `run_security`.
+4. **Frontend analysis** — lint, typecheck, npm audit, tests, coverage and build (delegates to `frontend-pr-analysis.yml`). Enabled by default; disable with `run_frontend_analysis: false`.
+5. **Security scan** — Trivy, CodeQL, prerelease checks (delegates to `pr-security-scan.yml`). Enabled by default; disable with `run_security: false`.
 6. **Socket supply chain** — refuses malicious packages at install time, turns the Socket App's advisory verdict into an enforceable check, and reports per-package findings split into what this pull request introduced and what the tree already carried. Enabled by default; disable with `run_socket: false`.
 
 The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` aggregator job that exposes a single stable status-check name (`Frontend Analysis`, `Security`, `Socket`) for branch protection, regardless of the internal job names. All are gated by the change detector, so documentation-only PRs skip them (and the aggregators still report success). If the change detector (`changes`) job itself fails, the aggregators propagate that failure instead of passing.


### PR DESCRIPTION
## Description

Documentation-only fix in `docs/js-pr-validation.md`.

Items 4 and 5 of the workflow overview described the **Frontend analysis** and **Security scan** pipelines as "opt-in via `run_frontend_analysis`" / "opt-in via `run_security`". Both reusable-workflow inputs default to `true` (`.github/workflows/js-pr-validation.yml`), so the pipelines are enabled by default and the wording stated the opposite of the actual behavior.

Both items now follow the same wording already used for `run_socket` (item 6): enabled by default, disableable with the corresponding input set to `false`. The inputs table was already correct and was left untouched.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

No workflow file changed, so no caller run is required to validate this PR.

## Related Issues

Closes #646
