### PR TITLE
chore(deployment-matrix): register plugin-br-pix-lerian

### DIFF
--- a/config/deployment-matrix.yml
+++ b/config/deployment-matrix.yml
@@ -76,6 +76,7 @@ apps:
     - plugin-access-manager-caradhras  # pre-promotion test instance of the plugin-access-manager auth-backend, running the caradhras image; pushed by LerianStudio/caradhras via gitops_app_name (its image is ghcr.io/lerianstudio/caradhras, so the repo name alone does not match this app dir)
     - plugin-fees
     - plugin-br-pix-indirect-btg
+    - plugin-br-pix-lerian        # new name of plugin-br-pix-switch; both entries coexist until the repo rename cutover completes
     - plugin-br-pix-switch
     - plugin-br-bank-transfer
     - plugin-br-payments
@@ -133,6 +134,7 @@ clusters:
       - plugin-access-manager
       - plugin-fees
       - plugin-br-pix-indirect-btg
+      - plugin-br-pix-lerian
       - plugin-br-pix-switch
       - br-sisbajud
       - lender
@@ -181,6 +183,7 @@ clusters:
       - plugin-access-manager-caradhras
       - plugin-fees
       - plugin-br-pix-indirect-btg
+      - plugin-br-pix-lerian
       - plugin-br-pix-switch
       - plugin-br-bank-transfer
       - plugin-br-payments


### PR DESCRIPTION
Requested by: @Leonardox7

## Description

Additive preparation for the **Pix Switch -> Pix Lerian** rename: the
`plugin-br-pix-switch` repository is being renamed to `plugin-br-pix-lerian`, and
this shared deployment matrix has to know the new app name **before** the rename
lands on GitHub.

`gitops-update.yml` resolves target clusters by looking the caller's `app_name` up
in `config/deployment-matrix.yml`. If the new name is not registered when the first
post-rename release runs, resolution returns an empty cluster set — the workflow
emits `App '<name>' is not registered in any cluster of the deployment matrix` and
deploys nowhere. Registering the name first removes that window.

Affected workflow: `gitops-update.yml` (manifest data only — no workflow logic
changed).

**`plugin-br-pix-lerian` added to three lists**, so it resolves to exactly the same
cluster set as the current name:

| List | Change |
|---|---|
| `apps.registry` | `+ plugin-br-pix-lerian` |
| `clusters.anacleto.apps` | `+ plugin-br-pix-lerian` |
| `clusters.benedita.apps` | `+ plugin-br-pix-lerian` |

### The old entry is preserved on purpose

`plugin-br-pix-switch` is **not** touched — no line is removed or modified
(`+3 / -0`). Both names must resolve for the whole cutover:

- Releases cut from the repository before the rename still push as
  `plugin-br-pix-switch`.
- Rolling the rename back has to leave a working deployment path.

Removing `plugin-br-pix-switch` is a deliberate later change, once the cutover is
finished and nothing publishes under the old name any more. A diff that dropped it
here would break the rollback path.

Tracked as Lerian Map initiative 464, card #4632 ("Preparação do novo nome"),
Epic 1.2 / Task 1.2.2.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [x] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Purely additive — every app already in the manifest resolves to the same
clusters as before.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Validation performed locally**

1. **This repo's own manifest linter** — the validator extracted verbatim from
   `src/lint/deployment-matrix/action.yml` (the same composite the
   `deployment-matrix` job runs in `self-pr-validation.yml`, which is triggered
   because `config/deployment-matrix.yml` is in the changed-file set):

   ```
   Deployment matrix is valid (40 apps registered, 2 clusters defined).
   exit=0
   ```

   Zero violations and zero warnings. No orphan warning for the new app, which
   confirms it is referenced by at least one cluster and not just registered.

2. **Cluster resolution, both names** — replaying the exact `yq | jq` query from
   the `Resolve target clusters from deployment matrix` step of
   `gitops-update.yml`:

   ```
   plugin-br-pix-switch -> [anacleto benedita]
   plugin-br-pix-lerian -> [anacleto benedita]
   ```

   Old and new name resolve to an identical cluster set, which is the property this
   PR exists to guarantee.

3. **yamllint** with the repo's `.yamllint.yml` — exit 0. The single reported
   `line-length` warning is on line 76 (`plugin-access-manager-caradhras`) and is
   pre-existing, untouched by this diff.

The caller-repo checkbox is intentionally unchecked: an end-to-end run under the new
name is only possible after the repository rename itself, which is the next step of
the cutover. This PR is the prerequisite that makes that run resolvable.

## Merge and Release Gates

The diff itself is reviewed and correct. It is **not** sufficient on its own: three
gates stand between this PR and a working post-rename deploy. They are listed in the
order they must be satisfied.

### Gate 1 — merging to `develop` alone has no runtime effect

`gitops-update.yml` does not read the matrix from the branch it runs on. It
checks the manifest out of this repository at an explicit ref:

- `.github/workflows/gitops-update.yml:30-33` — declares the input:
  ```yaml
  deployment_matrix_ref:
    description: 'Git ref of LerianStudio/github-actions-shared-workflows to read the deployment matrix from. Defaults to main (always latest). Override only when testing a branch.'
    type: string
    default: 'main'
  ```
- `.github/workflows/gitops-update.yml:186-190` — consumes it as the checkout ref:
  ```yaml
  - name: Checkout deployment matrix manifest
    uses: actions/checkout@...
    with:
      repository: LerianStudio/github-actions-shared-workflows
      ref: ${{ inputs.deployment_matrix_ref }}
  ```

The two release workflows pass the input straight through with the same `main`
default: `go-release.yml:212-215` and `:807`, `js-release.yml:176` and `:461`.

**Consequence:** while this change sits only on `develop`, every release that does
not explicitly override `deployment_matrix_ref` still reads the `main` copy of
`config/deployment-matrix.yml`, which does not contain `plugin-br-pix-lerian`. The
change must be **promoted through to `main`** before the repository rename lands.
Merging here is step one of two.

### Gate 2 — the new GitOps paths do not exist yet, and this PR makes their absence quieter

Measured in `LerianStudio/lerian-internal-gitops` at `main`:

| Name | Paths present |
|---|---|
| `plugin-br-pix-switch` | **28** |
| `plugin-br-pix-lerian` | **0** |

The 28 breaks down as 21 files plus 7 directories. Of those, **7 are `values.yaml`
files** — the exact artefacts the lookup below resolves, and therefore the set the
GitOps PR has to recreate under the new name:

```
gitops/environments/anacleto/helmfile/applications/chaos/dev-st/plugin-br-pix-switch/values.yaml
gitops/environments/anacleto/helmfile/applications/chaos/stg-st/plugin-br-pix-switch/values.yaml
gitops/environments/anacleto/helmfile/applications/fuzzing/dev-st/plugin-br-pix-switch/values.yaml
gitops/environments/anacleto/helmfile/applications/fuzzing/stg-st/plugin-br-pix-switch/values.yaml
gitops/environments/anacleto/helmfile/applications/stg-mt/plugin-br-pix-switch/values.yaml
gitops/environments/benedita/helmfile/applications/dev-st/plugin-br-pix-switch/values.yaml
gitops/environments/benedita/helmfile/applications/stg-mt/plugin-br-pix-switch/values.yaml
```

Alongside them sit 7 ArgoCD `Application` manifests under
`environments/*/apps/applications/` and 7 `helmfile.yaml` files, which need the same
treatment for the new name to be deployable.

`gitops-update.yml` resolves the values file by app name at
`.github/workflows/gitops-update.yml:764`:

```
gitops/environments/${SERVER}/helmfile/applications/${HELMFILE_ENV}/${APP_NAME}/values.yaml
```

With this PR applied and no GitOps PR, a release under the new name behaves as
follows:

1. Cluster resolution **succeeds** — `anacleto` and `benedita` are found (this is
   exactly what this PR fixes).
2. Every values-file lookup **misses**, hitting the skip branch at lines 774-777:
   ```bash
   if [[ ! -f "$VALUES_FILE" ]]; then
     echo "  WARNING: Values file not found for ${SERVER}/${ENV}: ${VALUES_FILE}"
     MISSING_FILES="${MISSING_FILES}${SERVER}/${ENV}:${VALUES_FILE}\n"
     continue
   fi
   ```
3. `MISSING_FILES` is only **printed** in the summary block (lines 852-856). There is
   no `exit 1` and no `::error::` on that path.
4. `updated_count=0` and `has_sync_targets=false` are emitted (lines 872-881), and the
   commit step short-circuits on purpose (lines 916-920):
   ```bash
   if git diff --quiet; then
     echo "No changes to commit"
     exit 0
   fi
   ```

**Consequence:** the release finds the clusters, updates **zero** files, deploys
nothing, and finishes **green**. A silent no-op.

Worth flagging explicitly, because it is counter-intuitive: **this PR downgrades the
visibility of the failure.** Today, an unregistered app produces a real GitHub
annotation at line 349 —
`echo "::warning::App '$APP_NAME' is not registered in any cluster..."` — which
surfaces in the run summary. Once the app is registered, the failure mode moves to
line 775, a plain `echo` with no `::warning::` prefix, which produces **no
annotation** and is visible only to someone reading the raw job log.

**Ordering requirement:** the GitOps PR that creates the `plugin-br-pix-lerian`
paths must merge **before** the first release under the new name. This PR is a
prerequisite for that release, not a green light for it.

### Gate 3 — CI is red for a cause external to this diff

`validation / Blocking Checks` fails in ~5s with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action
'LerianStudio/github-actions-shared-workflows/src/validate/pr-commit-signatures@v1'.
```

**Diagnosis.** The failure is in the runner's `Prepare all required actions` phase,
during job setup — before any step executes. That is why the step's own
`continue-on-error: true` (`pr-validation.yml:233`) cannot absorb it, and why the
whole job dies.

| Ref | Commit | Contains `src/validate/pr-commit-signatures/action.yml` |
|---|---|---|
| `origin/develop` | — | **yes** |
| `origin/main` | — | no |
| tag `v1` | `dbee3e5` | no |

- The caller was introduced on `develop` by `3608818` (2026-08-26 12:08), merged via
  `29cca3c` — PR #693 — and it references the action by the **`@v1` tag**
  (`pr-validation.yml:234`).
- `v1` is an annotated tag (object `32436b9`) pointing at commit `dbee3e5`
  *"fix(release): develop to main (#691)"*, 2026-08-25 17:14 — which **predates** the
  action by roughly a day.

So `develop` calls a versioned action that `v1` does not yet carry.

**Not caused by this PR.** This branch changes exactly one file —
`config/deployment-matrix.yml` — and touches no workflow or action. Action resolution
happens before any repository content is read, so the diff cannot influence it. The
run history confirms a repo-wide breakage rather than a branch-specific one: every
`Self — PR Validation` run after ~17:10 on 2026-08-26 fails on every branch
(`fix/build-partial-publish-skip` across 9 consecutive runs,
`docs/js-pr-validation-default-enabled-wording`, `dependabot/...`, and this one). The
dependabot branch is the clearest control: identical content **passed** at 17:01 and
17:06, then **failed** at 17:14 — the only change in between was its base picking up
the new caller.

**Precise fix for whoever maintains the tags:** promote `develop` to `main` including
`3608818` / `29cca3c` (19 commits currently sit in `origin/main..origin/develop`),
then move the annotated `v1` tag onto the resulting `main` head so
`src/validate/pr-commit-signatures/action.yml` is reachable at `@v1`. Retagging `v1`
alone, without the promotion, is not enough — the path does not exist anywhere on
`main`.

**This PR must not be treated as green until `v1` is fixed and the check passes.**
Its own content-specific checks already pass, including `Deployment Matrix Lint`.

## Related Issues

Lerian Map initiative 464, card #4632.

