### PR TITLE
test(coderabbit): verify base_branches fix on a fresh pull request

### DIFF
--- a/CODERABBIT-BASE-BRANCHES-TEST.md
+++ b/CODERABBIT-BASE-BRANCHES-TEST.md
@@ -1,0 +1,40 @@
+# CodeRabbit gate — throwaway test file
+
+**Do not merge.** Close this pull request and delete the branch once the
+behaviour has been observed.
+
+## What is being tested
+
+PR #713 restored `reviews.auto_review.base_branches` in `.coderabbit.yml`, which
+#708 had removed on the wrong premise that it was made redundant by
+`enabled: false`. It is not: `base_branches` and `labels` are two independent
+filters and both must pass.
+
+With the key absent, the eligible set fell back to the default branch alone, and
+every pull request into `develop` was refused with:
+
+> Auto reviews are disabled on base/target branches other than the default branch.
+
+This pull request exists because the fix **cannot validate itself**. CodeRabbit
+reads `.coderabbit.yml` from the base branch, not from the head, so #713 was
+still judged by the broken config it was fixing. Only a pull request opened
+*after* the merge is judged by the corrected one.
+
+It also cannot be validated on #712: that pull request already carries
+`review-ready`, applied at 00:17 while the config still refused its base. Adding
+a label that is already present is a no-op, so no event exists for CodeRabbit to
+react to.
+
+## Expected outcome
+
+| Step | Expectation |
+|------|-------------|
+| Every required check | passes |
+| `Release CodeRabbit Review` | applies `review-ready` |
+| CodeRabbit | reviews this pull request |
+
+The review is the whole point: it is what proves the base is eligible again.
+
+If CodeRabbit still reports *"Auto reviews are disabled on base/target branches
+other than the default branch"*, the fix is wrong and the finding is worth more
+than this pull request.


### PR DESCRIPTION
## Description

**Throwaway PR — do not merge.** Opened only to confirm that #713 restored CodeRabbit reviews on `develop`, then closed.

#708 removed `reviews.auto_review.base_branches` on the premise that it was redundant under `enabled: false`. It is not — `base_branches` and `labels` are independent filters and both must pass. Without it, only the default branch stayed eligible and every pull request into `develop` was refused:

> Auto reviews are disabled on base/target branches other than the default branch.

#713 restored the key. This PR is needed because that fix **cannot validate itself**: CodeRabbit reads `.coderabbit.yml` from the base branch, not the head, so #713 was judged by the very config it was repairing. Only a pull request opened after the merge sees the corrected one.

It also cannot be validated on #712 — that PR already carries `review-ready`, applied at 00:17 while its base was still being refused. Re-adding a label that is already present is a no-op, so there is no event for CodeRabbit to react to.

## Expected outcome

| Step | Expectation |
|------|-------------|
| Required checks | pass |
| `Release CodeRabbit Review` | applies `review-ready` |
| CodeRabbit | reviews this PR |

A review appearing is the proof. If the "reviews are disabled on base/target branches" message shows up again, the fix is wrong.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [x] `test`: Adding or updating tests

## Breaking Changes

None. Adds one throwaway markdown file and touches no workflow, composite or config.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

This PR is the test. Its own outcome is the evidence.

## Related Issues

Validates #713. Regression introduced by #708, surfaced by #712.