### PR TITLE
test(coderabbit): verify the gate withholds review when a check fails

### DIFF
--- a/CODERABBIT-GATE-TEST.md
+++ b/CODERABBIT-GATE-TEST.md
@@ -1,0 +1,31 @@
+# CodeRabbit gate — throwaway test file
+
+This file exists only to verify that the CodeRabbit review gate holds when a
+required check fails. **Do not merge this PR.** Close it and delete the branch
+once the behaviour has been observed.
+
+## What is being tested
+
+`gate-coderabbit` in `.github/workflows/self-pr-validation.yml` applies the
+`review-ready` label only when no required check failed. With
+`reviews.auto_review.enabled: false` in `.coderabbit.yml`, that label is the
+trigger for a review — so no label means no review.
+
+The two words below are misspelled on purpose, which makes `Spelling Check`
+fail. It runs whenever any file changes, so it is the most reliable check to
+break deliberately:
+
+- enviroment
+- recieve
+
+## Expected outcome
+
+| Step | Expectation |
+|------|-------------|
+| `Spelling Check` | fails on the two words above |
+| `gate-coderabbit` | skipped — its `if:` requires no failure among `needs` |
+| `review-ready` | never applied |
+| CodeRabbit | posts no review |
+
+A summary/walkthrough comment may still appear: `high_level_summary` is
+independent of `auto_review.enabled` and is not governed by the gate.

--- a/CODERABBIT-GATE-TEST.md
+++ b/CODERABBIT-GATE-TEST.md
@@ -11,21 +11,37 @@ once the behaviour has been observed.
 `reviews.auto_review.enabled: false` in `.coderabbit.yml`, that label is the
 trigger for a review — so no label means no review.
 
-The two words below are misspelled on purpose, which makes `Spelling Check`
-fail. It runs whenever any file changes, so it is the most reliable check to
-break deliberately:
+## First revision — red path (confirmed)
 
-- enviroment
-- recieve
+The first commit carried two deliberate misspellings, which failed
+`Spelling Check`. That check runs whenever any file changes, so it is the most
+reliable one to break on purpose. Observed on commit `b263f5d`:
 
-## Expected outcome
+| Step | Expected | Observed |
+|------|----------|----------|
+| `Spelling Check` | fails | failed on both words |
+| `gate-coderabbit` | skipped | skipped |
+| `review-ready` | never applied | never applied |
+| CodeRabbit | no review | no review, no inline comments |
+
+CodeRabbit stated the reason itself, rather than staying silent:
+
+> Review skipped — auto reviews are limited based on label configuration.
+> Required labels (at least one): `review-ready`.
+> Excluded labels (none allowed): `skip-coderabbit`.
+
+A summary/walkthrough comment did appear: `high_level_summary` is independent of
+`auto_review.enabled` and is not governed by the gate.
+
+## Second revision — transition to green
+
+This revision fixes both spellings, so every required check should pass. It
+exercises the one path the earlier PRs never covered: a revision going from red
+to green on the same pull request.
 
 | Step | Expectation |
 |------|-------------|
-| `Spelling Check` | fails on the two words above |
-| `gate-coderabbit` | skipped — its `if:` requires no failure among `needs` |
-| `review-ready` | never applied |
-| CodeRabbit | posts no review |
-
-A summary/walkthrough comment may still appear: `high_level_summary` is
-independent of `auto_review.enabled` and is not governed by the gate.
+| `Hold CodeRabbit Review` | runs (this push is a `synchronize`) and finds nothing to withdraw |
+| `Spelling Check` | passes |
+| `gate-coderabbit` | runs and applies `review-ready` |
+| CodeRabbit | reviews, now that the revision earned the label |


### PR DESCRIPTION
## Description

**Throwaway PR — do not merge.** Open only to observe the CodeRabbit review gate under a failing check, then close.

`gate-coderabbit` (`.github/workflows/self-pr-validation.yml`) applies `review-ready` only when nothing among its `needs` failed. Since `.coderabbit.yml` sets `reviews.auto_review.enabled: false`, that label is the review trigger — so withholding it should mean no review at all.

Until now the gate was only ever exercised on green PRs (#704, #706). This exercises the negative path, which is the half that actually saves money.

`CODERABBIT-GATE-TEST.md` carries two deliberate misspellings (`enviroment`, `recieve`) to fail `Spelling Check`. That check was chosen because it runs on any file change, unlike the other ten which are conditional on file type.

## Expected outcome

| Step | Expectation |
|------|-------------|
| `Spelling Check` | fails |
| `gate-coderabbit` | skipped |
| `review-ready` | never applied |
| CodeRabbit | no review, no inline comments |

A summary/walkthrough comment may still appear — `high_level_summary` is independent of `auto_review.enabled` and outside the gate's control, as observed on #706.

If a review *does* appear, the gate does not hold and the finding is worth more than this PR.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [x] `test`: Adding or updating tests

## Breaking Changes

None. Adds one throwaway markdown file and touches no workflow, composite or config.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

This PR *is* the test. The failing check is intentional and the run is the evidence.

## Related Issues

Follows #704 and #706, which validated the positive path only.