### PR TITLE
feat(workflows): add per-job runner overrides to js workflows

### DIFF
--- a/.github/workflows/frontend-pr-analysis.yml
+++ b/.github/workflows/frontend-pr-analysis.yml
@@ -22,6 +22,14 @@ on:
         description: 'GitHub runner type'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      build_runner_type:
+        description: 'Optional runner override for the Build jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      custom_checks_runner_type:
+        description: 'Optional runner override for the Custom Checks jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       filter_paths:
         description: 'JSON array of paths to monitor for changes (e.g., ["apps/web", "apps/console"]). If empty, treats repo as single-app and runs against root directory.'
         type: string
@@ -544,7 +552,7 @@ jobs:
     name: Build (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_build
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.build_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -691,7 +699,7 @@ jobs:
     name: Custom Checks (${{ matrix.app.name }})
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true' && inputs.enable_custom_checks
-    runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
+    runs-on: ${{ inputs.custom_checks_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -22,6 +22,18 @@ on:
         description: 'GitHub runner type to use'
         type: string
         default: 'blacksmith-4vcpu-ubuntu-2404'
+      build_runner_type:
+        description: 'Optional runner override for the Frontend analysis Build jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      custom_checks_runner_type:
+        description: 'Optional runner override for the Frontend analysis Custom Checks jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
+      security_scan_runner_type:
+        description: 'Optional runner override for the security_scan jobs only. Empty = vars.GENERAL_RUNNERS, then runner_type.'
+        type: string
+        default: ''
       dry_run:
         description: 'Preview metadata validations without posting comments or labels'
         required: false
@@ -492,6 +504,8 @@ jobs:
     uses: ./.github/workflows/frontend-pr-analysis.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      build_runner_type: ${{ inputs.build_runner_type }}
+      custom_checks_runner_type: ${{ inputs.custom_checks_runner_type }}
       node_version: ${{ inputs.node_version }}
       package_manager: ${{ inputs.package_manager }}
       eslint_args: ${{ inputs.eslint_args }}
@@ -559,6 +573,7 @@ jobs:
     uses: ./.github/workflows/pr-security-scan.yml
     with:
       runner_type: ${{ inputs.runner_type }}
+      security_scan_runner_type: ${{ inputs.security_scan_runner_type }}
       ignore_file: ${{ inputs.ignore_file }}
       enable_docker_scan: ${{ inputs.enable_docker_scan }}
       dockerfile_path: ${{ inputs.dockerfile_path }}

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -215,6 +215,10 @@ on:
         description: 'Node.js version for the E2E test runner'
         type: string
         default: '22'
+      e2e_runner_type:
+        description: 'Optional runner override for the E2E Tests job only. Empty = runner_type.'
+        type: string
+        default: ''
       e2e_s3_artifact_path:
         description: 'Subpath under s3://lerian-e2e-artifacts/<repo>/<channel>/<tag>/ where the Playwright report is uploaded. Channel (main/beta/rc) is derived from the tag''s prerelease identifier.'
         type: string
@@ -356,7 +360,7 @@ jobs:
     if: >-
       github.ref_type == 'tag' && inputs.enable_e2e &&
       !cancelled() && needs.build.result == 'success' && !inputs.dry_run
-    runs-on: ${{ inputs.runner_type }}
+    runs-on: ${{ inputs.e2e_runner_type || inputs.runner_type }}
     permissions:
       id-token: write
       contents: read

--- a/docs/frontend-pr-analysis-workflow.md
+++ b/docs/frontend-pr-analysis-workflow.md
@@ -153,6 +153,8 @@ Set `enable_socket_firewall: false` to restore the previous behaviour (cached, u
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `runner_type` | GitHub runner type | No | `blacksmith-4vcpu-ubuntu-2404` |
+| `build_runner_type` | Optional runner override for the Build jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
+| `custom_checks_runner_type` | Optional runner override for the Custom Checks jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | No | `''` |
 | `filter_paths` | JSON array of paths to monitor for changes. If empty, treats repo as single-app. | No | `''` |
 | `shared_paths` | Newline-separated path patterns (e.g. `package.json`) that, when matched by any changed file, trigger analysis for ALL components in `filter_paths` | No | `''` |
 | `path_level` | Directory depth level to extract app name | No | `2` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -21,6 +21,9 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | Input | Description | Type | Default |
 |-------|-------------|------|---------|
 | `runner_type` | GitHub runner type | string | `blacksmith-4vcpu-ubuntu-2404` |
+| `build_runner_type` | Optional runner override for the frontend analysis Build jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
+| `custom_checks_runner_type` | Optional runner override for the frontend analysis Custom Checks jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
+| `security_scan_runner_type` | Optional runner override for the `security_scan` jobs only; empty falls back to `vars.GENERAL_RUNNERS`, then `runner_type` | string | `''` |
 | `dry_run` | Preview metadata validations without posting comments/labels | boolean | `false` |
 | `run_metadata` | Run the PR metadata pipeline (title, scopes, labeler, size, breaking-change guard). Set `false` in a multi-component repository that also calls `go-pr-validation.yml`, so exactly one umbrella owns PR metadata | boolean | `true` |
 | `run_frontend_analysis` | Run the frontend analysis pipeline | boolean | `true` |

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -68,6 +68,7 @@ Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services â€
 | `e2e_script` | npm script for E2E tests (e.g. `test:e2e`, `test:e2e:mock`) | string | `test:e2e` |
 | `e2e_base_url` | Base URL injected as `BASE_URL` env var. Empty = localhost fallback | string | `''` |
 | `node_version` | Node.js version for the E2E runner | string | `22` |
+| `e2e_runner_type` | Optional runner override for the E2E Tests job only; empty falls back to `runner_type` | string | `''` |
 | `e2e_s3_artifact_path` | Subpath under `s3://lerian-e2e-artifacts/<repo>/<channel>/<tag>/` where the Playwright report is uploaded. Channel (`main`/`beta`/`rc`) is derived from the tag's prerelease identifier. Only used when `AWS_E2E_ARTIFACTS_ROLE_ARN` is set | string | `playwright-report` |
 | `enable_ungoliant_release_diff` | Fire the Ungoliant release-diff webhook on tag push after a successful gitops-update (see [Ungoliant release diff](#ungoliant-release-diff)) | boolean | `false` |
 | `ungoliant_app` | App slug sent to the controller; when empty falls back to `app_name_prefix`, then the repo name | string | `''` |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

Right-sizing telemetry on `LerianStudio/product-console` (30 days) flagged four jobs that need a bigger runner: `Custom Checks` and `Build` in the frontend analysis pipeline, `security_scan` in the security pipeline, and `E2E Tests` in the release pipeline. Those jobs live here, and today the JS workflows only accept a single `runner_type` for the whole umbrella, so a caller cannot lift one job without lifting every job.

This adds the same optional per-job overrides that PR #636 gave the Go workflows, for the JS side:

- `frontend-pr-analysis.yml`: new `build_runner_type` and `custom_checks_runner_type`
- `js-pr-validation.yml`: new `build_runner_type`, `custom_checks_runner_type`, `security_scan_runner_type`, forwarded to `frontend-pr-analysis.yml` and `pr-security-scan.yml` (the latter already accepted the input)
- `js-release.yml`: new `e2e_runner_type` for the `E2E Tests` job

Every input defaults to `''`, and resolution keeps an explicit override ahead of the org variable:

```yaml
  custom-checks:
    name: Custom Checks (${{ matrix.app.name }})
    runs-on: ${{ inputs.custom_checks_runner_type || vars.GENERAL_RUNNERS || inputs.runner_type }}
```

The `E2E Tests` job in `js-release.yml` has no `vars.GENERAL_RUNNERS` in its expression today, so its override resolves as `${{ inputs.e2e_runner_type || inputs.runner_type }}` to avoid changing that job's existing behavior.

With this in place, `product-console` can pin `Custom Checks` / `Build` / `security_scan` / `E2E Tests` to `blacksmith-8vcpu-ubuntu-2404` while the ~30 idle orchestration jobs stay on 4 vCPU.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. All five inputs are optional and default to `''`, which reproduces today's resolution exactly.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

**Caller repo / workflow run:** not yet run against a caller. The `product-console` follow-up PR (pinning the four jobs to 8 vCPU) is blocked on a release tag for this change, and can serve as the validating caller once tagged.

## Related Issues

Closes #
