### PR TITLE
fix(coderabbit): withhold review-ready outside the review scope

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -80,15 +80,17 @@ reviews:
     drafts: false
     base_branches:
       - "develop"
-    # `review-ready` opts a PR in (added by CI); `!skip-coderabbit` keeps it out
-    # regardless. A PR is reviewed only when it has the first and not the second.
+    # `review-ready` is what opts a PR in, applied by CI once the checks pass.
     #
-    # The negative match is how base branches are excluded at all: CodeRabbit
-    # always reviews the default branch (main) and `base_branches` only extends
-    # that set, so `skip-coderabbit` is applied to every PR not targeting develop
-    # by `.github/workflows/self-coderabbit-guard.yml`.
+    # `!skip-coderabbit` is kept as defence in depth only — do NOT rely on it.
+    # With `enabled: false` the positive label acts as a trigger and this negative
+    # match does not veto it: on PR #705 `skip-coderabbit` was applied 8 minutes
+    # before CodeRabbit reviewed that release PR regardless. Restricting reviews
+    # to develop is therefore enforced in `self-pr-validation.yml`, by withholding
+    # `review-ready` altogether, and the label here is redundant signalling.
     #
-    # To review a PR anyway, drop the labels and comment `@coderabbitai review`.
+    # To review a PR anyway, add `review-ready` by hand, or comment
+    # `@coderabbitai review`.
     labels:
       - "review-ready"
       - "!skip-coderabbit"

--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -66,7 +66,7 @@ on:
         type: string
         default: 'direct-with-pr-fallback'
       product_alpha_enabled:
-        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives both the tag prefix and the prerelease identifier, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
+        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives the tag prefix, while the prerelease identifier stays alpha, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
         type: boolean
         default: false
       product_alpha_branch_pattern:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ on:
         type: boolean
         default: false
       product_alpha_enabled:
-        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives both the tag prefix and the prerelease identifier, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
+        description: 'Release product branches (see product_alpha_branch_pattern) on their own alpha line: the product name is taken from the branch and drives the tag prefix, while the prerelease identifier stays alpha, so develop-midaz publishes midaz-v1.0.0-alpha.1. Off by default; when off, branches and tag format come solely from the caller .releaserc.'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/self-coderabbit-guard.yml
+++ b/.github/workflows/self-coderabbit-guard.yml
@@ -44,6 +44,14 @@ on:
 permissions:
   contents: read
 
+# Serialized per PR so two reconcilers never fight over the same labels — a base
+# change fires `edited` while an earlier run may still be in flight. Cancelling is
+# safe and wanted here, unlike the repo's other concurrency groups: the superseded
+# run would only be acting on a base branch that no longer applies.
+concurrency:
+  group: self-coderabbit-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   reconcile-review-scope:
     name: Reconcile CodeRabbit Review Scope
@@ -59,15 +67,29 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
+          # BASE_REF/HEAD_REF come from the event payload, frozen at dispatch time.
+          # Read the live values instead, so a run superseded by a base change
+          # cannot reconcile against a branch that no longer applies. They are still
+          # logged to make a divergence visible.
+          read -r base head labels < <(
+            gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json baseRefName,headRefName,labels \
+              --jq '"\(.baseRefName) \(.headRefName) \([.labels[].name] | join(","))"'
+          )
+          labels=${labels//,/ }
+
+          if [ "$base" != "$BASE_REF" ] || [ "$head" != "$HEAD_REF" ]; then
+            echo "ℹ️ PR moved since dispatch: event said ${HEAD_REF} → ${BASE_REF}, live is ${head} → ${base}. Using the live values."
+          fi
+
           # Suppress reviews unless the PR targets develop, or is a hotfix —
           # hotfix code never passed through develop, so it was never reviewed.
-          if [ "$BASE_REF" = "develop" ] || [[ "$HEAD_REF" == hotfix/* ]]; then
+          if [ "$base" = "develop" ] || [[ "$head" == hotfix/* ]]; then
             should_skip=false
           else
             should_skip=true
           fi
 
-          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
           case " $labels " in
             *" skip-coderabbit "*) has_skip=true ;;
             *) has_skip=false ;;
@@ -77,7 +99,7 @@ jobs:
             *) has_ready=false ;;
           esac
 
-          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (suppress=${should_skip}, skip=${has_skip}, ready=${has_ready})"
+          echo "📌 PR #${PR_NUMBER}: ${head} → ${base} (suppress=${should_skip}, skip=${has_skip}, ready=${has_ready})"
 
           # Only mutate when the state actually differs. `gh pr edit --remove-label`
           # errors out when the label does not exist in the repository, so guarding

--- a/.github/workflows/self-coderabbit-guard.yml
+++ b/.github/workflows/self-coderabbit-guard.yml
@@ -69,24 +69,45 @@ jobs:
 
           labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(" ")')
           case " $labels " in
-            *" skip-coderabbit "*) has_label=true ;;
-            *) has_label=false ;;
+            *" skip-coderabbit "*) has_skip=true ;;
+            *) has_skip=false ;;
+          esac
+          case " $labels " in
+            *" review-ready "*) has_ready=true ;;
+            *) has_ready=false ;;
           esac
 
-          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (suppress=${should_skip}, labelled=${has_label})"
+          echo "📌 PR #${PR_NUMBER}: ${HEAD_REF} → ${BASE_REF} (suppress=${should_skip}, skip=${has_skip}, ready=${has_ready})"
 
           # Only mutate when the state actually differs. `gh pr edit --remove-label`
           # errors out when the label does not exist in the repository, so guarding
           # on the current state keeps PRs to develop working before labels-sync
           # has created it.
-          if [ "$should_skip" = true ] && [ "$has_label" = false ]; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label skip-coderabbit
-            echo "✅ Suppression applied"
-          elif [ "$should_skip" = false ] && [ "$has_label" = true ]; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label skip-coderabbit
-            echo "✅ Suppression cleared"
+          if [ "$should_skip" = true ]; then
+            if [ "$has_skip" = false ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label skip-coderabbit
+              echo "✅ Suppression applied"
+            fi
+
+            # Suppressing has to revoke the authorisation too, not just add a
+            # contradictory label. A PR that collected review-ready while it
+            # targeted develop and was then retargeted to main would otherwise keep
+            # it, and the positive label is what triggers the review — the skip
+            # label does not veto it (see .coderabbit.yml).
+            if [ "$has_ready" = true ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label review-ready
+              echo "✅ Authorisation revoked — review-ready withdrawn"
+            fi
           else
-            echo "✅ Already in the desired state — nothing to do"
+            if [ "$has_skip" = true ]; then
+              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label skip-coderabbit
+              echo "✅ Suppression cleared"
+            fi
+
+            # Deliberately not adding review-ready here: CI owns that label. This
+            # workflow also runs on `edited`, so a PR retargeted back to develop
+            # re-triggers Self — PR Validation, and the gate applies it once the
+            # checks pass.
           fi
 
-          echo "✅ Label applied"
+          echo "✅ Reconciled"

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -408,10 +408,20 @@ jobs:
     # `always()` so skipped lints (no matching files changed) do not block the
     # gate; only a real failure or cancellation does. Draft PRs are excluded —
     # `drafts: false` in .coderabbit.yml means the label would be inert anyway.
+    #
+    # The base/head condition is what actually keeps release PRs unreviewed. The
+    # `!skip-coderabbit` negative match in .coderabbit.yml does not do it: with
+    # `auto_review.enabled: false` the positive label is a *trigger*, and the
+    # negative match does not veto it. PR #705 proved it — `skip-coderabbit` was
+    # applied 8 minutes before CodeRabbit reviewed that release PR anyway. So the
+    # scope is decided here, where it is deterministic: withhold the label unless
+    # the PR targets develop, or is a hotfix (hotfix code never passed through
+    # develop, so it was never reviewed).
     if: >-
       always()
       && github.event_name == 'pull_request'
       && github.event.pull_request.draft != true
+      && (github.base_ref == 'develop' || startsWith(github.head_ref, 'hotfix/'))
       && !contains(needs.*.result, 'failure')
       && !contains(needs.*.result, 'cancelled')
     steps:

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -431,7 +431,24 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          echo "✅ All required checks passed — releasing CodeRabbit on PR #${PR_NUMBER}"
+          # The `if:` above reads `github.base_ref`, which comes from the event
+          # payload and is frozen at dispatch time. A run that started while the PR
+          # targeted develop would still pass that check after the PR was retargeted
+          # to main, and would then re-apply the label the guard had just revoked.
+          # Re-read the live state before mutating, which holds regardless of how
+          # many runs are in flight.
+          read -r base head < <(
+            gh pr view "$PR_NUMBER" --repo "$REPO" \
+              --json baseRefName,headRefName \
+              --jq '"\(.baseRefName) \(.headRefName)"'
+          )
+
+          if [ "$base" != "develop" ] && [[ "$head" != hotfix/* ]]; then
+            echo "⏭️ PR #${PR_NUMBER} now targets '${base}' from '${head}' — out of the review scope, withholding review-ready"
+            exit 0
+          fi
+
+          echo "✅ All required checks passed — releasing CodeRabbit on PR #${PR_NUMBER} (${head} → ${base})"
 
           # Idempotent: re-adding a label the PR already carries is a no-op.
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label review-ready


### PR DESCRIPTION
## Description

Fixes the flaw that PR #705 exposed: release PRs were still being reviewed by CodeRabbit, which was the main cost the gating work set out to cut.

### What went wrong

`#704` relied on `reviews.auto_review.labels: ["review-ready", "!skip-coderabbit"]` to keep PRs outside `develop` unreviewed. That negative match does not work under `enabled: false`. The timeline on #705 rules out a race:

| Time | Event |
|---|---|
| 13:29:27 | PR opened |
| 13:29:39 | `skip-coderabbit` applied — the guard took 12s |
| 13:32:11 | `review-ready` applied by the gate |
| **13:37:39** | **CodeRabbit reviewed anyway** — 8 min after the skip label |

Both labels were on the PR long before the review. With `enabled: false` the positive label acts as a *trigger* and the negative match does not veto it, so a `size/L` release PR got a full review.

### The fix

Scope is now decided in the workflow, where it is deterministic, instead of relying on CodeRabbit's label semantics. `gate-coderabbit` withholds `review-ready` unless the PR targets `develop` or comes from `hotfix/*`:

```yaml
&& (github.base_ref == 'develop' || startsWith(github.head_ref, 'hotfix/'))
```

Since `enabled: false` means no label → no review, withholding it is sufficient and does not depend on the guard having run at all.

Credit where due: this was CodeRabbit's own suggestion on #705, though it filed it as Minor on race-condition grounds. The measured cause is different and the severity higher.

Also corrects the `product_alpha_enabled` description in `release.yml` and `js-release.yml`. It claimed the product name drives "both the tag prefix and the prerelease identifier", but `release.yml:335` never passes `prerelease-id`, so the composite default (`alpha`) always applies and the product name only feeds `tag_format`. The example gave it away: in `midaz-v1.0.0-alpha.1` the identifier is `alpha`, not `midaz`. `docs/release-workflow.md` was already correct and is untouched.

### Mutual exclusivity of the two labels

Withholding `review-ready` outside the review scope is not enough on its own, because a PR can *enter* the suppressed scope after already earning the label. Open a PR against `develop`, let the checks pass (gate applies `review-ready`), then retarget it to `main`: the guard adds `skip-coderabbit`, the authorisation stays, and since the positive label is the trigger, CodeRabbit reviews the release PR — the #705 failure returning through another door.

So suppressing now revokes the authorisation instead of merely adding a contradictory label. The guard withdraws `review-ready` whenever it suppresses, and also cleans up a PR that already carries both.

The reverse is asymmetric on purpose: clearing `skip-coderabbit` does not apply `review-ready`, because CI owns that label. It still works out — `Self — PR Validation` also listens to `edited`, so a PR retargeted back to `develop` re-runs the gate and earns the label if the checks pass.

Full decision matrix, all 16 states of (base, head, skip present, ready present):

| base | head | skip | ready | action |
|---|---|:---:|:---:|---|
| develop | any | yes | any | `-skip` |
| develop | any | no | any | noop |
| main | `hotfix/*` | yes | any | `-skip` |
| main | `hotfix/*` | no | any | noop |
| main | other | no | no | `+skip` |
| main | other | no | yes | `+skip` `-ready` |
| main | other | yes | yes | `-ready` |
| main | other | yes | no | noop |

No state leaves both labels on a PR.

### Known redundancy, deliberately left in place

`skip-coderabbit` and `self-coderabbit-guard.yml` are now redundant: the same rule (base is not `develop`, `hotfix/*` excepted) is enforced in two places, and only the gate's copy has any effect. The label is downgraded to signalling — it makes the intent visible on the PR — and `!skip-coderabbit` is kept as defence in depth, with the comments in `.coderabbit.yml` rewritten to say plainly that it must not be relied on.

Removing the guard entirely is the right cleanup, but it belongs with the portability work rather than here: `gate-coderabbit` still hardcodes this repo's 15 job names in `needs`, which is what blocks reusing any of this in another repository. That change will revisit the whole shape, and collapsing two rules into one is best done there rather than twice.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The `product_alpha_enabled` change is to an input's description text only — no behaviour, name, type or default is altered, so no caller needs to do anything. Everything else is local to this repository's own CI.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed:

- `actionlint` clean on all three touched workflows; YAML parsed for all four files.
- The `product_alpha_enabled` claim was traced through the code before rewording: `release.yml:335` → `src/config/product-alpha-channel/action.yml`, where `prerelease-id` defaults to `alpha` (line 20) and the resolved `product` is interpolated only into `tag_format`.
- Grepped `docs/` and `src/` for the same wording — no other copies.

This PR is itself the test for the fix: it targets `develop`, so `review-ready` should still be applied and CodeRabbit should still review it. The complementary case — a PR to `main` no longer being reviewed — can only be confirmed on the next release PR, since the condition depends on the base branch.

## Related Issues

Follows up on #704. Fixes the behaviour observed on #705.

