### PR TITLE
ci(coderabbit): gate auto-review behind CI and scope it to develop

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -72,17 +72,25 @@ reviews:
         Flag any usage example that references `@main` — examples must use `@develop` or `@feat/<branch>` for testing and `@vX.Y.Z` for production.
 
   auto_review:
-    enabled: true
+    # Reviews are gated on CI rather than firing when the PR opens: with
+    # `enabled: false` a positive label match is what triggers the review, so
+    # nothing is spent on a PR until it is green. `Self — PR Validation` applies
+    # `review-ready` once every required check has passed.
+    enabled: false
     drafts: false
     base_branches:
       - "develop"
-    # Negative match: review everything except PRs carrying this label.
-    # `base_branches` cannot express this on its own — the default branch (main)
-    # is always reviewed and `base_branches` only extends that set. The label is
-    # applied to every PR not targeting develop by
-    # `.github/workflows/self-coderabbit-guard.yml`. Remove it from a PR (and
-    # comment `@coderabbitai review`) to review that PR anyway.
+    # `review-ready` opts a PR in (added by CI); `!skip-coderabbit` keeps it out
+    # regardless. A PR is reviewed only when it has the first and not the second.
+    #
+    # The negative match is how base branches are excluded at all: CodeRabbit
+    # always reviews the default branch (main) and `base_branches` only extends
+    # that set, so `skip-coderabbit` is applied to every PR not targeting develop
+    # by `.github/workflows/self-coderabbit-guard.yml`.
+    #
+    # To review a PR anyway, drop the labels and comment `@coderabbitai review`.
     labels:
+      - "review-ready"
       - "!skip-coderabbit"
     ignore_title_keywords:
       - "WIP"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -76,6 +76,14 @@ reviews:
     drafts: false
     base_branches:
       - "develop"
+    # Negative match: review everything except PRs carrying this label.
+    # `base_branches` cannot express this on its own — the default branch (main)
+    # is always reviewed and `base_branches` only extends that set. The label is
+    # applied to every PR not targeting develop by
+    # `.github/workflows/self-coderabbit-guard.yml`. Remove it from a PR (and
+    # comment `@coderabbitai review`) to review that PR anyway.
+    labels:
+      - "!skip-coderabbit"
     ignore_title_keywords:
       - "WIP"
       - "wip"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -155,3 +155,7 @@
 - name: skip-coderabbit
   color: "5319e7"
   description: CodeRabbit skips auto-review on this PR
+
+- name: review-ready
+  color: "0e8a16"
+  description: Required checks passed — CodeRabbit is cleared to review

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -149,3 +149,9 @@
 - name: pinned
   color: "d4a017"
   description: Pinned discussion/tracker — exempt from stale auto-close
+
+# ── Review routing ─────────────────────────────────────────────────────────────
+
+- name: skip-coderabbit
+  color: "5319e7"
+  description: CodeRabbit skips auto-review on this PR

--- a/.github/workflows/self-coderabbit-guard.yml
+++ b/.github/workflows/self-coderabbit-guard.yml
@@ -24,30 +24,34 @@ name: Self — CodeRabbit Guard
 # reaching main comes from develop, where CodeRabbit already reviewed it — those
 # release PRs are the expensive duplicate this workflow exists to avoid.
 #
-# To get a review on a PR that was labelled, remove the label and comment
-# `@coderabbitai review`. Nothing re-applies it.
+# The label is reconciled in both directions rather than only applied, because a
+# PR's base branch can change after it is opened (the `edited` event). Retargeting
+# main → develop has to clear the label, otherwise it stays stuck and the PR is
+# never reviewed — silently, since reviews are gated.
+#
+# To get a review on a labelled PR, remove the label and comment
+# `@coderabbitai review`. Only another `edited`/`reopened` event re-applies it.
 
 on:
   pull_request:
     types:
       - opened
       - reopened
-    branches-ignore:
-      - develop
+      # `edited` fires when the base branch changes — that is what needs
+      # reconciling. It also fires on title/body edits, which cost one cheap run.
+      - edited
 
 permissions:
   contents: read
 
 jobs:
-  skip-review:
-    name: Suppress CodeRabbit Review
-    # Never suppress hotfixes — that code has not been reviewed anywhere else.
-    if: ${{ !startsWith(github.head_ref, 'hotfix/') }}
+  reconcile-review-scope:
+    name: Reconcile CodeRabbit Review Scope
     runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       pull-requests: write
     steps:
-      - name: Apply skip-coderabbit label
+      - name: Reconcile skip-coderabbit label
         env:
           GH_TOKEN: ${{ secrets.MANAGE_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -55,11 +59,34 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (base is not develop) — suppressing CodeRabbit review"
+          # Suppress reviews unless the PR targets develop, or is a hotfix —
+          # hotfix code never passed through develop, so it was never reviewed.
+          if [ "$BASE_REF" = "develop" ] || [[ "$HEAD_REF" == hotfix/* ]]; then
+            should_skip=false
+          else
+            should_skip=true
+          fi
 
-          # Idempotent: adding a label the PR already carries is a no-op.
-          # The label itself is declared in .github/labels.yml and created by
-          # the labels-sync routine — this only attaches it.
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label skip-coderabbit
+          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
+          case " $labels " in
+            *" skip-coderabbit "*) has_label=true ;;
+            *) has_label=false ;;
+          esac
+
+          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (suppress=${should_skip}, labelled=${has_label})"
+
+          # Only mutate when the state actually differs. `gh pr edit --remove-label`
+          # errors out when the label does not exist in the repository, so guarding
+          # on the current state keeps PRs to develop working before labels-sync
+          # has created it.
+          if [ "$should_skip" = true ] && [ "$has_label" = false ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label skip-coderabbit
+            echo "✅ Suppression applied"
+          elif [ "$should_skip" = false ] && [ "$has_label" = true ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label skip-coderabbit
+            echo "✅ Suppression cleared"
+          else
+            echo "✅ Already in the desired state — nothing to do"
+          fi
 
           echo "✅ Label applied"

--- a/.github/workflows/self-coderabbit-guard.yml
+++ b/.github/workflows/self-coderabbit-guard.yml
@@ -1,0 +1,65 @@
+name: Self — CodeRabbit Guard
+
+# Keeps CodeRabbit auto-review scoped to PRs targeting develop.
+#
+# CodeRabbit always reviews the repository default branch (main) and its
+# `reviews.auto_review.base_branches` setting only *extends* that set — there is
+# no way to exclude a base branch through configuration. The exclusion is
+# therefore expressed as a label: `.coderabbit.yml` sets
+# `reviews.auto_review.labels: ["!skip-coderabbit"]`, a negative match meaning
+# "review every PR except the labelled ones". This workflow applies that label
+# to every PR whose base branch is not develop.
+#
+# It is deliberately a standalone workflow instead of a `.github/labeler.yml`
+# rule: the auto-labeler runs inside the `advisory-checks` job, which waits on
+# `blocking-checks`, so the label would only land minutes after the PR opens —
+# long after CodeRabbit has already reviewed it. This one runs on its own within
+# seconds of the `opened` event.
+#
+# `branches-ignore: [develop]` is the exact complement of develop, so main,
+# release-candidate and any future base branch are covered without listing them.
+#
+# hotfix/* is excluded from the suppression on purpose: those PRs carry code that
+# never passed through develop, so they have never been reviewed. Everything else
+# reaching main comes from develop, where CodeRabbit already reviewed it — those
+# release PRs are the expensive duplicate this workflow exists to avoid.
+#
+# To get a review on a PR that was labelled, remove the label and comment
+# `@coderabbitai review`. Nothing re-applies it.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+    branches-ignore:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  skip-review:
+    name: Suppress CodeRabbit Review
+    # Never suppress hotfixes — that code has not been reviewed anywhere else.
+    if: ${{ !startsWith(github.head_ref, 'hotfix/') }}
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply skip-coderabbit label
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (base is not develop) — suppressing CodeRabbit review"
+
+          # Idempotent: adding a label the PR already carries is a no-op.
+          # The label itself is declared in .github/labels.yml and created by
+          # the labels-sync routine — this only attaches it.
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label skip-coderabbit
+
+          echo "✅ Label applied"

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -331,3 +331,57 @@ jobs:
           composite-schema-files: ${{ needs.changed-files.outputs.composite_files }}
           deployment-matrix-result: ${{ needs.deployment-matrix.result }}
           deployment-matrix-files: ${{ contains(needs.changed-files.outputs.all_files, 'config/deployment-matrix.yml') && 'config/deployment-matrix.yml' || '' }}
+
+  # ----------------- CodeRabbit Gate -----------------
+  # Releases CodeRabbit onto the PR only after every required check is green.
+  #
+  # `.coderabbit.yml` sets `reviews.auto_review.enabled: false`, so nothing is
+  # reviewed automatically; a positive label match is what triggers the review.
+  # Applying `review-ready` here is that trigger, which keeps CodeRabbit from
+  # spending a review on a PR that still fails lint or validation.
+  #
+  # PRs whose base is not develop also carry `skip-coderabbit` (applied by
+  # self-coderabbit-guard.yml), and that negative match wins — they stay
+  # unreviewed even once this label lands.
+  gate-coderabbit:
+    name: Release CodeRabbit Review
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      pull-requests: write
+    needs:
+      - validation
+      - changed-files
+      - breaking-change-guard-tests
+      - permission-manifest-publish-tests
+      - pr-commit-signatures-tests
+      - yamllint
+      - actionlint
+      - pinned-actions
+      - codeql-action-versions
+      - markdown-link-check
+      - typos
+      - shellcheck
+      - readme-check
+      - composite-schema
+      - deployment-matrix
+      - codeql
+    # `always()` so skipped lints (no matching files changed) do not block the
+    # gate; only a real failure or cancellation does. Draft PRs are excluded —
+    # `drafts: false` in .coderabbit.yml means the label would be inert anyway.
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.draft != true
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+    steps:
+      - name: Apply review-ready label
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "✅ All required checks passed — releasing CodeRabbit on PR #${PR_NUMBER}"
+
+          # Idempotent: re-adding a label the PR already carries is a no-op.
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label review-ready

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -343,12 +343,52 @@ jobs:
   # PRs whose base is not develop also carry `skip-coderabbit` (applied by
   # self-coderabbit-guard.yml), and that negative match wins — they stay
   # unreviewed even once this label lands.
+  #
+  # `revoke-coderabbit` withdraws the label as soon as a new revision is pushed,
+  # so it has to be re-earned by that revision. Without it the label from the
+  # previous run would still be on the PR while the new checks run, and since
+  # incremental reviews stay enabled, CodeRabbit would review a revision that may
+  # well be failing — exactly what the gate exists to prevent. It also means each
+  # green push re-applies the label and therefore does get reviewed.
+  revoke-coderabbit:
+    name: Hold CodeRabbit Review
+    runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      pull-requests: write
+    # No `needs`: this must land before the checks finish, not after them.
+    if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    steps:
+      - name: Withdraw review-ready label
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
+
+          # `gh pr edit --remove-label` errors out when the label does not exist
+          # in the repository, so only call it when the PR actually carries it.
+          case " $labels " in
+            *" review-ready "*)
+              echo "🔒 New revision pushed — withdrawing review-ready from PR #${PR_NUMBER}"
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label review-ready
+              echo "✅ Withdrawn — the revision must pass the checks to earn it back"
+              ;;
+            *)
+              echo "✅ PR #${PR_NUMBER} does not carry review-ready — nothing to withdraw"
+              ;;
+          esac
+
   gate-coderabbit:
     name: Release CodeRabbit Review
     runs-on: ${{ vars.GENERAL_RUNNERS || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       pull-requests: write
     needs:
+      # Ordering guarantee: the withdrawal must never land after this job's
+      # re-application. If it failed, the gate stays closed rather than releasing
+      # a label we could not withdraw.
+      - revoke-coderabbit
       - validation
       - changed-files
       - breaking-change-guard-tests


### PR DESCRIPTION
## Description

Two changes to when CodeRabbit spends a review, both driven off the same mechanism — labels:

1. **Gate reviews on CI.** Nothing is reviewed when the PR opens; the review fires once every required check is green.
2. **Scope reviews to `develop`.** PRs targeting any other base branch are not reviewed at all, `hotfix/*` excepted.

### Why labels, and not configuration

CodeRabbit always reviews the repository default branch (`main`), and `reviews.auto_review.base_branches` only **extends** that set — a base branch cannot be excluded through configuration, in the YAML or in the dashboard. The field's own description says so: *"Base branches (other than the default branch) to review"*. The `base_branches: ["develop"]` we already had therefore never excluded anything — `main` was reviewed for being the default branch, `develop` for being listed.

Labels are the only lever that can express both rules, and `.coderabbit.yml` now reads:

```yaml
enabled: false
labels: ["review-ready", "!skip-coderabbit"]
```

A PR is reviewed only when it carries `review-ready` **and** does not carry `skip-coderabbit`. Per CodeRabbit's schema, with `enabled: false` *"a positive label match (for example ['review-ready']) triggers a review"*.

### The two labels

| Label | Applied by | When |
|---|---|---|
| `review-ready` | `self-pr-validation.yml` → `gate-coderabbit` | every required check passed |
| `skip-coderabbit` | `self-coderabbit-guard.yml` (new) | PR base is not `develop` |

`branches-ignore: [develop]` on the guard is the exact complement of `develop`, so `main`, `release-candidate` and any future base branch are covered without listing them.

**`hotfix/*` is deliberately exempt from the skip.** Those PRs carry code that never passed through `develop`, so it has never been reviewed anywhere. Everything else reaching `main` comes from `develop`, where CodeRabbit already reviewed it — those release PRs are the expensive duplicate this change exists to avoid, and they are the largest PRs in the repo.

Resulting behaviour:

| head → base | labels | CodeRabbit |
|---|---|---|
| `feature/*` → `develop`, CI green | `review-ready` | reviews |
| `feature/*` → `develop`, CI red | — | never reviewed |
| `develop` → `main` (release) | `skip-coderabbit` + `review-ready` | skips |
| `develop` → `release-candidate` | `skip-coderabbit` | skips |
| `hotfix/*` → `main`, CI green | `review-ready` | reviews |

To review a PR anyway, drop the labels and comment `@coderabbitai review` — nothing re-applies them within the same run.

### Why the guard is a standalone workflow

`actions/labeler@v6` does support a `base-branch` matcher, which would have avoided a new file. But the auto-labeler step lives in the `advisory-checks` job (`pr-validation.yml:306`), which has `needs: [blocking-checks]` and only runs once they pass — the label would land minutes after the PR opens, long after CodeRabbit had already reviewed it. The standalone workflow runs within seconds of the `opened` event.

The gate job has the opposite requirement — it *must* run last — so it lives in `self-pr-validation.yml`, where it can depend on the whole job graph. It is not added to the reusable `pr-validation.yml`, so no consumer repository is affected.

### ⚠️ Merge prerequisites and known trade-offs

**The labels do not exist yet.** `labels-sync` only fires on `push` to `main` touching `.github/labels.yml` (`self-routine.yml:9`), so merging this into `develop` will not create them. Until they exist, `gh pr edit --add-label` fails: the gate errors on every PR and — because reviews are now gated — **no PR gets reviewed**. Create both labels before merging, from the UI or by dispatching `Self — Repository Routines` with `routine=labels-sync`.

**Reviews are now fail-closed.** If the gate job fails or never runs, the PR is silently never reviewed. That is the cost of gating; previously a broken workflow just meant reviews happened anyway.

**Incremental review is uncertain under `enabled: false`.** `auto_incremental_review` defaults to `true` (*"Re-run the review on each push"*), but with automatic reviews disabled it is unclear whether pushes after the label lands still trigger incremental reviews, or whether the label produces a single review. Re-adding a label the PR already carries is a no-op, so the gate cannot force it. This PR is itself the experiment: `.coderabbit.yml` is read from the head branch, so this PR already runs under the new regime — watch whether a second review appears after a follow-up push. If it does not and incremental reviews are wanted, the gate can be changed to remove and re-add the label on each green run.

**Reviews now wait on CodeQL.** The gate needs the full job graph, CodeQL included, so the review arrives later than it used to. Trimming the `needs` list trades strictness for a faster review.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [x] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Nothing here is part of the reusable surface — `.coderabbit.yml`, `.github/labels.yml` and the `self-*` workflows are all local to this repository. The reusable `pr-validation.yml` is untouched.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed:

- YAML parsed for all four touched files; `actionlint` clean on both workflows.
- Every entry in the gate's `needs` cross-checked against the actual job graph — 16 jobs, no dangling reference. The only job left out is `lint-report`, deliberately: it runs `if: always()` and is a reporter, so it is green even when a lint fails and would not filter anything.
- The gate uses `always()` with `!contains(needs.*.result, 'failure')` so that skipped lints (no matching files changed) do not block it, while a real failure or cancellation does.
- `reviews.auto_review` keys checked against CodeRabbit's official schema (`schema.v2.json`): `labels` is a valid field typed `array<string>`, and the `enabled: false` + positive-label trigger is documented there.
- Neither new workflow uses an external action, so there is nothing for `pinned-actions` to flag.
- `.github/labeler.yml` is untouched (an earlier draft modified it; reverted).

Not applicable: caller-repo run. Nothing in this PR is reachable from a consumer repository.

## Related Issues
