### PR TITLE
fix(build): stop publishing floating major/minor image tags

### DIFF
--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -196,7 +196,10 @@ Generated tags based on semantic versioning:
 | Tag Pattern | Example | When Applied |
 |-------------|---------|--------------|
 | `{{version}}` | `1.0.0-beta.1` | Always |
-| `{{major}}` | `1` | Release tags only |
+
+Only the exact version is published. Floating aliases (`1`, `1.12`) are not:
+re-pointing an existing alias is refused by Docker Hub immutable-tag rules and
+fails the whole build. Consumers must pin the exact version.
 
 ## Monorepo Change Detection
 

--- a/src/build/docker-build-ts/action.yml
+++ b/src/build/docker-build-ts/action.yml
@@ -86,21 +86,21 @@ runs:
     # ----------------- Setup -----------------
     - name: Set up QEMU
       if: ${{ contains(inputs.platforms, 'arm64') }}
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
     - name: Log in to DockerHub
       if: ${{ inputs.enable-dockerhub == 'true' }}
-      uses: docker/login-action@v4
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-password }}
 
     - name: Log in to GHCR
       if: ${{ inputs.enable-ghcr == 'true' }}
-      uses: docker/login-action@v4
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -141,7 +141,7 @@ runs:
 
     - name: Docker metadata
       id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
       with:
         images: ${{ steps.image-names.outputs.images }}
         tags: |
@@ -198,7 +198,7 @@ runs:
     - name: Build Docker image (dry run)
       if: ${{ inputs.dry-run == 'true' }}
       id: build-dry
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: ${{ inputs.build-context }}
         file: ${{ steps.dockerfile.outputs.path }}
@@ -212,7 +212,7 @@ runs:
     - name: Build and push Docker image
       if: ${{ inputs.dry-run != 'true' }}
       id: build-push
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: ${{ inputs.build-context }}
         file: ${{ steps.dockerfile.outputs.path }}

--- a/src/build/docker-build-ts/action.yml
+++ b/src/build/docker-build-ts/action.yml
@@ -145,9 +145,10 @@ runs:
       with:
         images: ${{ steps.image-names.outputs.images }}
         tags: |
+          # Exact version only: floating major/minor aliases are incompatible
+          # with Docker Hub immutable-tag rules (re-pointing an existing alias
+          # is refused and fails the whole build).
           type=semver,pattern={{version}},value=${{ inputs.version }}
-          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-          type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.is-release }}
 
     - name: Resolve Dockerfile path
       id: dockerfile


### PR DESCRIPTION
## Description

Stable releases currently publish three image tags per cut: the exact version (`1.12.0`), a floating minor alias (`1.12`) and a floating major alias (`1`). Docker Hub repos now carry immutable-tag rules, which refuse re-pointing an existing tag — and a floating alias exists precisely to be re-pointed. The two are incompatible by definition.

First casualty: **product-console v1.12.0**. The exact tag and `1.12` were pushed, but re-pointing `:1` (assigned since April) was refused, killing the whole build job — no cosign signature, no E2E, no gitops update. Reporter v3.0.0 only passed because `3`/`3.0` were brand new; the NEXT stable release of any product that repeats a major or minor (e.g. reporter 3.0.1) fails the same way.

This PR removes the two floating-alias patterns from `src/build/docker-build-ts/action.yml` (the single emission point — the Go pipeline already publishes only the exact version) and updates the docs table. Deployments already pin exact versions via gitops, so nothing we operate consumes the aliases.

`js-release.yml` references this action by the floating `@v1` git ref, so once this lands on main and `v1` moves, every consumer repo picks the fix up without a local bump.

## Type of Change

- [x] `fix`: Bug fix

Requested by: @fredcamaral

🤖 Generated with [Claude Code](https://claude.com/claude-code)
