### PR TITLE
fix(coderabbit): restore base_branches, reviews were off for develop

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -93,14 +93,23 @@ reviews:
     # rule is also inert in the common case, since a PR that never receives
     # `review-ready` is already excluded by the inverted default.
     #
-    # `base_branches` is intentionally absent for the same reason: it governs
-    # which base branches are *auto*-reviewed, and there is no auto-review to
-    # govern. Restore it only alongside `enabled: true`.
+    # `base_branches` is REQUIRED, and is not made redundant by `enabled: false`.
+    # It is a separate filter: a pull request is reviewed only when its base is
+    # eligible AND the trigger label is present. Left absent, the eligible set
+    # falls back to the default branch alone (main), and every pull request into
+    # develop is refused with "reviews are disabled for this base branch" —
+    # exactly what happened on PR #712 after #708 removed this key. It must list
+    # every base the gate is allowed to release on, mirroring
+    # `review_base_branches` in Self — PR Validation.
     #
     # To review an out-of-scope PR anyway, add `review-ready` by hand or comment
     # `@coderabbitai review`.
     enabled: false
     drafts: false
+    # Must cover every base the gate may release on. `main` is always eligible as
+    # the default branch; develop has to be named explicitly.
+    base_branches:
+      - "develop"
     labels:
       - "review-ready"
     ignore_title_keywords:

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -260,7 +260,14 @@ The gate is on by default in `go-pr-validation.yml` and `js-pr-validation.yml`, 
 
    Both keys are needed. `base_branches` decides which bases are *eligible*;
    `labels` is the trigger. Omitting the first refuses every pull request into
-   `develop` with "reviews are disabled for this base branch", label or not.
+   `develop`, label or not, with CodeRabbit reporting: *"Auto reviews are
+   disabled on base/target branches other than the default branch."*
+
+   **Config changes take effect on merge, not in the pull request that
+   introduces them.** CodeRabbit reads `.coderabbit.yml` from the base branch, so
+   a pull request carrying a config fix is still judged by the old config — a fix
+   for a broken `base_branches` cannot validate itself. Confirm it on the next
+   pull request instead.
 
 3. Nothing else — the umbrella already calls the gate.
 

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -23,6 +23,8 @@ repository's `.coderabbit.yml`:
 reviews:
   auto_review:
     enabled: false
+    base_branches:      # every base the gate may release on
+      - "develop"
     labels:
       - "review-ready"
 ```
@@ -38,9 +40,13 @@ Two consequences worth internalising:
   trigger under `enabled: false`, and it is inert in the common case anyway — a
   pull request that never receives the label is already excluded by the inverted
   default. Scope belongs here, where it is deterministic.
-- **`base_branches` has nothing to govern.** It filters which base branches are
-  *auto*-reviewed, and there is no auto-review left. Restore it only alongside
-  `enabled: true`.
+- **`base_branches` is required, and is a separate filter.** It is not made
+  redundant by `enabled: false`: a pull request is reviewed only when its base is
+  eligible **and** the trigger label is present. Absent, the eligible set falls
+  back to the default branch alone — every pull request into `develop` is then
+  refused with *"reviews are disabled for this base branch"*, regardless of the
+  label. List every base the gate may release on, mirroring
+  `review_base_branches`.
 
 ## Modes
 
@@ -246,9 +252,15 @@ The gate is on by default in `go-pr-validation.yml` and `js-pr-validation.yml`, 
    reviews:
      auto_review:
        enabled: false
+       base_branches:
+         - "develop"        # every base the gate may release on
        labels:
          - "review-ready"
    ```
+
+   Both keys are needed. `base_branches` decides which bases are *eligible*;
+   `labels` is the trigger. Omitting the first refuses every pull request into
+   `develop` with "reviews are disabled for this base branch", label or not.
 
 3. Nothing else — the umbrella already calls the gate.
 


### PR DESCRIPTION
## Description

Restores `reviews.auto_review.base_branches`, removed by #708 on a wrong premise. Without it CodeRabbit refuses every pull request into `develop`.

Observed on #712, opened after #708 merged:

> CodeRabbit — Review skipped: **reviews are disabled for this base branch**

The pull request had `review-ready` applied by the gate and all checks green. The label was never the problem.

### What I got wrong

#708 removed the key with this reasoning: *"it governs which base branches are auto-reviewed, and there is no auto-review to govern"*. That is false. `base_branches` and `labels` are **two independent filters**, and both must pass:

| | Question it answers | Absent means |
|---|---|---|
| `base_branches` | is this base eligible at all? | only the default branch (`main`) is eligible |
| `labels` | did CI authorise this pull request? | nothing is ever authorised |

With the key gone, the eligible set collapsed to `main` alone — so every pull request into `develop`, which is all development work in this repository, was refused before the label was even considered. `enabled: false` inverts the *default*; it does not make the base filter redundant.

This also explains #705 consistently: that release PR targeted `main`, always eligible as the default branch, which is why it was reviewed while the develop-targeted ones now are not.

### Changes

- `.coderabbit.yml` — `base_branches: ["develop"]` restored, with a comment stating it is a separate filter and what its absence causes
- `docs/coderabbit-gate.md` — the "How it works" bullet and the adoption snippet claimed the key was redundant; both corrected, including the example config which omitted it

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. `.coderabbit.yml` is local to this repository. The corrected guidance in `docs/coderabbit-gate.md` matters for any repository adopting the gate — the snippet it copied from was missing the key.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

This pull request is its own test: it targets `develop`, the base that was refused. `.coderabbit.yml` is read from the head branch, so if the fix is right CodeRabbit should review it once the gate applies the label — and #712 should start being reviewed once this merges.

## Related Issues

Fixes the regression introduced by #708. Surfaced by #712.
