### PR TITLE
feat(release): add per-product alpha tag line

### DIFF
--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -65,6 +65,22 @@ on:
         description: 'Backmerge strategy: direct | pr | direct-with-pr-fallback'
         type: string
         default: 'direct-with-pr-fallback'
+      product_alpha_enabled:
+        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives both the tag prefix and the prerelease identifier, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
+        type: boolean
+        default: false
+      product_alpha_branch_pattern:
+        description: 'Glob matching the product branches that get their own alpha line. The text replacing `*` becomes the product name. Only read when product_alpha_enabled is true.'
+        type: string
+        default: 'develop-*'
+      product_alpha_anchor_branch:
+        description: 'Release branch included in the generated alpha config. semantic-release rejects a branches list containing only prerelease branches, so one release branch must be named even though no tag in the product format is expected on it.'
+        type: string
+        default: 'main'
+      product_alpha_excluded_products:
+        description: 'Comma-separated product names that must not get an alpha line even when their branch matches product_alpha_branch_pattern (e.g. shared branches like `core`).'
+        type: string
+        default: ''
       filter_paths:
         description: 'Newline-separated list of path prefixes to filter. Empty = single-app repo.'
         type: string
@@ -313,6 +329,10 @@ jobs:
       backmerge_source: ${{ inputs.backmerge_source }}
       backmerge_target: ${{ inputs.backmerge_target }}
       backmerge_mode: ${{ inputs.backmerge_mode }}
+      product_alpha_enabled: ${{ inputs.product_alpha_enabled }}
+      product_alpha_branch_pattern: ${{ inputs.product_alpha_branch_pattern }}
+      product_alpha_anchor_branch: ${{ inputs.product_alpha_anchor_branch }}
+      product_alpha_excluded_products: ${{ inputs.product_alpha_excluded_products }}
       shared_paths: ${{ inputs.shared_paths }}
       path_level: ${{ inputs.path_level }}
       enable_release_announcement: ${{ inputs.enable_release_announcement }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
         id: guard
         if: |
           steps.semantic_dry.outputs.new_release_published == 'true' &&
-          steps.alpha.outputs.is-alpha != 'true'
+          steps.alpha.outputs.has-alpha != 'true'
         uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1
         with:
           calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,26 @@ on:
         required: false
         type: boolean
         default: false
+      product_alpha_enabled:
+        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives both the tag prefix and the prerelease identifier, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
+        required: false
+        type: boolean
+        default: false
+      product_alpha_branch_pattern:
+        description: 'Glob matching the product branches that get their own alpha line. The text replacing `*` becomes the product name. Only read when product_alpha_enabled is true.'
+        required: false
+        type: string
+        default: 'develop-*'
+      product_alpha_anchor_branch:
+        description: 'Release branch included in the generated alpha config. semantic-release rejects a branches list containing only prerelease branches, so one release branch must be named even though no tag in the product format is expected on it.'
+        required: false
+        type: string
+        default: 'main'
+      product_alpha_excluded_products:
+        description: 'Comma-separated product names that must not get an alpha line even when their branch matches product_alpha_branch_pattern (e.g. shared branches like `core`).'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -308,6 +328,17 @@ jobs:
         run: |
           printf '::warning::Release skipped for %s — %s could not be auto-merged into %s (PR: %s). Merge it and push again to release.\n' "$APP_NAME" "$BACKMERGE_SOURCE" "$REF_NAME" "$PR_URL"
 
+      # ----------------- Per-product alpha line -----------------
+      - name: Resolve product alpha channel
+        id: alpha
+        if: inputs.product_alpha_enabled
+        uses: LerianStudio/github-actions-shared-workflows/src/config/product-alpha-channel@v1
+        with:
+          ref-name: ${{ github.ref_name }}
+          branch-pattern: ${{ inputs.product_alpha_branch_pattern }}
+          anchor-branch: ${{ inputs.product_alpha_anchor_branch }}
+          excluded-products: ${{ inputs.product_alpha_excluded_products }}
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
@@ -335,15 +366,22 @@ jobs:
           dry_run: true
           semantic_version: ${{ inputs.semantic_version }}
           working_directory: ${{ matrix.app.working_dir }}
+          # Empty strings are dropped by the action, leaving the caller .releaserc untouched.
+          branches: ${{ steps.alpha.outputs.branches }}
+          tag_format: ${{ steps.alpha.outputs.tag-format }}
           extra_plugins: |
             conventional-changelog-conventionalcommits@v7.0.2
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # A product alpha line carries its own tag prefix, so it never shares an
+      # X.Y.Z namespace with the stable `v*` tags the guard compares against.
       - name: Guard against stale prerelease
         id: guard
-        if: steps.semantic_dry.outputs.new_release_published == 'true'
+        if: |
+          steps.semantic_dry.outputs.new_release_published == 'true' &&
+          steps.alpha.outputs.is-alpha != 'true'
         uses: LerianStudio/github-actions-shared-workflows/src/config/prerelease-guard@v1
         with:
           calculated-version: ${{ steps.semantic_dry.outputs.new_release_version }}
@@ -361,6 +399,9 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
           semantic_version: ${{ inputs.semantic_version }}
           working_directory: ${{ matrix.app.working_dir }}
+          # Empty strings are dropped by the action, leaving the caller .releaserc untouched.
+          branches: ${{ steps.alpha.outputs.branches }}
+          tag_format: ${{ steps.alpha.outputs.tag-format }}
           extra_plugins: |
             conventional-changelog-conventionalcommits@v7.0.2
         env:

--- a/docs/js-release.md
+++ b/docs/js-release.md
@@ -32,6 +32,10 @@ Mirrors the [`go-release`](./go-release-workflow.md) umbrella for Go services â€
 | `dry_run` | Run semantic-release and build in dry-run mode (no tags/releases/images created); also skips the E2E test job entirely | boolean | `false` |
 | `ignore_globs` | Space-separated globs treated as docs/meta for the branch-push gate | string | `*.md docs/* .github/* LICENSE* .gitignore` |
 | `semantic_version` | semantic-release version | string | `23.0.8` |
+| `product_alpha_enabled` | Release product branches on their own alpha line, product name taken from the branch (see [release-workflow](release-workflow.md#per-product-alpha-lines)) | boolean | `false` |
+| `product_alpha_branch_pattern` | Glob matching the product branches that get their own alpha line | string | `develop-*` |
+| `product_alpha_anchor_branch` | Release branch included in the generated alpha config | string | `main` |
+| `product_alpha_excluded_products` | Comma-separated product names excluded from the alpha line | string | `''` |
 | `filter_paths` | Path prefixes to filter (empty = single-app repo) | string | `''` |
 | `shared_paths` | Path patterns that trigger a release/build for all components | string | `''` |
 | `path_level` | Directory depth level to extract app name | string | `2` |

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -535,7 +535,7 @@ Notes:
 - The consuming repo must add the product branches to its own `on.push.branches`, otherwise the workflow never runs on them.
 - Each product line starts at `1.0.0-alpha.1`: no tag matches `<product>-v*` on the first run, so `semantic-release` falls back to its first-release baseline. Push an annotated tag in the product format to start from another version.
 - Product lines are excluded from the stale-prerelease guard. The guard compares a calculated version against the stable `v*` tags, and a product line never shares that namespace.
-- The pre-version backmerge sync (`prerelease_backmerge_sync_enabled`) is driven by `prerelease_branches`, which is an exact-match list. Product branches are not in it by default, and adding them is not recommended: the guard that follows the sync assumes the stable `v*` namespace.
+- The pre-version backmerge sync (`prerelease_backmerge_sync_enabled`) is driven by `prerelease_branches`, which is an exact-match list. Product branches are not in it by default. Adding one turns the sync on for that branch — `backmerge_source` is merged into the product line before its version is calculated, and the release is skipped for the run when that merge cannot complete directly. The stale-prerelease guard stays skipped either way. Add a product branch only when you do want the product line to track `backmerge_source`.
 - `product_alpha_excluded_products` keeps shared branches that match the pattern (for example `develop-core`) out of the alpha mechanism.
 
 ## Semantic Release Plugins

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -91,6 +91,10 @@ jobs:
 | `dry_run` | boolean | `false` | Run semantic-release in dry-run mode (no tags/releases) and preview the backmerge instead of applying it |
 | `prerelease_branches` | string | `develop,release-candidate` | Comma-separated list of branches treated as prerelease lines (beta/rc) |
 | `prerelease_backmerge_sync_enabled` | boolean | `false` | Merge `backmerge_source` into a prerelease branch before calculating its next version. Independent of `backmerge_enabled`, which also gates the separate post-release backmerge on `backmerge_source` itself. Opt-in — set to `true` to enable this pre-version-calculation sync, which can skip/block a release on prerelease branches when the merge cannot complete directly |
+| `product_alpha_enabled` | boolean | `false` | Release product branches on their own alpha line, with the product name taken from the branch (see [Per-product alpha lines](#per-product-alpha-lines)) |
+| `product_alpha_branch_pattern` | string | `develop-*` | Glob matching the product branches that get their own alpha line. The text replacing `*` becomes the product name |
+| `product_alpha_anchor_branch` | string | `main` | Release branch included in the generated alpha config, required for `semantic-release` to accept it |
+| `product_alpha_excluded_products` | string | `''` | Comma-separated product names that must not get an alpha line even when their branch matches the pattern |
 | `enable_release_announcement` | boolean | `true` | Announce the published release to the repository Slack channel after a successful release |
 | `announcement_product_name` | string | `''` | Product name displayed in the announcement. Defaults to the repository name |
 | `announcement_slack_channel` | string | `''` | Slack channel that receives the announcement. Defaults to the `RELEASE_SLACK_CHANNEL` repository variable; the announcement is skipped when both are empty |
@@ -511,6 +515,28 @@ jobs:
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/release.yml@v1.0.0
     secrets: inherit
 ```
+
+## Per-product alpha lines
+
+A repo where each product owns its own long-lived branch can publish isolated alpha tags per product, so a product is validated on its own before being integrated into the unified prerelease line.
+
+Enable it with `product_alpha_enabled: true`. On every push, the `product-alpha-channel` composite matches the ref against `product_alpha_branch_pattern` and, on a match, extracts the product name and overrides `semantic-release` for that run:
+
+| Branch | Tag published |
+|--------|---------------|
+| `develop-midaz` | `midaz-v1.0.0-alpha.1` |
+| `develop-tracer` | `tracer-v1.0.0-alpha.1` |
+| `develop` | unchanged — from the caller `.releaserc` |
+| `release-candidate` | unchanged — from the caller `.releaserc` |
+| `main` | unchanged — from the caller `.releaserc` |
+
+Notes:
+
+- The consuming repo must add the product branches to its own `on.push.branches`, otherwise the workflow never runs on them.
+- Each product line starts at `1.0.0-alpha.1`: no tag matches `<product>-v*` on the first run, so `semantic-release` falls back to its first-release baseline. Push an annotated tag in the product format to start from another version.
+- Product lines are excluded from the stale-prerelease guard. The guard compares a calculated version against the stable `v*` tags, and a product line never shares that namespace.
+- The pre-version backmerge sync (`prerelease_backmerge_sync_enabled`) is driven by `prerelease_branches`, which is an exact-match list. Product branches are not in it by default, and adding them is not recommended: the guard that follows the sync assumes the stable `v*` namespace.
+- `product_alpha_excluded_products` keeps shared branches that match the pattern (for example `develop-core`) out of the alpha mechanism.
 
 ## Semantic Release Plugins
 

--- a/src/config/product-alpha-channel/README.md
+++ b/src/config/product-alpha-channel/README.md
@@ -30,10 +30,10 @@ The generated `branches` list always includes `anchor-branch`. `semantic-release
 
 | Output | Description |
 |--------|-------------|
-| `is-alpha` | `'true'` when `ref-name` matches `branch-pattern` and the product is not excluded |
-| `product` | Product name extracted from the branch, empty when `is-alpha` is `'false'` |
-| `branches` | JSON branches config to override `semantic-release` with, empty when `is-alpha` is `'false'` |
-| `tag-format` | Tag format to override `semantic-release` with, empty when `is-alpha` is `'false'` |
+| `has-alpha` | `'true'` when `ref-name` matches `branch-pattern` and the product is not excluded |
+| `product` | Product name extracted from the branch, empty when `has-alpha` is `'false'` |
+| `branches` | JSON branches config to override `semantic-release` with, empty when `has-alpha` is `'false'` |
+| `tag-format` | Tag format to override `semantic-release` with, empty when `has-alpha` is `'false'` |
 
 For `develop-midaz` with the defaults:
 
@@ -95,7 +95,11 @@ The consuming repo must add the product branches to its `on.push.branches` — t
 
 ## Required permissions
 
+The composite itself only reads the ref name it is given — it makes no API call and touches no git state:
+
 ```yaml
 permissions:
   contents: read
 ```
+
+The reusable-workflow usage above is a different scope: `js-release.yml` publishes tags, releases and images, so the caller must grant the release workflow its own permission union, not this block. See [`js-release`](../../../docs/js-release.md) and [`release-workflow`](../../../docs/release-workflow.md) for the authoritative set.

--- a/src/config/product-alpha-channel/README.md
+++ b/src/config/product-alpha-channel/README.md
@@ -1,0 +1,101 @@
+<table border="0" cellspacing="0" cellpadding="0">
+  <tr>
+    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
+    <td><h1>product-alpha-channel</h1></td>
+  </tr>
+</table>
+
+Resolves the `semantic-release` branches config and tag format for a per-product alpha line, deriving the product name from the branch being released. A repo where each product owns a `develop-<product>` branch can then publish isolated alpha tags — `develop-midaz` produces `midaz-v1.0.0-alpha.1`, `develop-tracer` produces `tracer-v1.0.0-alpha.1` — while the unified `develop`, `release-candidate` and `main` lines keep using the caller's own `.releaserc`.
+
+The action only computes values; it never writes a config file or creates a tag. `release.yml` feeds the outputs to the `branches` and `tag_format` inputs of `cycjimmy/semantic-release-action`, which override the caller's `.releaserc` for that run. Both outputs are empty when the branch does not match, and the action drops empty inputs, so non-product branches are untouched.
+
+## Why this shape
+
+`semantic-release` has no per-branch `tagFormat`: the option is global to a run. Overriding `branches` and `tagFormat` per run is the only way to give each product its own tag line without maintaining one config file per product in every consuming repo.
+
+The generated `branches` list always includes `anchor-branch`. `semantic-release` validates that at least one release (non-prerelease) branch is configured — see `release.branchesValidator` in `lib/definitions/branches.js` — and aborts with `ERELEASEBRANCHES` on a list containing only prerelease entries.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `ref-name` | Branch name being released (e.g. `github.ref_name`) | Yes | |
+| `branch-pattern` | Glob matching product branches. The text replacing `*` becomes the product name. | No | `develop-*` |
+| `anchor-branch` | Release branch included in the generated config, required for the config to validate | No | `main` |
+| `prerelease-id` | `semantic-release` prerelease identifier for the product line | No | `alpha` |
+| `tag-format-template` | Tag format for the product line. `{product}` is replaced by the resolved product name; `${version}` is left for `semantic-release` to expand. | No | `{product}-v${version}` |
+| `excluded-products` | Comma-separated product names that must not get an alpha line, even when the branch matches the pattern | No | `''` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `is-alpha` | `'true'` when `ref-name` matches `branch-pattern` and the product is not excluded |
+| `product` | Product name extracted from the branch, empty when `is-alpha` is `'false'` |
+| `branches` | JSON branches config to override `semantic-release` with, empty when `is-alpha` is `'false'` |
+| `tag-format` | Tag format to override `semantic-release` with, empty when `is-alpha` is `'false'` |
+
+For `develop-midaz` with the defaults:
+
+```json
+[{"name":"main"},{"name":"develop-midaz","prerelease":"alpha"}]
+```
+
+The action fails the run when `branch-pattern` has no `*`, when the extracted product name does not match `^[a-z0-9][a-z0-9-]*$`, or when `ref-name` equals `anchor-branch`.
+
+## Version baseline
+
+A product line starts from scratch: no tag matches `<product>-v*` on the first run, so `semantic-release` falls back to `FIRST_RELEASE` and publishes `<product>-v1.0.0-alpha.1`. The repo's existing `v*` tags are invisible to that calculation because they do not match the tag format. To start a product from another baseline, push an annotated tag in the product format (e.g. `midaz-v0.1.0`) before the first alpha run.
+
+## Usage as composite step
+
+```yaml
+jobs:
+  release:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Resolve product alpha channel
+        id: alpha
+        uses: LerianStudio/github-actions-shared-workflows/src/config/product-alpha-channel@v1.x.x
+        with:
+          ref-name: ${{ github.ref_name }}
+          branch-pattern: 'develop-*'
+          anchor-branch: main
+          excluded-products: core
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@<sha> # v6
+        with:
+          ci: false
+          working_directory: ${{ matrix.app.working_dir }}
+          branches: ${{ steps.alpha.outputs.branches }}
+          tag_format: ${{ steps.alpha.outputs.tag-format }}
+```
+
+## Usage as reusable workflow
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [develop, develop-*, release-candidate, main]
+
+jobs:
+  release:
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/js-release.yml@v1.x.x
+    with:
+      product_alpha_enabled: true
+      product_alpha_branch_pattern: 'develop-*'
+      product_alpha_excluded_products: 'core'
+    secrets: inherit
+```
+
+The consuming repo must add the product branches to its `on.push.branches` — the alpha line is never reached otherwise.
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+```

--- a/src/config/product-alpha-channel/action.yml
+++ b/src/config/product-alpha-channel/action.yml
@@ -27,17 +27,17 @@ inputs:
     default: ""
 
 outputs:
-  is-alpha:
+  has-alpha:
     description: "'true' when ref-name matches branch-pattern and the product is not excluded"
     value: ${{ steps.resolve.outputs.is_alpha }}
   product:
-    description: Product name extracted from the branch, empty when is-alpha is 'false'
+    description: Product name extracted from the branch, empty when has-alpha is 'false'
     value: ${{ steps.resolve.outputs.product }}
   branches:
-    description: JSON branches config to override semantic-release with, empty when is-alpha is 'false'
+    description: JSON branches config to override semantic-release with, empty when has-alpha is 'false'
     value: ${{ steps.resolve.outputs.branches }}
   tag-format:
-    description: Tag format to override semantic-release with, empty when is-alpha is 'false'
+    description: Tag format to override semantic-release with, empty when has-alpha is 'false'
     value: ${{ steps.resolve.outputs.tag_format }}
 
 runs:
@@ -75,10 +75,12 @@ runs:
         prefix="${BRANCH_PATTERN%%\**}"
         suffix="${BRANCH_PATTERN#*\*}"
 
+        # A non-match is the common case on the shared branches, so it stays a
+        # plain log line — only an engaged alpha line is worth a run annotation.
         case "$REF_NAME" in
           "${prefix}"*"${suffix}") ;;
           *)
-            echo "::notice::'${REF_NAME}' does not match '${BRANCH_PATTERN}' — no alpha channel"
+            echo "'${REF_NAME}' does not match '${BRANCH_PATTERN}' — no alpha channel"
             not_alpha
             ;;
         esac
@@ -96,7 +98,7 @@ runs:
         IFS=',' read -ra excluded <<< "$EXCLUDED_PRODUCTS"
         for item in "${excluded[@]}"; do
           if [ "$(echo "$item" | xargs)" = "$product" ]; then
-            echo "::notice::Product '${product}' is excluded — no alpha channel"
+            echo "Product '${product}' is excluded — no alpha channel"
             not_alpha
           fi
         done

--- a/src/config/product-alpha-channel/action.yml
+++ b/src/config/product-alpha-channel/action.yml
@@ -1,0 +1,126 @@
+name: Product Alpha Channel
+description: "Resolves the semantic-release branches and tag format for a per-product alpha line, derived from the branch name."
+
+inputs:
+  ref-name:
+    description: Branch name being released (e.g. github.ref_name)
+    required: true
+  branch-pattern:
+    description: Glob matching product branches. The text replacing `*` becomes the product name.
+    required: false
+    default: "develop-*"
+  anchor-branch:
+    description: Release branch included in the generated config. semantic-release rejects a branches list with no release branch, so this must be set even though no tag in the product format is expected on it.
+    required: false
+    default: main
+  prerelease-id:
+    description: semantic-release prerelease identifier for the product line
+    required: false
+    default: alpha
+  tag-format-template:
+    description: "Tag format for the product line. `{product}` is replaced by the resolved product name; `${version}` is left for semantic-release to expand."
+    required: false
+    default: '{product}-v${version}'
+  excluded-products:
+    description: Comma-separated product names that must not get an alpha line, even when the branch matches the pattern.
+    required: false
+    default: ""
+
+outputs:
+  is-alpha:
+    description: "'true' when ref-name matches branch-pattern and the product is not excluded"
+    value: ${{ steps.resolve.outputs.is_alpha }}
+  product:
+    description: Product name extracted from the branch, empty when is-alpha is 'false'
+    value: ${{ steps.resolve.outputs.product }}
+  branches:
+    description: JSON branches config to override semantic-release with, empty when is-alpha is 'false'
+    value: ${{ steps.resolve.outputs.branches }}
+  tag-format:
+    description: Tag format to override semantic-release with, empty when is-alpha is 'false'
+    value: ${{ steps.resolve.outputs.tag_format }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve product alpha channel
+      id: resolve
+      shell: bash
+      env:
+        REF_NAME: ${{ inputs.ref-name }}
+        BRANCH_PATTERN: ${{ inputs.branch-pattern }}
+        ANCHOR_BRANCH: ${{ inputs.anchor-branch }}
+        PRERELEASE_ID: ${{ inputs.prerelease-id }}
+        TAG_FORMAT_TEMPLATE: ${{ inputs.tag-format-template }}
+        EXCLUDED_PRODUCTS: ${{ inputs.excluded-products }}
+      run: |
+        set -euo pipefail
+
+        not_alpha() {
+          echo "is_alpha=false" >> "$GITHUB_OUTPUT"
+          echo "product=" >> "$GITHUB_OUTPUT"
+          echo "branches=" >> "$GITHUB_OUTPUT"
+          echo "tag_format=" >> "$GITHUB_OUTPUT"
+          exit 0
+        }
+
+        case "$BRANCH_PATTERN" in
+          *'*'*) ;;
+          *)
+            echo "::error::branch-pattern must contain a '*' placeholder (got '${BRANCH_PATTERN}')"
+            exit 1
+            ;;
+        esac
+
+        prefix="${BRANCH_PATTERN%%\**}"
+        suffix="${BRANCH_PATTERN#*\*}"
+
+        case "$REF_NAME" in
+          "${prefix}"*"${suffix}") ;;
+          *)
+            echo "::notice::'${REF_NAME}' does not match '${BRANCH_PATTERN}' — no alpha channel"
+            not_alpha
+            ;;
+        esac
+
+        product="${REF_NAME#"$prefix"}"
+        product="${product%"$suffix"}"
+
+        # The product name lands in a git tag and in a JSON config, so keep it to
+        # a conservative charset instead of trusting whatever the branch is called.
+        if ! printf '%s' "$product" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+          echo "::error::Product name '${product}' (from branch '${REF_NAME}') must match ^[a-z0-9][a-z0-9-]*$"
+          exit 1
+        fi
+
+        IFS=',' read -ra excluded <<< "$EXCLUDED_PRODUCTS"
+        for item in "${excluded[@]}"; do
+          if [ "$(echo "$item" | xargs)" = "$product" ]; then
+            echo "::notice::Product '${product}' is excluded — no alpha channel"
+            not_alpha
+          fi
+        done
+
+        if [ "$REF_NAME" = "$ANCHOR_BRANCH" ]; then
+          echo "::error::ref-name and anchor-branch must differ (both '${REF_NAME}')"
+          exit 1
+        fi
+
+        tag_format="${TAG_FORMAT_TEMPLATE//\{product\}/$product}"
+
+        branches="$(
+          jq -nc \
+            --arg anchor "$ANCHOR_BRANCH" \
+            --arg ref "$REF_NAME" \
+            --arg id "$PRERELEASE_ID" \
+            '[{name: $anchor}, {name: $ref, prerelease: $id}]'
+        )"
+
+        {
+          echo "is_alpha=true"
+          echo "product=${product}"
+          echo "branches=${branches}"
+          echo "tag_format=${tag_format}"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::notice::Alpha channel for '${product}' — tag format '${tag_format}', prerelease '${PRERELEASE_ID}'"


### PR DESCRIPTION
## Description

Adds a per-product alpha release line to `release.yml`, so a repo where each product owns its own long-lived branch can validate that product in isolation before integrating it into the unified prerelease line.

When `product_alpha_enabled` is on, every push is matched against `product_alpha_branch_pattern`. On a match, the new `product-alpha-channel` composite extracts the product name from the branch and derives both the tag prefix and the prerelease identifier from it:

| Branch | Tag published |
|--------|---------------|
| `develop-midaz` | `midaz-v1.0.0-alpha.1` |
| `develop-tracer` | `tracer-v1.0.0-alpha.1` |
| `develop` / `release-candidate` / `main` | unchanged — from the caller `.releaserc` |

The composite only computes values; it never writes a config file or creates a tag. `release.yml` forwards the outputs to the `branches` and `tag_format` inputs of `cycjimmy/semantic-release-action`, which override the caller `.releaserc` for that run only.

Affected workflows: `release.yml` (new inputs + wiring), `js-release.yml` (forwards the inputs). `go-release.yml` and `self-release.yml` inherit the new inputs but stay off by default.

Two design constraints are encoded deliberately:

- **The generated `branches` list always names an anchor release branch.** `semantic-release` validates that at least one non-prerelease branch is configured (`release.branchesValidator` in `lib/definitions/branches.js`) and aborts with `ERELEASEBRANCHES` on a prerelease-only list.
- **Product lines are excluded from the stale-prerelease guard.** The guard compares a calculated version against the stable `v*` tags; a product line carries its own prefix and never shares that namespace, so the guard would only produce false positives there.

A product line starts at `1.0.0-alpha.1` — no tag matches `<product>-v*` on the first run, so `semantic-release` falls back to its first-release baseline. Documented in the composite README, along with how to seed another baseline.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. All four new inputs default to the current behavior (`product_alpha_enabled: false`), and the `branches` / `tag_format` overrides resolve to empty strings for every existing caller. Confirmed in `src/handleOptions.js` of the pinned action: an empty input returns `{}` and is never passed to `semantic-release`, so the caller `.releaserc` stays authoritative.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validated locally:

- `actionlint` v1.7.12 — clean on `release.yml` and `js-release.yml`
- `src/lint/composite-schema` — the new composite passes, and so do all pre-existing composites
- `shellcheck --severity=warning --exclude=SC1090,SC1091,SC2154` (same settings as `src/lint/shellcheck`) — no findings
- Branch resolution exercised over 11 cases: `develop-midaz`, `develop-tracer`, `develop`, `main`, `release-candidate`, `feat/foo`, an excluded product, an uppercase product, an empty product, a pattern with no `*`, and an alternative `alpha/*` pattern

**Caller repo / workflow run:** not yet. `release.yml` references the composite as `@v1`, matching its siblings (`prerelease-guard@v1`, `backmerge-sync@v1`), and that floating tag will only carry `product-alpha-channel` once this PR is released. Validating end to end on `product-console` first requires temporarily pointing that ref at this branch.

Product-name input is validated against `^[a-z0-9][a-z0-9-]*$` and every value reaches the script through `env:`, never interpolated into `run:`.

## Related Issues

