### PR TITLE
fix(build): harden on_existing_tag against partial and stale tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,10 @@ on:
         description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push when the tag exists in EVERY enabled registry, still emitting GitOps artifacts for an idempotent re-run; abort when only some registries have it), "repair" (same as skip, but on a partial publish build and push only to the registries missing the tag), or "warn" (warn and build anyway).'
         type: string
         default: 'fail'
+      require_image_provenance:
+        description: 'Under on_existing_tag "skip"/"repair", abort when the existing image does not record the commit it was built from (the org.opencontainers.image.revision label, emitted by docker/metadata-action). An image whose recorded commit differs from this run always aborts, regardless of this input. Set false to accept unverifiable images, e.g. tags published before the label was emitted.'
+        type: boolean
+        default: true
       dockerfile_name:
         description: 'Name of the Dockerfile'
         type: string
@@ -406,6 +410,7 @@ jobs:
           APP_NAME: ${{ matrix.app.name }}
           VERSION: ${{ steps.version.outputs.version }}
           ALL_IMAGES: ${{ steps.image-names.outputs.images }}
+          REQUIRE_PROVENANCE: ${{ inputs.require_image_provenance }}
         run: |
           set -uo pipefail
 
@@ -418,10 +423,29 @@ jobs:
           # Image tag matches what docker/metadata-action publishes (semver without leading 'v').
           TAG="${VERSION#v}"
           EXISTING=""
+          EXISTING_REFS=""
           MISSING=""
           MISSING_IMAGES=""
           ENABLED_COUNT=0
           EXISTING_COUNT=0
+
+          # The commit an image was built from is recorded by docker/metadata-action's
+          # default label set (org.opencontainers.image.revision), which this workflow
+          # feeds to build-push-action. Reading it back is the only thing that tells a
+          # genuine re-run of the same commit apart from a tag that was retargeted to a
+          # newer one — tag existence alone cannot.
+          #
+          # `.Image` is a single image config for a single-platform tag and a
+          # platform-keyed map for a multi-arch one, so the label is picked with a
+          # recursive descent rather than a fixed path. Prints the revision, or nothing
+          # when the lookup fails or the image carries no such label; the caller treats
+          # both as "unverifiable".
+          resolve_revision() {
+            local ref="$1" out
+            if out=$(docker buildx imagetools inspect "$ref" --format '{{json .Image}}' 2>/dev/null); then
+              printf '%s' "$out" | jq -r '[.. | objects | .Labels? | objects | .["org.opencontainers.image.revision"]? | strings] | first // empty'
+            fi
+          }
 
           # `docker manifest inspect` reuses the registry logins from earlier steps and
           # returns non-zero when the tag is absent. A non-existence/error result is
@@ -436,6 +460,7 @@ jobs:
             IMAGE="${DOCKERHUB_ORG}/${APP_NAME}"
             if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
               EXISTING="${EXISTING}${EXISTING:+, }docker.io/${IMAGE}:${TAG}"
+              EXISTING_REFS="${EXISTING_REFS}docker.io/${IMAGE}:${TAG}"$'\n'
               EXISTING_COUNT=$((EXISTING_COUNT + 1))
             else
               MISSING="${MISSING}${MISSING:+, }docker.io/${IMAGE}:${TAG}"
@@ -447,6 +472,7 @@ jobs:
             IMAGE="ghcr.io/${GHCR_ORG}/${APP_NAME}"
             if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
               EXISTING="${EXISTING}${EXISTING:+, }${IMAGE}:${TAG}"
+              EXISTING_REFS="${EXISTING_REFS}${IMAGE}:${TAG}"$'\n'
               EXISTING_COUNT=$((EXISTING_COUNT + 1))
             else
               MISSING="${MISSING}${MISSING:+, }${IMAGE}:${TAG}"
@@ -464,6 +490,38 @@ jobs:
                 exit 1
                 ;;
               skip|repair)
+                # Provenance gate. Both modes reuse an image that is already in the
+                # registry, so an existing tag has to be proven to come from this commit
+                # before it is honoured. Without this, a retargeted tag is skipped (GitOps
+                # deploys the older image) or repaired (the registries end up holding
+                # different content under one immutable tag).
+                DIVERGED=""
+                UNVERIFIABLE=""
+                while IFS= read -r REF; do
+                  [ -z "$REF" ] && continue
+                  REV="$(resolve_revision "$REF")"
+                  if [ -z "$REV" ]; then
+                    UNVERIFIABLE="${UNVERIFIABLE}${UNVERIFIABLE:+, }${REF}"
+                  elif [ "$REV" != "$GITHUB_SHA" ]; then
+                    DIVERGED="${DIVERGED}${DIVERGED:+, }${REF} (built from ${REV})"
+                  fi
+                done <<< "$EXISTING_REFS"
+
+                # A confirmed different commit is never a re-run, so it aborts even with
+                # require_image_provenance disabled — that input only governs the
+                # can't-tell case below.
+                if [ -n "$DIVERGED" ]; then
+                  echo "::error::Tag ${TAG} in the registry was not built from this commit: ${DIVERGED}; this run is at ${GITHUB_SHA}. Registry tags are immutable, so on_existing_tag: ${MODE} would publish the older image. Cut a new version instead of retargeting the tag."
+                  exit 1
+                fi
+                if [ -n "$UNVERIFIABLE" ]; then
+                  if [ "$REQUIRE_PROVENANCE" = "true" ]; then
+                    echo "::error::Cannot verify that tag ${TAG} was built from this commit (${UNVERIFIABLE}): the image carries no org.opencontainers.image.revision label, or the lookup failed. Set require_image_provenance: false to accept unverifiable images, or cut a new version."
+                    exit 1
+                  fi
+                  echo "::warning::Cannot verify that tag ${TAG} was built from this commit (${UNVERIFIABLE}) — proceeding because require_image_provenance is false."
+                fi
+
                 if [ "$EXISTING_COUNT" -eq "$ENABLED_COUNT" ]; then
                   echo "::warning::Tag ${TAG} already exists in every enabled registry (${EXISTING}) — skipping build/push (idempotent re-run)."
                   SHOULD_BUILD=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -587,9 +587,11 @@ jobs:
           else
             echo "Tag ${TAG} not present in enabled registries — proceeding with build."
           fi
-          echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
-          echo "partial_existing=$PARTIAL_EXISTING" >> "$GITHUB_OUTPUT"
-          echo "push_images=$PUSH_IMAGES" >> "$GITHUB_OUTPUT"
+          {
+            echo "should_build=$SHOULD_BUILD"
+            echo "partial_existing=$PARTIAL_EXISTING"
+            echo "push_images=$PUSH_IMAGES"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         if: steps.preflight.outputs.should_build != 'false'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -426,6 +426,7 @@ jobs:
           EXISTING_REFS=""
           MISSING=""
           MISSING_IMAGES=""
+          UNKNOWN=""
           ENABLED_COUNT=0
           EXISTING_COUNT=0
 
@@ -448,9 +449,25 @@ jobs:
           }
 
           # `docker manifest inspect` reuses the registry logins from earlier steps and
-          # returns non-zero when the tag is absent. A non-existence/error result is
-          # treated as "not present" so a flaky check never blocks a legitimate build.
+          # returns non-zero both when the tag is absent and when the lookup itself
+          # fails, so the two are told apart by the registry's own error text. That
+          # distinction carries weight now that "missing from this registry" drives
+          # control flow: counting an unconfirmed registry as missing would make a
+          # transient blip on one registry look exactly like a partial publish.
           #
+          # An unrecognised error is deliberately "unknown" rather than "absent" —
+          # guessing absent is the option that silently loses information.
+          classify_tag() {
+            local ref="$1" err
+            if err=$(docker manifest inspect "$ref" 2>&1 >/dev/null); then
+              printf 'present'
+            elif printf '%s' "$err" | grep -qiE 'manifest unknown|manifest_unknown|no such manifest|not found|repository does not exist|pull access denied'; then
+              printf 'absent'
+            else
+              printf 'unknown'
+            fi
+          }
+
           # Each enabled registry is tracked separately: a previous run can have
           # published to one registry and failed on the other, and "the tag is in
           # every enabled registry" and "the tag is in some of them" are different
@@ -458,26 +475,38 @@ jobs:
           if [ "$ENABLE_DOCKERHUB" = "true" ]; then
             ENABLED_COUNT=$((ENABLED_COUNT + 1))
             IMAGE="${DOCKERHUB_ORG}/${APP_NAME}"
-            if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
-              EXISTING="${EXISTING}${EXISTING:+, }docker.io/${IMAGE}:${TAG}"
-              EXISTING_REFS="${EXISTING_REFS}docker.io/${IMAGE}:${TAG}"$'\n'
-              EXISTING_COUNT=$((EXISTING_COUNT + 1))
-            else
-              MISSING="${MISSING}${MISSING:+, }docker.io/${IMAGE}:${TAG}"
-              MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
-            fi
+            case "$(classify_tag "${IMAGE}:${TAG}")" in
+              present)
+                EXISTING="${EXISTING}${EXISTING:+, }docker.io/${IMAGE}:${TAG}"
+                EXISTING_REFS="${EXISTING_REFS}docker.io/${IMAGE}:${TAG}"$'\n'
+                EXISTING_COUNT=$((EXISTING_COUNT + 1))
+                ;;
+              absent)
+                MISSING="${MISSING}${MISSING:+, }docker.io/${IMAGE}:${TAG}"
+                MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
+                ;;
+              *)
+                UNKNOWN="${UNKNOWN}${UNKNOWN:+, }docker.io/${IMAGE}:${TAG}"
+                ;;
+            esac
           fi
           if [ "$ENABLE_GHCR" = "true" ]; then
             ENABLED_COUNT=$((ENABLED_COUNT + 1))
             IMAGE="ghcr.io/${GHCR_ORG}/${APP_NAME}"
-            if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
-              EXISTING="${EXISTING}${EXISTING:+, }${IMAGE}:${TAG}"
-              EXISTING_REFS="${EXISTING_REFS}${IMAGE}:${TAG}"$'\n'
-              EXISTING_COUNT=$((EXISTING_COUNT + 1))
-            else
-              MISSING="${MISSING}${MISSING:+, }${IMAGE}:${TAG}"
-              MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
-            fi
+            case "$(classify_tag "${IMAGE}:${TAG}")" in
+              present)
+                EXISTING="${EXISTING}${EXISTING:+, }${IMAGE}:${TAG}"
+                EXISTING_REFS="${EXISTING_REFS}${IMAGE}:${TAG}"$'\n'
+                EXISTING_COUNT=$((EXISTING_COUNT + 1))
+                ;;
+              absent)
+                MISSING="${MISSING}${MISSING:+, }${IMAGE}:${TAG}"
+                MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
+                ;;
+              *)
+                UNKNOWN="${UNKNOWN}${UNKNOWN:+, }${IMAGE}:${TAG}"
+                ;;
+            esac
           fi
 
           SHOULD_BUILD=true
@@ -490,6 +519,18 @@ jobs:
                 exit 1
                 ;;
               skip|repair)
+                # A registry whose status could not be determined is not evidence of a
+                # partial publish, and treating it as one would turn a transient lookup
+                # failure into an abort (`skip`) or a push to a registry that may already
+                # hold the tag (`repair`). Stop on the unknown instead of guessing: the
+                # state is unresolved rather than known-bad, and a re-run once the
+                # registry answers is enough. Reached only when another registry did
+                # confirm the tag — when nothing is confirmed there is simply a build.
+                if [ -n "$UNKNOWN" ]; then
+                  echo "::error::Could not determine whether tag ${TAG} exists in ${UNKNOWN} (the registry lookup failed rather than reporting the tag absent). on_existing_tag: ${MODE} needs every enabled registry's status to be known before reusing an existing tag. Re-run once the registry is reachable."
+                  exit 1
+                fi
+
                 # Provenance gate. Both modes reuse an image that is already in the
                 # registry, so an existing tag has to be proven to come from this commit
                 # before it is honoured. Without this, a retargeted tag is skipped (GitOps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ on:
         type: string
         default: ''
       on_existing_tag:
-        description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push when the tag exists in EVERY enabled registry, still emitting GitOps artifacts for an idempotent re-run; when only some registries have it, build and push to the missing ones), or "warn" (warn and build anyway).'
+        description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push when the tag exists in EVERY enabled registry, still emitting GitOps artifacts for an idempotent re-run; abort when only some registries have it), "repair" (same as skip, but on a partial publish build and push only to the registries missing the tag), or "warn" (warn and build anyway).'
         type: string
         default: 'fail'
       dockerfile_name:
@@ -411,8 +411,8 @@ jobs:
 
           MODE="${ON_EXISTING_TAG:-fail}"
           case "$MODE" in
-            fail|skip|warn) ;;
-            *) echo "::error::Invalid on_existing_tag '$MODE' (must be: fail, skip, warn)"; exit 1 ;;
+            fail|skip|repair|warn) ;;
+            *) echo "::error::Invalid on_existing_tag '$MODE' (must be: fail, skip, repair, warn)"; exit 1 ;;
           esac
 
           # Image tag matches what docker/metadata-action publishes (semver without leading 'v').
@@ -428,8 +428,9 @@ jobs:
           # treated as "not present" so a flaky check never blocks a legitimate build.
           #
           # Each enabled registry is tracked separately: a previous run can have
-          # published to one registry and failed on the other, and the two cases
-          # ("everywhere" vs. "somewhere") need different handling under `skip`.
+          # published to one registry and failed on the other, and "the tag is in
+          # every enabled registry" and "the tag is in some of them" are different
+          # situations that `skip` and `repair` must not conflate.
           if [ "$ENABLE_DOCKERHUB" = "true" ]; then
             ENABLED_COUNT=$((ENABLED_COUNT + 1))
             IMAGE="${DOCKERHUB_ORG}/${APP_NAME}"
@@ -462,18 +463,22 @@ jobs:
                 echo "::error::Tag ${TAG} already exists (${EXISTING}). Registry tags are immutable; aborting before rebuild. Use on_existing_tag: skip for idempotent re-runs."
                 exit 1
                 ;;
-              skip)
+              skip|repair)
                 if [ "$EXISTING_COUNT" -eq "$ENABLED_COUNT" ]; then
                   echo "::warning::Tag ${TAG} already exists in every enabled registry (${EXISTING}) — skipping build/push (idempotent re-run)."
                   SHOULD_BUILD=false
-                else
-                  # Partial publish: skipping here would emit GitOps artifacts for a tag
-                  # that is absent from at least one enabled registry. Build once and push
-                  # only where it is missing, leaving the immutable tags already in place
-                  # untouched.
-                  echo "::warning::Tag ${TAG} exists in ${EXISTING} but is missing from ${MISSING} (partial publish) — building and pushing only to the missing registry/registries."
+                elif [ "$MODE" = "repair" ]; then
+                  # Partial publish, repair opted in: build once and push only where the
+                  # tag is missing, leaving the immutable tags already in place untouched.
+                  echo "::warning::Tag ${TAG} exists in ${EXISTING} but is missing from ${MISSING} (partial publish) — repairing: building and pushing only to the missing registry/registries."
                   PARTIAL_EXISTING=true
                   PUSH_IMAGES="$MISSING_IMAGES"
+                else
+                  # Partial publish under `skip`. Skipping would emit GitOps artifacts for
+                  # a tag that is absent from an enabled registry, so the run stops instead
+                  # of publishing a reference that is not resolvable everywhere.
+                  echo "::error::Tag ${TAG} exists in ${EXISTING} but is missing from ${MISSING} — partial publish. Skipping would emit GitOps artifacts for a tag that is absent from an enabled registry. Use on_existing_tag: repair to build and push only the missing registries, or cut a new version."
+                  exit 1
                 fi
                 ;;
               warn)
@@ -493,7 +498,7 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           # Every enabled registry, except under a partial-publish repair
-          # (`on_existing_tag: skip`), where it narrows to the missing ones only.
+          # (`on_existing_tag: repair`), where it narrows to the missing ones only.
           images: ${{ steps.preflight.outputs.push_images }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
@@ -520,8 +525,8 @@ jobs:
       # ----------------- Cosign Image Signing -----------------
       # Lets `on_existing_tag: skip` retry just the signing step for an already-pushed
       # tag (e.g. after a transient cosign/Rekor failure) without a full rebuild.
-      # Also runs after a partial-publish repair, where the registry that already
-      # carried the tag has its own (possibly different) digest to resolve.
+      # Also runs after an `on_existing_tag: repair` partial publish, where the registry
+      # that already carried the tag has its own (possibly different) digest to resolve.
       - name: Resolve digest for existing tag
         if: inputs.enable_cosign_sign && (steps.preflight.outputs.should_build == 'false' || steps.preflight.outputs.partial_existing == 'true')
         id: existing-digest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ on:
         type: string
         default: ''
       on_existing_tag:
-        description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push, still emit GitOps artifacts for an idempotent re-run), or "warn" (warn and build anyway).'
+        description: 'Behaviour when the target image tag already exists in an enabled registry (checked before build): "fail" (abort early, default), "skip" (skip build/push when the tag exists in EVERY enabled registry, still emitting GitOps artifacts for an idempotent re-run; when only some registries have it, build and push to the missing ones), or "warn" (warn and build anyway).'
         type: string
         default: 'fail'
       dockerfile_name:
@@ -405,6 +405,7 @@ jobs:
           GHCR_ORG: ${{ steps.image-names.outputs.ghcr_org }}
           APP_NAME: ${{ matrix.app.name }}
           VERSION: ${{ steps.version.outputs.version }}
+          ALL_IMAGES: ${{ steps.image-names.outputs.images }}
         run: |
           set -uo pipefail
 
@@ -417,24 +418,44 @@ jobs:
           # Image tag matches what docker/metadata-action publishes (semver without leading 'v').
           TAG="${VERSION#v}"
           EXISTING=""
+          MISSING=""
+          MISSING_IMAGES=""
+          ENABLED_COUNT=0
+          EXISTING_COUNT=0
 
           # `docker manifest inspect` reuses the registry logins from earlier steps and
           # returns non-zero when the tag is absent. A non-existence/error result is
           # treated as "not present" so a flaky check never blocks a legitimate build.
+          #
+          # Each enabled registry is tracked separately: a previous run can have
+          # published to one registry and failed on the other, and the two cases
+          # ("everywhere" vs. "somewhere") need different handling under `skip`.
           if [ "$ENABLE_DOCKERHUB" = "true" ]; then
-            REF="${DOCKERHUB_ORG}/${APP_NAME}:${TAG}"
-            if docker manifest inspect "$REF" >/dev/null 2>&1; then
-              EXISTING="${EXISTING}${EXISTING:+, }docker.io/${REF}"
+            ENABLED_COUNT=$((ENABLED_COUNT + 1))
+            IMAGE="${DOCKERHUB_ORG}/${APP_NAME}"
+            if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+              EXISTING="${EXISTING}${EXISTING:+, }docker.io/${IMAGE}:${TAG}"
+              EXISTING_COUNT=$((EXISTING_COUNT + 1))
+            else
+              MISSING="${MISSING}${MISSING:+, }docker.io/${IMAGE}:${TAG}"
+              MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
             fi
           fi
           if [ "$ENABLE_GHCR" = "true" ]; then
-            REF="ghcr.io/${GHCR_ORG}/${APP_NAME}:${TAG}"
-            if docker manifest inspect "$REF" >/dev/null 2>&1; then
-              EXISTING="${EXISTING}${EXISTING:+, }${REF}"
+            ENABLED_COUNT=$((ENABLED_COUNT + 1))
+            IMAGE="ghcr.io/${GHCR_ORG}/${APP_NAME}"
+            if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+              EXISTING="${EXISTING}${EXISTING:+, }${IMAGE}:${TAG}"
+              EXISTING_COUNT=$((EXISTING_COUNT + 1))
+            else
+              MISSING="${MISSING}${MISSING:+, }${IMAGE}:${TAG}"
+              MISSING_IMAGES="${MISSING_IMAGES}${MISSING_IMAGES:+,}${IMAGE}"
             fi
           fi
 
           SHOULD_BUILD=true
+          PARTIAL_EXISTING=false
+          PUSH_IMAGES="$ALL_IMAGES"
           if [ -n "$EXISTING" ]; then
             case "$MODE" in
               fail)
@@ -442,8 +463,18 @@ jobs:
                 exit 1
                 ;;
               skip)
-                echo "::warning::Tag ${TAG} already exists (${EXISTING}) — skipping build/push (idempotent re-run)."
-                SHOULD_BUILD=false
+                if [ "$EXISTING_COUNT" -eq "$ENABLED_COUNT" ]; then
+                  echo "::warning::Tag ${TAG} already exists in every enabled registry (${EXISTING}) — skipping build/push (idempotent re-run)."
+                  SHOULD_BUILD=false
+                else
+                  # Partial publish: skipping here would emit GitOps artifacts for a tag
+                  # that is absent from at least one enabled registry. Build once and push
+                  # only where it is missing, leaving the immutable tags already in place
+                  # untouched.
+                  echo "::warning::Tag ${TAG} exists in ${EXISTING} but is missing from ${MISSING} (partial publish) — building and pushing only to the missing registry/registries."
+                  PARTIAL_EXISTING=true
+                  PUSH_IMAGES="$MISSING_IMAGES"
+                fi
                 ;;
               warn)
                 echo "::warning::Tag ${TAG} already exists (${EXISTING}) — building anyway (push may fail on immutable registries)."
@@ -453,13 +484,17 @@ jobs:
             echo "Tag ${TAG} not present in enabled registries — proceeding with build."
           fi
           echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
+          echo "partial_existing=$PARTIAL_EXISTING" >> "$GITHUB_OUTPUT"
+          echo "push_images=$PUSH_IMAGES" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         if: steps.preflight.outputs.should_build != 'false'
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: ${{ steps.image-names.outputs.images }}
+          # Every enabled registry, except under a partial-publish repair
+          # (`on_existing_tag: skip`), where it narrows to the missing ones only.
+          images: ${{ steps.preflight.outputs.push_images }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
 
@@ -485,8 +520,10 @@ jobs:
       # ----------------- Cosign Image Signing -----------------
       # Lets `on_existing_tag: skip` retry just the signing step for an already-pushed
       # tag (e.g. after a transient cosign/Rekor failure) without a full rebuild.
+      # Also runs after a partial-publish repair, where the registry that already
+      # carried the tag has its own (possibly different) digest to resolve.
       - name: Resolve digest for existing tag
-        if: inputs.enable_cosign_sign && steps.preflight.outputs.should_build == 'false'
+        if: inputs.enable_cosign_sign && (steps.preflight.outputs.should_build == 'false' || steps.preflight.outputs.partial_existing == 'true')
         id: existing-digest
         env:
           APP_NAME: ${{ matrix.app.name }}
@@ -570,6 +607,7 @@ jobs:
           DOCKERHUB_ORG: ${{ inputs.dockerhub_org }}
           APP_NAME: ${{ matrix.app.name }}
           GHCR_ORG: ${{ steps.image-names.outputs.ghcr_org }}
+          PARTIAL_EXISTING: ${{ steps.preflight.outputs.partial_existing }}
         run: |
           REFS=""
 
@@ -578,8 +616,19 @@ jobs:
           # was skipped (existing tag), fall back to each registry's own resolved
           # digest instead, and only emit a ref when that registry's digest was
           # actually found.
-          DOCKERHUB_FINAL="${DIGEST:-$DOCKERHUB_DIGEST}"
-          GHCR_FINAL="${DIGEST:-$GHCR_DIGEST}"
+          #
+          # A partial-publish repair is the exception: build-push only pushed to
+          # the registry that was missing the tag, so its digest does not describe
+          # the image the other registry already carries (a rebuild is not
+          # bit-for-bit reproducible). Both registries use their own resolved
+          # digest there, read back from the registry after the push.
+          if [ "$PARTIAL_EXISTING" == "true" ]; then
+            DOCKERHUB_FINAL="$DOCKERHUB_DIGEST"
+            GHCR_FINAL="$GHCR_DIGEST"
+          else
+            DOCKERHUB_FINAL="${DIGEST:-$DOCKERHUB_DIGEST}"
+            GHCR_FINAL="${DIGEST:-$GHCR_DIGEST}"
+          fi
 
           if [ "$ENABLE_DOCKERHUB" == "true" ] && [ -n "$DOCKERHUB_FINAL" ]; then
             REFS="docker.io/${DOCKERHUB_ORG}/${APP_NAME}@${DOCKERHUB_FINAL}"

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -104,6 +104,7 @@ jobs:
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `ghcr_org` | string | `''` | GHCR organization (defaults to repository owner) |
 | `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push when every enabled registry already has the tag, still emitting GitOps artifacts for an idempotent re-run; abort on a partial publish), `repair` (same as `skip`, but on a partial publish push only to the registries missing the tag), `warn` (warn and build anyway) |
+| `require_image_provenance` | boolean | `true` | Under `on_existing_tag: skip`/`repair`, abort when the existing image does not record the commit it was built from (`org.opencontainers.image.revision`). An image whose recorded commit *differs* from this run always aborts, regardless of this input. Set `false` to accept unverifiable images (e.g. tags published before the label was emitted) |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
 | `tag_prefix` | string | `''` | Skip this build entirely (`has_builds=false`) when triggered by a tag that does not start with this prefix. For callers with multiple independently-tagged components sharing one workflow_call chain. Empty = build on every tag |
 | `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
@@ -153,7 +154,26 @@ A partial publish is an accident, not a normal state, so the default path is to 
 
 `repair` exists for the residual case that cleanup cannot reach: a registry with tag immutability enabled, where deleting the partially published tag is not possible at all. It builds once and pushes only where the tag is missing, leaving the immutable tags already in place untouched. Cosign then signs each registry with its own digest read back from that registry, since a rebuild is not bit-for-bit reproducible and the newly pushed digest does not describe the image the other registry already carries.
 
-> **`repair` assumes the commit has not moved.** Neither `skip` nor `repair` compares the existing image against the current commit. If the tag was retargeted to a newer commit, `skip` deploys the older image and `repair` leaves the two registries holding different content under the same tag. Retargeting a released semver tag is an anti-pattern for exactly this reason — cut a new patch version instead.
+### Image provenance
+
+Tag existence alone does not prove the image in the registry is the code this run is building. Two situations look identical to a `docker manifest inspect`:
+
+- **A genuine re-run.** The push succeeded earlier and something after it failed (cosign, the GitOps upload, the Helm dispatch). The registry image *is* the merged code — this is what `skip` is for.
+- **A retargeted tag.** A released semver tag was deleted and recreated on a newer commit. Registry tags are immutable, so the registry still holds the image built from the **old** commit. Skipping would have GitOps deploy the older code, and repairing would leave the registries holding different content under one tag.
+
+So before `skip` or `repair` reuses an existing tag, the pre-flight reads `org.opencontainers.image.revision` off the existing image (`docker buildx imagetools inspect`) and compares it with the run's commit. `docker/metadata-action` emits that label by default and this workflow passes its label set to the build, so every image it publishes carries the commit it came from.
+
+| Recorded commit | Behaviour |
+|---|---|
+| matches this run | proceed with `skip` / `repair` as described above |
+| differs from this run | **abort**, naming both commits — always, regardless of `require_image_provenance` |
+| absent, or the lookup failed | abort when `require_image_provenance: true` (default); warn and proceed when `false` |
+
+A confirmed different commit is never a re-run, so it is not something an input should be able to wave through. `require_image_provenance` governs only the can't-tell case — set it to `false` for repositories whose registry still holds tags published before the label was emitted, and images that *do* carry the label are still checked.
+
+`fail` and `warn` never reach this gate: neither reuses an existing image.
+
+Retargeting a released semver tag stays an anti-pattern — cut a new patch version instead. The gate is there so CI fails loudly rather than deploying stale code quietly.
 
 ## Platform Build Strategy
 

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -103,7 +103,7 @@ jobs:
 | `enable_ghcr` | boolean | `true` | Enable pushing to GitHub Container Registry (requires `MANAGE_TOKEN`) |
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `ghcr_org` | string | `''` | GHCR organization (defaults to repository owner) |
-| `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push when every enabled registry already has the tag, still emitting GitOps artifacts for an idempotent re-run; push only to the missing registries when some do not), `warn` (warn and build anyway) |
+| `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push when every enabled registry already has the tag, still emitting GitOps artifacts for an idempotent re-run; abort on a partial publish), `repair` (same as `skip`, but on a partial publish push only to the registries missing the tag), `warn` (warn and build anyway) |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
 | `tag_prefix` | string | `''` | Skip this build entirely (`has_builds=false`) when triggered by a tag that does not start with this prefix. For callers with multiple independently-tagged components sharing one workflow_call chain. Empty = build on every tag |
 | `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
@@ -134,15 +134,26 @@ Before building, the workflow checks whether the target image tag already exists
 
 - **`fail`** (default): abort early with a clear error instead of rebuilding then failing at push.
 - **`skip`**: skip the build/push but still emit the GitOps tag artifacts (from the version), so a re-run remains idempotent for the downstream GitOps update. Cosign signing (if enabled) also retries in this mode: the digest is resolved from the existing registry tag via `docker buildx imagetools inspect` instead of the build/push step, so a transient signing failure on an already-pushed tag can be recovered with a plain re-run instead of cutting a new release. The skip requires the tag in **every** enabled registry — see partial publishes below.
+- **`repair`**: same as `skip`, plus it repairs a partial publish instead of aborting on it. Opt-in — see partial publishes below.
 - **`warn`**: emit a warning and build anyway (push may still fail on immutable registries).
 
 A non-existent tag (or a check that errors out, e.g. transient registry issues) is treated as "not present" so the check never blocks a legitimate build.
 
-### Partial publishes under `skip`
+### Partial publishes
 
-When more than one registry is enabled, a previous run can have published to one and failed on the other (e.g. the DockerHub push succeeded and the GHCR push did not). Skipping outright there would emit a GitOps tag artifact for a tag that is missing from an enabled registry.
+When more than one registry is enabled, a previous run can have published to one and failed on the other (e.g. the DockerHub push succeeded and the GHCR push did not). Skipping outright there would emit a GitOps tag artifact for a tag that is missing from an enabled registry, so `skip` short-circuits **only** when every enabled registry already has the tag:
 
-So `skip` short-circuits only when **every** enabled registry already has the tag. When only some do, the pre-flight reports which registries are missing it, then builds once and pushes **only** to those — the immutable tags already in place are left untouched. Cosign signs each registry with its own digest read back from that registry, since a rebuild is not bit-for-bit reproducible and the newly pushed digest does not describe the image the other registry already carries.
+| Tag present in | `fail` (default) | `skip` | `repair` | `warn` |
+|---|---|---|---|---|
+| no registry | build | build | build | build |
+| some registries | abort | **abort**, naming the missing ones | build, push **only** to the missing ones | build, push to all |
+| every registry | abort | skip, emit GitOps artifacts | skip, emit GitOps artifacts | build, push to all |
+
+A partial publish is an accident, not a normal state, so the default path is to stop and report it rather than paper over it. Prefer removing the partially published tag and cutting a fresh run, or cut a new version outright.
+
+`repair` exists for the residual case that cleanup cannot reach: a registry with tag immutability enabled, where deleting the partially published tag is not possible at all. It builds once and pushes only where the tag is missing, leaving the immutable tags already in place untouched. Cosign then signs each registry with its own digest read back from that registry, since a rebuild is not bit-for-bit reproducible and the newly pushed digest does not describe the image the other registry already carries.
+
+> **`repair` assumes the commit has not moved.** Neither `skip` nor `repair` compares the existing image against the current commit. If the tag was retargeted to a newer commit, `skip` deploys the older image and `repair` leaves the two registries holding different content under the same tag. Retargeting a released semver tag is an anti-pattern for exactly this reason — cut a new patch version instead.
 
 ## Platform Build Strategy
 

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -138,7 +138,9 @@ Before building, the workflow checks whether the target image tag already exists
 - **`repair`**: same as `skip`, plus it repairs a partial publish instead of aborting on it. Opt-in — see partial publishes below.
 - **`warn`**: emit a warning and build anyway (push may still fail on immutable registries).
 
-A non-existent tag (or a check that errors out, e.g. transient registry issues) is treated as "not present" so the check never blocks a legitimate build.
+`docker manifest inspect` exits non-zero both when the tag is absent and when the lookup itself fails, so the pre-flight reads the registry's error text to tell the two apart — a tag is only treated as missing when the registry actually reports it absent. When no registry confirms the tag, an errored check still counts as "not present" and the build proceeds, so a flaky check never blocks a legitimate build.
+
+When one registry confirms the tag and another could not be reached, `skip` and `repair` abort naming the unreachable registry: an undetermined status is not evidence of a partial publish, and guessing either way is wrong (`skip` would publish a GitOps reference it cannot vouch for, `repair` would push to a registry that may already hold the immutable tag). A re-run once the registry answers is enough. `fail` and `warn` are unaffected — neither depends on which registries are missing the tag.
 
 ### Partial publishes
 

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -103,7 +103,7 @@ jobs:
 | `enable_ghcr` | boolean | `true` | Enable pushing to GitHub Container Registry (requires `MANAGE_TOKEN`) |
 | `dockerhub_org` | string | `lerianstudio` | DockerHub organization name |
 | `ghcr_org` | string | `''` | GHCR organization (defaults to repository owner) |
-| `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push, still emit GitOps artifacts for an idempotent re-run), `warn` (warn and build anyway) |
+| `on_existing_tag` | string | `fail` | Behaviour when the target tag already exists in an enabled registry (pre-flight check before build): `fail` (abort early), `skip` (skip build/push when every enabled registry already has the tag, still emitting GitOps artifacts for an idempotent re-run; push only to the missing registries when some do not), `warn` (warn and build anyway) |
 | `dockerfile_name` | string | `Dockerfile` | Name of the Dockerfile |
 | `tag_prefix` | string | `''` | Skip this build entirely (`has_builds=false`) when triggered by a tag that does not start with this prefix. For callers with multiple independently-tagged components sharing one workflow_call chain. Empty = build on every tag |
 | `app_name_prefix` | string | `''` | Prefix for app names in monorepo |
@@ -133,10 +133,16 @@ Uses `secrets: inherit` pattern. Required secrets:
 Before building, the workflow checks whether the target image tag already exists in each enabled registry (via `docker manifest inspect`, reusing the registry logins). This avoids a full rebuild that would only fail at push time on registries with tag immutability enabled. Behaviour is controlled by `on_existing_tag`:
 
 - **`fail`** (default): abort early with a clear error instead of rebuilding then failing at push.
-- **`skip`**: skip the build/push but still emit the GitOps tag artifacts (from the version), so a re-run remains idempotent for the downstream GitOps update. Cosign signing (if enabled) also retries in this mode: the digest is resolved from the existing registry tag via `docker buildx imagetools inspect` instead of the build/push step, so a transient signing failure on an already-pushed tag can be recovered with a plain re-run instead of cutting a new release.
+- **`skip`**: skip the build/push but still emit the GitOps tag artifacts (from the version), so a re-run remains idempotent for the downstream GitOps update. Cosign signing (if enabled) also retries in this mode: the digest is resolved from the existing registry tag via `docker buildx imagetools inspect` instead of the build/push step, so a transient signing failure on an already-pushed tag can be recovered with a plain re-run instead of cutting a new release. The skip requires the tag in **every** enabled registry — see partial publishes below.
 - **`warn`**: emit a warning and build anyway (push may still fail on immutable registries).
 
 A non-existent tag (or a check that errors out, e.g. transient registry issues) is treated as "not present" so the check never blocks a legitimate build.
+
+### Partial publishes under `skip`
+
+When more than one registry is enabled, a previous run can have published to one and failed on the other (e.g. the DockerHub push succeeded and the GHCR push did not). Skipping outright there would emit a GitOps tag artifact for a tag that is missing from an enabled registry.
+
+So `skip` short-circuits only when **every** enabled registry already has the tag. When only some do, the pre-flight reports which registries are missing it, then builds once and pushes **only** to those — the immutable tags already in place are left untouched. Cosign signs each registry with its own digest read back from that registry, since a rebuild is not bit-for-bit reproducible and the newly pushed digest does not describe the image the other registry already carries.
 
 ## Platform Build Strategy
 


### PR DESCRIPTION
## Description

Two related pre-flight defects in `.github/workflows/build.yml`: the tag-existence check conflated "the tag is in some registries" with "the tag is everywhere" (#648), and it never checked that an existing tag was built from the current commit (#696).

### 1. Partial publishes (#648)

The pre-flight set `should_build=false` as soon as the target tag existed in **any** enabled registry (`if [ -n "$EXISTING" ]`), and the GitOps artifacts were still emitted afterwards. After a partial publish — DockerHub push succeeded, GHCR push failed — a re-run with `skip` published nothing and updated GitOps with a tag missing from an enabled registry.

Each enabled registry is now tracked independently. A partial publish is an accident, not a normal state, so `skip` aborts and names the registries missing the tag. Repairing it is available only when explicitly asked for, via a new `repair` mode:

| Tag present in | `fail` (default) | `skip` | `repair` (new) | `warn` |
|---|---|---|---|---|
| no registry | build | build | build | build |
| some registries | abort | **abort**, naming the missing ones | build, push **only** to the missing ones | build, push to all |
| every registry | abort | skip, emit GitOps artifacts | skip, emit GitOps artifacts | build, push to all |

`repair` covers the residual case a cleanup cannot reach: a registry with tag immutability enabled, where deleting the partially published tag is impossible. The narrowed push target is exposed as a new `push_images` step output and fed to `docker/metadata-action`, so tags already in place are never re-pushed.

Cosign needs a further distinction there. `build-push` only pushed to the registry that was missing the tag, so its digest does not describe the image the other registry already carries — a rebuild is not bit-for-bit reproducible. `Resolve digest for existing tag` therefore also runs on a repair, and `Build cosign image references` stops applying the `build-push` digest to both registries when `partial_existing == 'true'`, using each registry's own resolved digest. Without this, cosign would sign a nonexistent ref in the registry published earlier.

### 2. Image provenance (#696)

Tag existence never proved the registry image was the code being built. A genuine re-run (push succeeded, something after it failed) and a **retargeted tag** (semver tag deleted and recreated on a newer commit) are indistinguishable to `docker manifest inspect`. So `skip` could hand GitOps an image built from an older commit — silently deploying stale code — and `repair` could leave the enabled registries holding different content under one immutable tag, both signed, because cosign resolves each digest independently.

The pre-flight now reads `org.opencontainers.image.revision` off the existing image (`docker buildx imagetools inspect`) and compares it with the run's commit before either mode reuses the tag. `docker/metadata-action` emits that label by default and this workflow already passes its label set to the build, so no producer-side change was needed.

| Recorded commit | Behaviour |
|---|---|
| matches this run | proceed with `skip` / `repair` |
| differs from this run | **abort**, naming both commits — always |
| absent, or lookup failed | abort when `require_image_provenance: true` (default); warn and proceed when `false` |

A confirmed different commit is never a re-run, so no input waves it through. The new `require_image_provenance` input (boolean, default `true`) governs only the can't-tell case — for registries still holding tags published before the label existed. Images that *do* carry the label are still checked when it is `false`.

`fail` and `warn` never reach the gate: neither reuses an existing image.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

No input, output or secret is renamed or removed. `repair` is a new accepted value of the existing `on_existing_tag` string input, and `require_image_provenance` is a new optional input — both additive.

Two observable behaviour changes, both converting a silent wrong result into a loud failure, and both scoped to callers already using `on_existing_tag: skip` (or the new `repair`) **with an existing tag**:

```
1. skip + partial publish
   Before:  nothing published; GitOps artifact emitted for a tag missing
            from an enabled registry
   After:   run aborts, naming the registries missing the tag
            (opt into `repair` to have it published instead)

2. skip/repair + existing tag whose provenance does not match
   Before:  tag reused unconditionally; a retargeted tag deployed stale code
   After:   run aborts naming both commits (divergent), or aborts asking for
            `require_image_provenance: false` (unverifiable)
```

Callers on registries holding pre-label images set `require_image_provenance: false` to keep re-running. `fail`, `warn`, and the no-tag-anywhere path of every mode are byte-for-byte identical.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

`actionlint .github/workflows/build.yml` passes clean.

The pre-flight `run:` block was **extracted verbatim from the workflow** (not retyped) and exercised against a stubbed `docker` providing both `manifest inspect` and `buildx imagetools inspect`, asserting on exit code and the emitted step outputs.

Existence matrix — `{no registry, both, DockerHub only, GHCR only} × {fail, skip, repair, warn}`, plus single-registry and invalid-mode:

- `fail` → exits 1 whenever any registry has the tag
- `skip` / `repair` + both present → `should_build=false`
- `skip` + one registry only → exits 1 naming the missing ref
- `repair` + DockerHub only → `partial=true`, `push_images=ghcr.io/<org>/<app>`
- `repair` + GHCR only → `partial=true`, `push_images=<org>/<app>`
- any mode + no registry → full build, `push_images` = every enabled registry
- `warn` → always builds, pushes to all, in all four presence cases
- single enabled registry with the tag → `should_build=false` (partial unreachable with one registry)
- unknown mode → exits 1 listing the four valid values

Provenance matrix — label shapes were verified against both `.Image` layouts (single-platform config and platform-keyed multi-arch map) plus missing/null/absent-label JSON:

- `skip`/`repair`, recorded commit == run commit → proceeds as before
- `skip`/`repair`, recorded commit != run commit → exits 1, both commits in the message
- same, with `require_image_provenance: false` → **still** exits 1 (divergence is not waivable)
- label absent, strict → exits 1 pointing at `require_image_provenance: false`
- label absent, lax → warns, proceeds
- `imagetools` lookup error, lax → warns, proceeds
- mixed across registries (one matching, one divergent) → exits 1 naming only the divergent ref
- mixed (one matching, one unlabelled), strict → exits 1 naming only the unverifiable ref
- `fail` + existing tag, `warn` + retargeted tag, and every no-tag-anywhere case → gate never runs

Registry-status matrix (added after CodeRabbit flagged that a failed lookup was being counted as a missing tag):

- one registry confirms the tag, the other's lookup errors, `skip`/`repair` → exits 1 naming the unreachable registry, *not* reported as a partial publish
- every registry's lookup errors, all four modes → treated as not present, full build proceeds (unchanged; the flaky-check property holds)
- one confirms, other confirmed **absent** → still the partial-publish path (`skip` aborts, `repair` narrows `push_images`)
- `fail` / `warn` with a tag present and another registry unreachable → unchanged behaviour, the unknown bucket is never consulted

**Caller repo / workflow run:** not yet. Needs a run on `backoffice-console` (which adopted `skip` in LerianStudio/backoffice-console#208) to exercise the partial and provenance paths against real registries.

## Related Issues

Closes #648
Closes #696

Prevention work tracked separately in #451 (`cleanup_on_failure`): removing a partially published tag so there is nothing to repair in the first place. That is orthogonal — #451 prevents the partial state, this PR detects and refuses to paper over it.
