### PR TITLE
fix(cosign): retry the cosign install and expose the knobs via go-release

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -99,6 +99,22 @@ on:
         description: 'Sign container images with cosign keyless (OIDC) signing after push'
         type: boolean
         default: true
+      cosign_max_attempts:
+        description: 'Maximum cosign signing attempts per image reference. Increase to absorb transient OIDC/Fulcio/Rekor rate limits. Forwarded to build.yml.'
+        type: string
+        default: '5'
+      cosign_initial_delay:
+        description: 'Initial delay (seconds) between cosign retries. Grows exponentially (×3) after each failed attempt, capped at cosign_max_delay, then randomized (equal jitter). Forwarded to build.yml.'
+        type: string
+        default: '5'
+      cosign_max_delay:
+        description: 'Maximum delay (seconds) between cosign retries. Caps the exponential backoff before jitter is applied. Forwarded to build.yml.'
+        type: string
+        default: '60'
+      continue_gitops_on_signing_failure:
+        description: 'When true, continue to GitOps artifact upload even if cosign signing fails after all retries. The image stays in the registry unsigned and a warning is emitted; manual signing is required afterwards. Forwarded to build.yml.'
+        type: boolean
+        default: false
       app_name_prefix:
         description: 'Prefix for app names in monorepo (e.g., "midaz" -> "midaz-agent")'
         type: string
@@ -474,6 +490,10 @@ jobs:
       build_context_from_working_dir: ${{ inputs.build_context_from_working_dir }}
       docker_build_args: ${{ inputs.docker_build_args }}
       enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      cosign_max_attempts: ${{ inputs.cosign_max_attempts }}
+      cosign_initial_delay: ${{ inputs.cosign_initial_delay }}
+      cosign_max_delay: ${{ inputs.cosign_max_delay }}
+      continue_gitops_on_signing_failure: ${{ inputs.continue_gitops_on_signing_failure }}
       enable_helm_dispatch: ${{ inputs.enable_helm_dispatch }}
       helm_chart: ${{ inputs.helm_chart }}
       helm_repository: ${{ inputs.helm_repository }}
@@ -747,6 +767,10 @@ jobs:
       enable_ghcr: ${{ (matrix.group.enable_ghcr == null && inputs.enable_ghcr == true) || matrix.group.enable_ghcr == true }}
       dockerhub_org: ${{ inputs.dockerhub_org }}
       enable_cosign_sign: ${{ inputs.enable_cosign_sign }}
+      cosign_max_attempts: ${{ inputs.cosign_max_attempts }}
+      cosign_initial_delay: ${{ inputs.cosign_initial_delay }}
+      cosign_max_delay: ${{ inputs.cosign_max_delay }}
+      continue_gitops_on_signing_failure: ${{ inputs.continue_gitops_on_signing_failure }}
       enable_gitops_artifacts: ${{ matrix.group.enable_gitops_artifacts == null && true || matrix.group.enable_gitops_artifacts }}
       filter_paths: ${{ matrix.group.filter_paths }}
       shared_paths: ${{ matrix.group.shared_paths || inputs.shared_paths }}

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -44,6 +44,10 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `tag_prefix` | Restrict the primary release/build jobs to tags starting with this prefix. Use when the repo also pushes tags for an unrelated component with its own `extra_builds` `tag_prefix`, so the primary jobs ignore that component's tags. Empty = react to every tag (current behavior) | string | `''` |
 | `docker_build_args` | Newline-separated Docker build args | string | `''` |
 | `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
+| `cosign_max_attempts` | Maximum cosign signing attempts per image reference. Increase to absorb transient OIDC/Fulcio/Rekor rate limits. Forwarded to `build.yml` | string | `'5'` |
+| `cosign_initial_delay` | Initial delay (seconds) between cosign retries. Grows exponentially (×3), capped at `cosign_max_delay`, then jittered. Forwarded to `build.yml` | string | `'5'` |
+| `cosign_max_delay` | Maximum delay (seconds) between cosign retries. Caps the backoff before jitter | string | `'60'` |
+| `continue_gitops_on_signing_failure` | Continue to the GitOps artifact upload even when cosign signing fails after all retries. The image stays in the registry unsigned and a warning is emitted; manual signing is required afterwards. Forwarded to `build.yml` | boolean | `false` |
 | `app_name_prefix` | Prefix for app names in monorepo (e.g. `midaz` -> `midaz-agent`) | string | `''` |
 | `app_name_overrides` | Explicit `path:name` app name mappings | string | `''` |
 | `dockerhub_org` | DockerHub organization name | string | `lerianstudio` |

--- a/src/security/cosign-sign/README.md
+++ b/src/security/cosign-sign/README.md
@@ -24,6 +24,14 @@ Composite action that signs container images using [Sigstore cosign](https://git
 |---|---|
 | `signed-refs` | Newline-separated list of successfully signed image references |
 
+## Install resilience
+
+`max-attempts` / `initial-delay` / `max-delay` budget retries around `cosign sign`. They do **not** cover installing the binary, which happens first — so the install has its own retry.
+
+`sigstore/cosign-installer` pulls cosign from the GitHub release assets, which are intermittently unreachable from runner egress (`curl` exit 56, connection reset mid-transfer, often with the bootstrap download having succeeded seconds earlier). The first install attempt is therefore allowed to fail: a warning is emitted, the action waits 15s, and installs once more before the step turns fatal. A final check confirms `cosign` is actually on `PATH`, so signing never starts against a half-installed binary.
+
+This matters because of *when* the failure lands. By the time this action runs the caller has already pushed the image, and registry tags are immutable — an unsigned tag can only be fixed by cutting a new version. See [#669](https://github.com/LerianStudio/github-actions-shared-workflows/issues/669).
+
 ## Usage
 
 ### As a composite step (after Docker build and push)

--- a/src/security/cosign-sign/action.yml
+++ b/src/security/cosign-sign/action.yml
@@ -35,10 +35,47 @@ runs:
   using: composite
   steps:
     # ----------------- Setup -----------------
+    # The installer pulls the binary from the GitHub release assets, which are
+    # intermittently unreachable from runner egress (curl exit 56 — connection reset
+    # mid-transfer — with the bootstrap download seconds earlier having succeeded).
+    #
+    # A failure here is the worst possible timing in a release: the caller has
+    # already pushed the image, registry tags are immutable, so an unsigned tag can
+    # only be fixed by cutting a new version. `max-attempts` does not help — it
+    # budgets retries around `cosign sign`, long after this step. So the first
+    # attempt is allowed to fail and is retried before the step turns fatal.
     - name: Install cosign
+      id: install
+      continue-on-error: true
       uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
       with:
         cosign-release: ${{ inputs.cosign-version }}
+
+    - name: Wait before retrying the cosign install
+      if: steps.install.outcome == 'failure'
+      shell: bash
+      env:
+        COSIGN_VERSION: ${{ inputs.cosign-version }}
+      run: |
+        echo "::warning::Installing cosign ${COSIGN_VERSION} failed — most likely transient egress toward the GitHub release assets. Retrying once in 15s."
+        sleep 15
+
+    - name: Install cosign (retry)
+      if: steps.install.outcome == 'failure'
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      with:
+        cosign-release: ${{ inputs.cosign-version }}
+
+    # Guards against a first attempt that failed halfway yet left something on PATH:
+    # signing must not start against a partially installed binary.
+    - name: Verify cosign is installed
+      shell: bash
+      run: |
+        if ! command -v cosign >/dev/null 2>&1; then
+          echo "::error::cosign is not on PATH after installation."
+          exit 1
+        fi
+        cosign version
 
     # ----------------- Validation -----------------
     - name: Validate image references


### PR DESCRIPTION
## Description

`src/security/cosign-sign@v1` failed before signing anything when `sigstore/cosign-installer` could not download the cosign binary (`curl` exit 56 — connection died mid-transfer), with the bootstrap download of a *different* cosign version having succeeded three seconds earlier. Intermittent runner egress, not an endpoint being down.

The timing is what makes it expensive. By the time this action runs, the caller has already pushed the image to every enabled registry, and registry tags are immutable — so the release is left with the image present and **unsigned**, the GitOps artifact steps never reached, and no way forward except cutting a new tag.

Two fixes, matching the issue's items 2 and 3.

### 1. Retry the install (`src/security/cosign-sign/action.yml`)

`max-attempts` / `initial-delay` / `max-delay` budget retries around `cosign sign` — they never covered *installing* the binary, which happens first. The install now has its own retry: the first attempt is allowed to fail (`continue-on-error`), a warning is emitted, the action waits 15s and installs once more before the step turns fatal. A final `command -v cosign` check confirms the binary is on `PATH`, so signing never starts against a half-installed one.

The happy path — install succeeds first try — is byte-for-byte unchanged. `sigstore/cosign-installer` is kept as the install mechanism, so its bootstrap-and-verify supply-chain guarantee is preserved (see below for why the binary is not cached instead).

### 2. Expose the cosign knobs through `go-release.yml`

`go-release.yml` forwarded only `enable_cosign_sign` to `build.yml`. A repository releasing through it could not reach `cosign_max_attempts`, `cosign_initial_delay`, `cosign_max_delay` or `continue_gitops_on_signing_failure` at all — no knob for either the retry budget or the GitOps-continuation decision. That is why the reported run had no way to soften the failure.

All four are now inputs on `go-release.yml`, forwarded at **both** `build.yml` call sites (the primary build and the `extra_builds` matrix), carrying `build.yml`'s own defaults.

## Two notes on the issue body

**The `if: always()` suggested in item 3 is not needed, and would be wrong.** `build.yml` sets `continue-on-error: ${{ inputs.continue_gitops_on_signing_failure || false }}` on the cosign step. When that flag is `true`, a failing step has *conclusion* `success` (only `outcome` is `failure`), the job is not marked failed, and the following steps run — so the GitOps upload already happens today, and `needs.build.result` is `'success'`. Adding `if: always()` would defeat the flag: with it `false` (the default), a signing failure **should** block the GitOps update. What the reported run hit was the correct `flag=false` behaviour, reached only because `go-release.yml` gave no way to set the flag — which is what this PR fixes.

**No false-success bug in the signing loop.** `sign_with_retry "$ref"` ignores the return value and the ref is appended to `signed_refs` unconditionally, which looks like a bug. It isn't: `shell: bash` runs `bash --noprofile --norc -eo pipefail`, so `-e` propagates the function's `return 1` out of the `while` body. Verified locally — with `-eo pipefail` the script exits 1 and never reaches the success notice; without `-e` it would. Left as is.

## Why the binary is not cached (issue item 1, deliberately not done)

The issue ranks `actions/cache` first. Not doing it here, for a reason not in the issue: caching the cosign binary puts a **cache-poisoning surface on an executable that handles the OIDC signing identity**. The Actions cache is writable by any workflow in the repo within its scope, so a forged `cosign` restored from cache would run with the identity that signs release images — trading a network flake for a supply-chain vector.

It can be done safely, by verifying the restored binary's checksum against the release's `cosign_checksums.txt` before use and discarding the cache on mismatch. That deserves its own PR and its own review, and the retry above already addresses the reported symptom without adding any new trust surface. Happy to file the follow-up issue.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Four new optional inputs on `go-release.yml`, each defaulting to the value `build.yml` already used, so a caller that sets nothing behaves exactly as before. No input or output is renamed or removed, and the composite's interface is untouched — the retry is internal.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

`actionlint` (with `shellcheck` on `PATH`) passes clean across the whole repo.

Checked against the repo's own composite contract: `cosign-sign` is at 7 steps against the `MAX_STEPS = 15` in `src/lint/composite-schema`, every step has a `name`, and every `run` step declares `shell`.

`runs.steps[*].continue-on-error` was confirmed against GitHub's metadata-syntax reference before use — it is documented for composite actions, and there was no prior use of it inside a composite in this repo to copy from.

The transient-failure path cannot be reproduced locally (it needs a real egress reset), so what is verified here is that the happy path is unchanged and the retry branch is only reachable on `steps.install.outcome == 'failure'`.

**Caller repo / workflow run:** not yet. Wants a run on `LerianStudio/ungoliant-controller` (where [run 31634549035](https://github.com/LerianStudio/ungoliant-controller/actions/runs/31634549035/job/94241505837) hit this on tag `v2.1.0-beta.81`) with `enable_cosign_sign: true`, to confirm the install path did not regress, plus one setting `continue_gitops_on_signing_failure: true` through `go-release.yml` to confirm the new input reaches `build.yml`.

## Related Issues

Closes #669
