### PR TITLE
feat(build): pass computed VERSION and BUILD_TIME as build args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ on:
         type: boolean
         default: false
       docker_build_args:
-        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi\nCOMPONENT_NAME=api"). For sensitive values (tokens, keys, passwords), use BuildKit secrets instead — build arguments are visible in image history.'
+        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi\nCOMPONENT_NAME=api"). For sensitive values (tokens, keys, passwords), use BuildKit secrets instead — build arguments are visible in image history. Two more arguments are always appended after these: VERSION (the published image version) and BUILD_TIME (RFC3339 UTC); a Dockerfile declaring ARG VERSION / ARG BUILD_TIME gets them stamped in, one that declares neither is unaffected.'
         type: string
         required: false
         default: ''
@@ -379,7 +379,7 @@ jobs:
           echo "images=$IMAGES" >> "$GITHUB_OUTPUT"
           echo "ghcr_org=$GHCR_ORG" >> "$GITHUB_OUTPUT"
 
-      - name: Extract version from tag
+      - name: Resolve version and build timestamp
         id: version
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
@@ -398,6 +398,13 @@ jobs:
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "Extracted version: $VERSION from tag: $TAG"
           fi
+
+          # Build provenance timestamp, fed to the image as the BUILD_TIME build
+          # argument below. Captured here (once per app, alongside the version it
+          # is published with) so every layer of one image sees the same instant.
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "build_time=$BUILD_TIME" >> "$GITHUB_OUTPUT"
+          echo "Build timestamp: $BUILD_TIME"
 
       - name: Pre-flight tag existence check
         id: preflight
@@ -615,7 +622,22 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.docker_build_args }}
+          # Caller-supplied arguments first, then the release provenance pair this
+          # workflow computes. A caller cannot pass VERSION itself: the version is
+          # only known after semantic-release runs inside the release umbrella, well
+          # after the static docker_build_args input is bound.
+          #
+          # Additive for every consumer: a Dockerfile that declares `ARG VERSION` /
+          # `ARG BUILD_TIME` gets a stamped binary (e.g. via -ldflags -X or OCI
+          # labels); one that declares neither is unaffected, because an undeclared
+          # build argument only warns and does not invalidate build cache.
+          #
+          # The computed pair goes LAST so an empty docker_build_args leaves a blank
+          # leading line (ignored by build-push-action) rather than a dangling one.
+          build-args: |
+            ${{ inputs.docker_build_args }}
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_TIME=${{ steps.version.outputs.build_time }}
           sbom: generator=docker/scout-sbom-indexer:latest
           provenance: mode=max
           cache-from: type=gha

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -92,7 +92,7 @@ on:
         type: string
         default: ''
       docker_build_args:
-        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi"). Use BuildKit secrets for sensitive values.'
+        description: 'Newline-separated Docker build arguments (e.g., "APP_NAME=spi"). Use BuildKit secrets for sensitive values. build.yml always appends VERSION (the computed release version) and BUILD_TIME (RFC3339 UTC) after these, for the primary build and every extra_builds group — the release version cannot be supplied here because semantic-release computes it inside this workflow.'
         type: string
         default: ''
       enable_cosign_sign:

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -201,6 +201,42 @@ Only the exact version is published. Floating aliases (`1`, `1.12`) are not:
 re-pointing an existing alias is refused by Docker Hub immutable-tag rules and
 fails the whole build. Consumers must pin the exact version.
 
+## Build Arguments
+
+Every image build receives the `docker_build_args` input first, then two build
+arguments this workflow computes:
+
+| Build argument | Value | Example |
+|----------------|-------|---------|
+| `VERSION` | The resolved release version — the `release_version` input verbatim, or the version parsed out of the git tag | `1.4.0` / `v1.4.0` |
+| `BUILD_TIME` | Build timestamp, RFC3339 UTC, captured once per app | `2026-08-28T14:03:11Z` |
+
+The leading `v` is **not** normalized: the tag-push path yields `v1.4.0` while the
+same-run branch-push path yields whatever semantic-release computed (usually
+`1.4.0`). Strip it before comparing against the published image tag, which is
+always the bare semver.
+
+This is additive. A Dockerfile that declares the arguments can stamp them into
+the artifact:
+
+```dockerfile
+ARG VERSION=dev
+ARG BUILD_TIME=unknown
+RUN go build -ldflags "-X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}" ./cmd/app
+```
+
+A Dockerfile that declares neither is unaffected — Docker only warns about an
+unused build argument, and an undeclared argument does not invalidate build
+cache. `BUILD_TIME` changes on every run, so in repos that *do* declare it the
+layers from its `ARG` onward rebuild each time; put the `ARG` as late as
+possible to keep dependency layers cached.
+
+`VERSION` cannot be passed through `docker_build_args` by a caller of
+`go-release.yml`: semantic-release computes the release version inside that
+workflow, after the static input is already bound. The primary build and every
+`extra_builds` group get both arguments, because both route through this
+workflow.
+
 ## Monorepo Change Detection
 
 When `filter_paths` is provided, the workflow:

--- a/docs/go-release-workflow.md
+++ b/docs/go-release-workflow.md
@@ -42,7 +42,7 @@ A third layout needs `release_single_app: true`: **one semantic-release tag for 
 | `enable_gitops_artifacts` | Upload GitOps artifacts for the downstream update | boolean | `false` |
 | `app_name` | Override app/image name (build single-app mode + gitops deploy name). Empty → gitops name derives from `app_name_prefix`, then repo name | string | `''` |
 | `tag_prefix` | Restrict the primary release/build jobs to tags starting with this prefix. Use when the repo also pushes tags for an unrelated component with its own `extra_builds` `tag_prefix`, so the primary jobs ignore that component's tags. Empty = react to every tag (current behavior) | string | `''` |
-| `docker_build_args` | Newline-separated Docker build args | string | `''` |
+| `docker_build_args` | Newline-separated Docker build args. `VERSION` (computed release version) and `BUILD_TIME` (RFC3339 UTC) are always appended after these, for the primary build and every `extra_builds` group — see [Build Arguments](build-workflow.md#build-arguments) | string | `''` |
 | `enable_cosign_sign` | Sign images with cosign keyless (OIDC) | boolean | `true` |
 | `cosign_max_attempts` | Maximum cosign signing attempts per image reference. Increase to absorb transient OIDC/Fulcio/Rekor rate limits. Forwarded to `build.yml` | string | `'5'` |
 | `cosign_initial_delay` | Initial delay (seconds) between cosign retries. Grows exponentially (×3), capped at `cosign_max_delay`, then jittered. Forwarded to `build.yml` | string | `'5'` |


### PR DESCRIPTION
<table border="0" cellspacing="0" cellpadding="0">
  <tr>
    <td><img src="https://github.com/LerianStudio.png" width="72" alt="Lerian" /></td>
    <td><h1>GitHub Actions Shared Workflows</h1></td>
  </tr>
</table>

---

## Description

`build.yml` now appends two build arguments after the caller-supplied `docker_build_args`, at its single `docker/build-push-action` site:

```
VERSION=<resolved release version>
BUILD_TIME=<RFC3339 UTC>
```

**Why a caller cannot do this today.** The release version is computed by semantic-release *inside* `go-release.yml`. `docker_build_args` is a static `workflow_call` input, bound before that job runs, so no caller repo can pass the tag it is about to be released as. Every image built by the Go release path was therefore built blind to its own version.

**Coverage.** `go-release.yml` builds no images itself — the primary build (`build` job) and every `extra_builds` matrix group both `uses: ./.github/workflows/build.yml`. Patching the one build-args site inside `build.yml` covers both, with no new inputs to thread through. `build.yml` has exactly one `build-push-action` step; `typescript-build.yml` is a separate file and is untouched.

**What changes for consumer repos.** Nothing, unless the repo opts in from its own Dockerfile:

- A Dockerfile that declares `ARG VERSION` / `ARG BUILD_TIME` gets a stamped artifact.
- A Dockerfile that declares neither is unaffected — Docker emits an unused-build-argument warning and nothing else. An undeclared build argument does not invalidate build cache.

No inputs, outputs, defaults, secrets, or step ordering changed. Two input descriptions gained a sentence, and the step formerly named `Extract version from tag` is now `Resolve version and build timestamp` (it emits a second output).

**Cache implications.** `BUILD_TIME` changes on every run, so in repos that *do* declare it, the layers from that `ARG` onward rebuild each time. Repos should place the `ARG` as late as possible so dependency layers stay cached — the reference Dockerfile in the docs does this. Repos that declare neither argument see no cache change at all.

**Leading `v`.** `VERSION` is passed verbatim from the existing `steps.version.outputs.version`, which is not normalized: the tag-push path yields `v1.4.0`, the same-run branch-push path yields whatever semantic-release computed (usually `1.4.0`). Normalizing it here would ripple through four other consumers of that output, so it is documented instead — consumers strip the `v` before comparing against the published image tag.

**Downstream consumer.** `LerianStudio/plugin-br-bank-transfer` already declares both arguments and wires them into `-ldflags -X .../internal/bootstrap.Version` and `.BuildTime`. Its released binaries currently report `dev` / `unknown` at runtime, and its `release-stamp-check` workflow — which verifies the shipped binary's link flags against the release tag — goes red on every release. This PR is what turns that check green.

### Files changed

| File | Change |
|---|---|
| `.github/workflows/build.yml` | `version` step also emits `build_time`; `build-args` becomes a block scalar with the caller input first and the computed pair last; `docker_build_args` description extended |
| `.github/workflows/go-release.yml` | `docker_build_args` description extended (documents the appended pair for the primary build and every `extra_builds` group) |
| `docs/build-workflow.md` | New **Build Arguments** section: the two arguments, an opt-in Dockerfile example, the cache note, the leading-`v` note |
| `docs/go-release-workflow.md` | `docker_build_args` row points at the new section |

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [x] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. Purely additive — no input, output, default, secret, or step ordering changed, and repos that do not declare the ARGs in their Dockerfile see identical builds.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed:

- `actionlint` clean on both changed workflows; all 45 `.github/workflows/*.yml` files parse.
- Parsed the composed `build-args` value back out of the YAML to confirm it is exactly `${{ inputs.docker_build_args }}\nVERSION=...\nBUILD_TIME=...\n`. With an empty `docker_build_args` this is a blank leading line, which `build-push-action` ignores — the computed pair is last so the list is always well-formed.
- Confirmed `build.yml` has one `build-push-action` step and that both `go-release.yml` call sites (primary + `extra_builds` matrix) route through it, so no second patch site exists.
- Nothing is echoed except the version and the timestamp, neither of which is sensitive.

**Caller repo / workflow run:** not yet — needs the beta tag from `develop`. Intended validator: `LerianStudio/plugin-br-bank-transfer` (`release-stamp-check` turning green on its next release).

## Related Issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)
