### PR TITLE
feat(coderabbit): request reviews by command instead of by label

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -79,39 +79,24 @@ reviews:
         Flag any usage example that references `@main` — examples must use `@develop` or `@feat/<branch>` for testing and `@vX.Y.Z` for production.
 
   auto_review:
-    # `enabled: false` inverts the default to "do not review": nothing is reviewed
-    # unless `review-ready` is on the PR. That label is applied by the
-    # `gate-coderabbit` job in `Self — PR Validation`, once every required check
-    # has passed and the PR is within the configured review scope — so no review
-    # is ever spent on a PR that is failing or out of scope.
+    # Nothing is reviewed automatically. `Self — PR Validation` posts
+    # `@coderabbitai review` once every required check has passed and the pull
+    # request is in scope, and that command is the only trigger.
     #
-    # The gate is the single owner of that decision. Do not add exclusion rules
-    # here expecting them to restrict anything: a negative label match does not
-    # veto the positive trigger under `enabled: false`. PR #705 demonstrated it —
-    # a release PR carried `skip-coderabbit` for over two minutes before
-    # `review-ready` arrived, and was reviewed five minutes after that. Any such
-    # rule is also inert in the common case, since a PR that never receives
-    # `review-ready` is already excluded by the inverted default.
+    # Do NOT add `labels:` here. The `review-ready` label still exists, but as a
+    # visual marker applied alongside the command — putting it back in this list
+    # would make it a second, competing trigger for the same decision, which is
+    # what produced the bugs in #705 and #708.
     #
-    # `base_branches` is REQUIRED, and is not made redundant by `enabled: false`.
-    # It is a separate filter: a pull request is reviewed only when its base is
-    # eligible AND the trigger label is present. Left absent, the eligible set
-    # falls back to the default branch alone (main), and every pull request into
-    # develop is refused with "reviews are disabled for this base branch" —
-    # exactly what happened on PR #712 after #708 removed this key. It must list
-    # every base the gate is allowed to release on, mirroring
-    # `review_base_branches` in Self — PR Validation.
-    #
-    # To review an out-of-scope PR anyway, add `review-ready` by hand or comment
-    # `@coderabbitai review`.
+    # To review a pull request the gate skipped, comment `@coderabbitai review`.
     enabled: false
     drafts: false
-    # Must cover every base the gate may release on. `main` is always eligible as
-    # the default branch; develop has to be named explicitly.
+    # Kept even though nothing is auto-reviewed: `base_branches` is a separate
+    # filter from the trigger, and leaving it out made every pull request into
+    # develop ineligible (#712/#713). Harmless here, and correct if `enabled`
+    # is ever turned back on.
     base_branches:
       - "develop"
-    labels:
-      - "review-ready"
     ignore_title_keywords:
       - "WIP"
       - "wip"

--- a/.github/workflows/coderabbit-gate.yml
+++ b/.github/workflows/coderabbit-gate.yml
@@ -1,22 +1,19 @@
 name: CodeRabbit Gate
 
-# Gates CodeRabbit reviews on CI, and declares which pull requests are in scope.
+# Asks CodeRabbit for a review once CI has passed, and only for pull requests in
+# scope. Nothing is reviewed automatically, so no review is spent on a revision
+# that is failing or on a pull request nobody wants reviewed.
 #
-# The consuming repository must set `reviews.auto_review.enabled: false` and
-# `reviews.auto_review.labels: ["review-ready"]` in its `.coderabbit.yml`. That
-# inverts CodeRabbit's default to "do not review": every PR is out until the
-# `review-ready` label arrives, and this workflow is what applies it. No review
-# is spent on a pull request that is failing, or that nobody asked to review.
+# The consuming repository sets `reviews.auto_review.enabled: false` in its
+# `.coderabbit.yml`. That turns automatic reviews off entirely; this workflow then
+# posts `@coderabbitai review`, the command CodeRabbit documents as working
+# regardless of auto-review settings — it says so itself when it skips a pull
+# request: "To trigger a single review, invoke the `@coderabbitai review` command."
 #
-# Two modes, called at different points of the caller's job graph:
-#
-#   withdraw  runs early, with no `needs`, on `synchronize`. Removes the label so
-#             the new revision has to earn it again. Without this, the label from
-#             the previous revision stays on the PR while the new checks run and
-#             CodeRabbit — whose incremental reviews remain enabled — reviews a
-#             revision that may well be failing.
-#   release   runs last, needing every required check. Applies the label when the
-#             PR is in scope and nothing failed.
+# The command is the trigger. The `review-ready` label is applied alongside it as
+# a visual marker only, best-effort: a repository that has not declared the label
+# still works, it just does not get the badge. Do NOT put that label back into
+# `reviews.auto_review.labels` — it would become a second, competing trigger.
 #
 # Scope is two independent dimensions, OR'd together:
 #
@@ -29,30 +26,25 @@ name: CodeRabbit Gate
 #
 # NOTE for callers: the caller's own `pull_request` trigger bounds this. A base
 # branch listed here but absent from `on.pull_request.branches` never sees the
-# workflow run at all, so the label never arrives. The effective scope is the
+# workflow run at all, so the command is never posted. The effective scope is the
 # intersection of the two.
 
 on:
   workflow_call:
     inputs:
-      mode:
-        description: '`release` to apply the label after checks pass, `withdraw` to remove it when a new revision arrives'
-        required: true
-        type: string
       pr_number:
         description: Pull request to act on
         required: true
         type: number
       checks_passed:
-        description: Whether every required check succeeded. Only read in `release` mode — pass the caller's `!contains(needs.*.result, ...)` verdict.
+        description: Whether every required check succeeded — pass the caller's `!contains(needs.*.result, ...)` verdict.
         required: false
         type: boolean
         default: false
       head_sha:
-        description: Commit the caller's verdict refers to. When it no longer matches the pull request head, the release is skipped — a stale run cannot authorise a commit it never validated. Empty disables the check.
-        required: false
+        description: Commit the caller's verdict refers to. Also the idempotency key — one review request per commit. When it no longer matches the pull request head, the request is skipped, so a stale run cannot ask for a review of a commit it never validated.
+        required: true
         type: string
-        default: ''
       review_base_branches:
         description: Comma-separated exact base branch names whose pull requests are reviewed. Empty removes this dimension.
         required: false
@@ -64,12 +56,12 @@ on:
         type: string
         default: hotfix/*
       label:
-        description: Label used as the review trigger. Must match `reviews.auto_review.labels` in .coderabbit.yml.
+        description: Visual marker applied when the review is requested. Cosmetic — failure to apply it never fails the job. Empty disables it.
         required: false
         type: string
         default: review-ready
       dry_run:
-        description: Log the decision without changing any label
+        description: Log the decision without commenting or labelling
         required: false
         type: boolean
         default: false
@@ -85,130 +77,60 @@ on:
 
 # No `workflow_dispatch`: the repository convention is that reusable workflows do
 # not offer one — manual triggering belongs in a `self-*` entrypoint, where the
-# inputs can be constrained. Dispatch does support `type: choice` and `boolean`,
-# but every value still arrives as a string at runtime, and free-text inputs
-# reaching `run:` blocks are a script injection surface. There is no `self-*`
-# entrypoint for this gate because the manual equivalent is simpler: add or remove
-# the trigger label on the pull request by hand.
+# inputs can be constrained. There is none for this gate because the manual
+# equivalent is simpler: comment `@coderabbitai review` on the pull request.
 
 permissions:
   contents: read
 
 jobs:
   gate:
-    name: Reconcile Review Authorisation
+    name: Request CodeRabbit Review
     runs-on: ${{ vars.GENERAL_RUNNERS || inputs.runner_type }}
     permissions:
       pull-requests: write
     steps:
-      - name: Reconcile review authorisation
+      - name: Request review when the pull request is green and in scope
         env:
           GH_TOKEN: ${{ secrets.MANAGE_TOKEN || github.token }}
           REPO: ${{ github.repository }}
-          MODE: ${{ inputs.mode }}
           PR_NUMBER: ${{ inputs.pr_number }}
           CHECKS_PASSED: ${{ inputs.checks_passed }}
           HEAD_SHA: ${{ inputs.head_sha }}
           REVIEW_BASE_BRANCHES: ${{ inputs.review_base_branches }}
           REVIEW_HEAD_PATTERNS: ${{ inputs.review_head_patterns }}
-          LABEL: ${{ inputs.label || 'review-ready' }}
+          LABEL: ${{ inputs.label }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          case "$MODE" in
-            release|withdraw) ;;
-            *) echo "::error::Unknown mode '${MODE}' — expected 'release' or 'withdraw'"; exit 1 ;;
-          esac
-
           # Read the live pull request rather than trusting event payload values,
-          # which are frozen at dispatch. A run started before the PR was
-          # retargeted would otherwise decide against a branch that no longer
+          # which are frozen at dispatch. A run started before the pull request
+          # was retargeted would otherwise decide against a branch that no longer
           # applies.
-          read -r base head live_sha labels < <(
+          read -r base head live_sha < <(
             gh pr view "$PR_NUMBER" --repo "$REPO" \
-              --json baseRefName,headRefName,headRefOid,labels \
-              --jq '"\(.baseRefName) \(.headRefName) \(.headRefOid) \([.labels[].name] | join(","))"'
+              --json baseRefName,headRefName,headRefOid \
+              --jq '"\(.baseRefName) \(.headRefName) \(.headRefOid)"'
           )
-          labels=",${labels},"
-
-          case "$labels" in
-            *",${LABEL},"*) has_label=true ;;
-            *) has_label=false ;;
-          esac
 
           # Verbose only under dry_run, per the repository's dry_run contract. A
           # real run emits a single `::notice::` with the decision — this job's
-          # only observable product is *why* a pull request was or was not
-          # released, so that one line has to survive.
+          # only observable product is *why* a review was or was not requested.
           if [ "$DRY_RUN" = "true" ]; then
-            echo "::notice::DRY RUN — no label will be changed"
+            echo "::notice::DRY RUN — no comment and no label will be posted"
             echo "  pull request      : #${PR_NUMBER}"
             echo "  head → base       : ${head} → ${base}"
-            echo "  mode              : ${MODE}"
-            echo "  label             : ${LABEL} (present=${has_label})"
             echo "  checks passed     : ${CHECKS_PASSED}"
-            echo "  verdict commit    : ${HEAD_SHA:-<unchecked>}"
+            echo "  verdict commit    : ${HEAD_SHA}"
             echo "  live head         : ${live_sha}"
             echo "  scope bases       : [${REVIEW_BASE_BRANCHES}]"
             echo "  scope head globs  : [${REVIEW_HEAD_PATTERNS}]"
           fi
 
-          # A repository that has not adopted the gate simply has no such label.
-          # Treat that — and only that — as "not adopted": `gh pr edit --add-label`
-          # fails outright on a label the repository does not define, which would
-          # turn every pull request red everywhere the labels sync has not run yet.
-          #
-          # Any other failure must not be mistaken for it. `gh api` exits non-zero
-          # on 4xx and 5xx alike, so a rate limit, a permissions problem or a
-          # transient 5xx would otherwise disable the gate while reporting a
-          # missing label — a wrong diagnosis on top of a silent outage.
-          if lookup_error=$(gh api "repos/${REPO}/labels/${LABEL}" 2>&1 >/dev/null); then
-            label_defined=true
-          else
-            case "$lookup_error" in
-              *"Not Found"*|*"404"*)
-                label_defined=false
-                ;;
-              *)
-                echo "::error::Could not determine whether label '${LABEL}' exists in ${REPO}: ${lookup_error}"
-                exit 1
-                ;;
-            esac
-          fi
-
-          if [ "$label_defined" = false ]; then
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "  decision          : label not defined in the repository — gate inert"
-            fi
-            echo "::warning::Label '${LABEL}' does not exist in ${REPO} — the CodeRabbit gate is inert here. Declare it in .github/labels.yml and run the labels sync, and set reviews.auto_review.enabled=false with labels=[\"${LABEL}\"] in .coderabbit.yml. See docs/coderabbit-gate.md."
-            exit 0
-          fi
-
-          # ---------- withdraw ----------
-          # Unconditional: a revision must re-earn the authorisation whatever the
-          # scope says. Removing is always the safe direction.
-          if [ "$MODE" = "withdraw" ]; then
-            if [ "$has_label" = false ]; then
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "  decision          : nothing to withdraw"
-              fi
-              exit 0
-            fi
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "  decision          : would remove '${LABEL}'"
-              exit 0
-            fi
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL"
-            echo "::notice::Withdrew '${LABEL}' from PR #${PR_NUMBER} — this revision must pass the checks to earn it back"
-            exit 0
-          fi
-
-          # ---------- release ----------
           # `checks_passed` describes one specific commit. Without concurrency
           # control an older run can finish after a newer push, and would then
-          # authorise a head whose checks it never saw. Comparing the caller's
-          # commit against the live head closes that.
-          if [ -n "$HEAD_SHA" ] && [ "$HEAD_SHA" != "$live_sha" ]; then
-            echo "::notice::Stale run — the verdict covers ${HEAD_SHA:0:7} but PR #${PR_NUMBER} now heads at ${live_sha:0:7}; withholding '${LABEL}'"
+          # ask for a review of a head whose checks it never saw.
+          if [ "$HEAD_SHA" != "$live_sha" ]; then
+            echo "::notice::Stale run — the verdict covers ${HEAD_SHA:0:7} but PR #${PR_NUMBER} now heads at ${live_sha:0:7}; not requesting a review"
             exit 0
           fi
 
@@ -233,45 +155,42 @@ jobs:
           fi
 
           if [ -z "$matched" ]; then
-            # Withdraw an authorisation the pull request should no longer hold.
-            # This is the reconciling half of scope enforcement: a pull request
-            # that earned the label in scope and was then retargeted out of it
-            # would otherwise stay authorised, and the notice below would be a
-            # lie. Only fires when the state actually diverged, so it costs
-            # nothing on the common path.
-            if [ "$has_label" = true ]; then
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "  decision          : out of scope, would remove '${LABEL}'"
-                exit 0
-              fi
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL"
-              echo "::notice::PR #${PR_NUMBER} (${head} → ${base}) is out of the review scope — removed '${LABEL}'"
-              exit 0
-            fi
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "  decision          : out of scope, nothing to do"
-              exit 0
-            fi
-            echo "::notice::PR #${PR_NUMBER} (${head} → ${base}) is out of the review scope — withholding '${LABEL}', CodeRabbit will not review it"
+            echo "::notice::PR #${PR_NUMBER} (${head} → ${base}) is out of the review scope — not requesting a review"
             exit 0
           fi
 
           if [ "$CHECKS_PASSED" != "true" ]; then
-            echo "::notice::PR #${PR_NUMBER} is in scope via ${matched}, but a required check did not pass — withholding '${LABEL}'"
+            echo "::notice::PR #${PR_NUMBER} is in scope via ${matched}, but a required check did not pass — not requesting a review"
             exit 0
           fi
 
-          if [ "$has_label" = true ]; then
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "  decision          : in scope via ${matched}, '${LABEL}' already present"
-            fi
+          # Idempotency. Unlike a label, a comment is not a no-op when repeated:
+          # every `@coderabbitai review` spends another review. Re-runs and
+          # concurrent runs on the same commit are both reachable, so the marker
+          # below — carrying the commit — is what makes "one review per revision"
+          # true rather than merely intended.
+          marker="<!-- coderabbit-gate: ${live_sha} -->"
+
+          if gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+               --jq '.[].body' | grep -qF "$marker"; then
+            echo "::notice::A review was already requested for ${live_sha:0:7} on PR #${PR_NUMBER} — not asking again"
             exit 0
           fi
 
           if [ "$DRY_RUN" = "true" ]; then
-            echo "  decision          : would add '${LABEL}' (in scope via ${matched}, checks passed)"
+            echo "  decision          : would request a review (in scope via ${matched}, checks passed)"
             exit 0
           fi
 
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
-          echo "::notice::Released CodeRabbit on PR #${PR_NUMBER} — in scope via ${matched} and every required check passed"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
+          echo "::notice::Requested a CodeRabbit review on PR #${PR_NUMBER} — in scope via ${matched} and every required check passed"
+
+          # Cosmetic only, and deliberately last: a repository that never declared
+          # the label still gets its review. Never let this fail the job.
+          if [ -n "$LABEL" ]; then
+            if gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL" 2>/dev/null; then
+              echo "🏷️ Marked with '${LABEL}'"
+            else
+              echo "::notice::Label '${LABEL}' not applied — it is not declared in ${REPO}. Cosmetic only; the review was requested regardless."
+            fi
+          fi

--- a/.github/workflows/go-pr-validation.yml
+++ b/.github/workflows/go-pr-validation.yml
@@ -275,7 +275,7 @@ on:
 
       # ----------------- CodeRabbit Review Gate -----------------
       enable_coderabbit_gate:
-        description: 'Hold CodeRabbit until this validation passes, so no review is spent on a failing or out-of-scope pull request. On by default, and inert until the repository opts in: it needs the `review-ready` label declared in .github/labels.yml and synced, plus `reviews.auto_review.enabled: false` with `labels: ["review-ready"]` in .coderabbit.yml. Without that the job warns and does nothing, leaving CodeRabbit at its own default — it does not fail. See docs/coderabbit-gate.md.'
+        description: 'Ask CodeRabbit for a review once this validation passes, so no review is spent on a failing or out-of-scope pull request. On by default. The consuming repository only needs `reviews.auto_review.enabled: false` in its .coderabbit.yml — the gate posts `@coderabbitai review` itself. The `review-ready` label is applied as a visual marker when declared, and skipped silently when not. See docs/coderabbit-gate.md.'
         type: boolean
         default: true
       coderabbit_review_base_branches:
@@ -524,7 +524,6 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/coderabbit-gate.yml
     with:
-      mode: release
       pr_number: ${{ github.event.pull_request.number }}
       # Skipped is fine; only a real failure or cancellation withholds the label.
       checks_passed: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/js-pr-validation.yml
+++ b/.github/workflows/js-pr-validation.yml
@@ -439,7 +439,7 @@ on:
 
       # ----------------- CodeRabbit Review Gate -----------------
       enable_coderabbit_gate:
-        description: 'Hold CodeRabbit until this validation passes, so no review is spent on a failing or out-of-scope pull request. On by default, and inert until the repository opts in: it needs the `review-ready` label declared in .github/labels.yml and synced, plus `reviews.auto_review.enabled: false` with `labels: ["review-ready"]` in .coderabbit.yml. Without that the job warns and does nothing, leaving CodeRabbit at its own default — it does not fail. See docs/coderabbit-gate.md.'
+        description: 'Ask CodeRabbit for a review once this validation passes, so no review is spent on a failing or out-of-scope pull request. On by default. The consuming repository only needs `reviews.auto_review.enabled: false` in its .coderabbit.yml — the gate posts `@coderabbitai review` itself. The `review-ready` label is applied as a visual marker when declared, and skipped silently when not. See docs/coderabbit-gate.md.'
         type: boolean
         default: true
       coderabbit_review_base_branches:
@@ -846,7 +846,6 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/coderabbit-gate.yml
     with:
-      mode: release
       pr_number: ${{ github.event.pull_request.number }}
       # Skipped is fine; only a real failure or cancellation withholds the label.
       checks_passed: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/self-pr-validation.yml
+++ b/.github/workflows/self-pr-validation.yml
@@ -393,7 +393,6 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/coderabbit-gate.yml
     with:
-      mode: release
       pr_number: ${{ github.event.pull_request.number }}
       # A required check failing or being cancelled withholds the label; skipped
       # is fine, since most lints are conditional on the file types touched.

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -16,78 +16,61 @@ This workflow makes the review something a revision has to earn.
 
 ## How it works
 
-CodeRabbit's own configuration provides the mechanism. In the consuming
-repository's `.coderabbit.yml`:
+The consuming repository turns automatic reviews off entirely:
 
 ```yaml
+# .coderabbit.yml
 reviews:
   auto_review:
     enabled: false
-    base_branches:      # every base the gate may release on
-      - "develop"
-    labels:
-      - "review-ready"
 ```
 
-`enabled: false` inverts the default to *do not review*. Every pull request is out
-of scope until the `review-ready` label appears, and a positive label match is
-what triggers the review. This workflow is what applies that label.
+Nothing is reviewed on its own. This workflow then posts `@coderabbitai review`
+once CI has passed — the command CodeRabbit documents as working regardless of
+auto-review settings, and which it recommends itself when it skips a pull
+request: *"To trigger a single review, invoke the `@coderabbitai review`
+command."*
 
-Two consequences worth internalising:
+The command is the trigger. That is the whole mechanism.
 
-- **Do not add exclusion rules to `.coderabbit.yml` expecting them to restrict
-  anything.** A negative match such as `!skip-review` does not veto the positive
-  trigger under `enabled: false`, and it is inert in the common case anyway — a
-  pull request that never receives the label is already excluded by the inverted
-  default. Scope belongs here, where it is deterministic.
-- **`base_branches` is required, and is a separate filter.** It is not made
-  redundant by `enabled: false`: a pull request is reviewed only when its base is
-  eligible **and** the trigger label is present. Absent, the eligible set falls
-  back to the default branch alone — every pull request into `develop` is then
-  refused with *"reviews are disabled for this base branch"*, regardless of the
-  label. List every base the gate may release on, mirroring
-  `review_base_branches`.
+### Why a command and not a label
 
-## Modes
+An earlier version used `auto_review.labels: ["review-ready"]` and had the gate
+apply that label. It worked, but the review then depended on four things
+agreeing — `enabled`, `base_branches`, `labels`, and the label existing in the
+repository — and each one broke in turn:
 
-Called at two points of the caller's job graph.
+| Failure | Cause |
+|---|---|
+| every PR red on a new repo | `gh pr edit --add-label` fails on a label the repo does not define |
+| release PRs reviewed anyway | a negative label match does not veto the positive trigger |
+| all of `develop` refused | `base_branches` removed on the wrong assumption that it was redundant |
+| a config fix could not validate itself | `.coderabbit.yml` is read from the base branch, not the head |
 
-| Mode | Position | Behaviour |
-|------|----------|-----------|
-| `withdraw` | early, no `needs`, on `synchronize` | Removes the label so the new revision must earn it again |
-| `release` | last, needing every required check | Applies the label when the PR is in scope and nothing failed |
+The command has none of those dependencies. It does not consult labels, and a
+repository adopting the gate needs one line of config.
 
-Calling `release` alone gates the **first** review: the label is granted once the
-pull request goes green and never taken back. Adding `withdraw` makes every
-revision re-earn it, which also gives each green push its own incremental review,
-since the remove → add transition is what triggers one.
+**`review-ready` still exists**, applied next to the command as a visual marker,
+best-effort: a repository that never declared it still gets its reviews. Do not
+put it back into `auto_review.labels` — it would become a second trigger for the
+same decision, which is exactly what produced the failures above.
 
-Removal is unconditional and needs no scope check: giving up an authorisation is
-always the safe direction.
+### One review per revision
 
-### `withdraw` buys a probability, not a guarantee
+Repeating a label is a no-op; repeating a command spends another review. Re-runs
+and concurrent runs on the same commit are both reachable, so the gate writes a
+marker carrying the commit:
 
-CodeRabbit decides whether to review **at the moment of the event** and publishes
-minutes later. A withdrawal that lands after that decision cannot cancel it.
+```
+@coderabbitai review
 
-Measured on this repository:
+<!-- coderabbit-gate: <head_sha> -->
+```
 
-| Pull request | Push | Withdrawal | Review | Outcome |
-|---|---|---|---|---|
-| #708 | — | 3 windows of 1–7 min without the label | none in any window | withdrawal won |
-| #705 | 14:09:38 | 14:09:59 (**21s late**) | 14:15:23 | withdrawal lost |
-
-So `withdraw` helps when CI reaction time exceeds CodeRabbit's (~1–2 min), which
-is the common case, and fails when it does not. The cost is a label add/remove
-pair on the timeline for every push.
-
-Whether that trade is worth it depends on the repository. This one decided it is
-not, and calls the gate in `release` mode only — see the rationale in
-`.github/workflows/self-pr-validation.yml`. A repository with slow CI and
-expensive reviews may reasonably decide the opposite.
-
-Note that `release` never re-adds a label that is already present, so running it
-on every push costs one short job and mutates nothing.
+and looks for it before commenting. That is what makes "one review per revision"
+true rather than merely intended. It matters more than it sounds: CodeRabbit
+plans are rate-limited, and a burst of duplicate requests degrades the allowance
+for the whole organisation.
 
 ## Scope
 
@@ -121,12 +104,12 @@ than which of them get reviewed.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | string | — | `release` or `withdraw`. Required. |
 | `pr_number` | number | — | Pull request to act on. Required. |
-| `checks_passed` | boolean | `false` | Whether every required check succeeded. Only read in `release` mode. |
+| `checks_passed` | boolean | `false` | Whether every required check succeeded. |
+| `head_sha` | string | — | Commit the verdict covers. Required — also the idempotency key. |
 | `review_base_branches` | string | `develop` | Comma-separated exact base branch names. Empty removes this dimension. |
 | `review_head_patterns` | string | `hotfix/*` | Comma-separated globs matched against the head branch. Empty removes this dimension. |
-| `label` | string | `review-ready` | Trigger label. Must match `reviews.auto_review.labels`. |
+| `label` | string | `review-ready` | Visual marker applied alongside the command. Cosmetic — failing to apply it never fails the job. Empty disables it. |
 | `dry_run` | boolean | `false` | Log the decision without changing any label. |
 | `runner_type` | string | `blacksmith-4vcpu-ubuntu-2404` | Runner label. Overridden by `vars.GENERAL_RUNNERS`. |
 
@@ -185,7 +168,6 @@ jobs:
       pull-requests: write
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/coderabbit-gate.yml@vX.Y.Z
     with:
-      mode: release
       pr_number: ${{ github.event.pull_request.number }}
       checks_passed: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       review_base_branches: develop
@@ -198,31 +180,6 @@ at all and the verdict never gets evaluated.
 
 Pin to a released version in production. When testing a change to the gate itself,
 point at the branch instead — `@develop`, or `@feat/<branch>`.
-
-### Optional: gate every revision
-
-Add a `withdraw` call ahead of the checks so each revision has to re-earn the
-label. Read [the trade-off](#withdraw-buys-a-probability-not-a-guarantee) first —
-it is a probability, paid for with timeline churn.
-
-```yaml
-  withdraw-coderabbit:
-    name: Hold CodeRabbit Review
-    # No needs: must land before the checks finish, not after them.
-    if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
-    permissions:
-      contents: read
-      pull-requests: write
-    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/coderabbit-gate.yml@vX.Y.Z
-    with:
-      mode: withdraw
-      pr_number: ${{ github.event.pull_request.number }}
-    secrets: inherit
-```
-
-Then list it first in the release job's `needs`, so the withdrawal can never land
-after the re-application. It is skipped on events other than `synchronize`, which
-`always()` tolerates.
 
 ## Escape hatches
 
@@ -238,7 +195,7 @@ Both are intentional. The gate is a spending policy, not an access control.
 The gate is on by default in `go-pr-validation.yml` and `js-pr-validation.yml`, and
 **inert until the repository opts in**. Three steps:
 
-1. Declare the label in `.github/labels.yml` and run the labels sync:
+1. *(Optional)* Declare the label in `.github/labels.yml` and run the labels sync, if you want the visual marker:
 
    ```yaml
    - name: review-ready
@@ -246,40 +203,21 @@ The gate is on by default in `go-pr-validation.yml` and `js-pr-validation.yml`, 
      description: Required checks passed — CodeRabbit is cleared to review
    ```
 
-2. Invert CodeRabbit's default in `.coderabbit.yml`:
+2. Turn automatic reviews off in `.coderabbit.yml`:
 
    ```yaml
    reviews:
      auto_review:
        enabled: false
-       base_branches:
-         - "develop"        # every base the gate may release on
-       labels:
-         - "review-ready"
    ```
 
-   Both keys are needed. `base_branches` decides which bases are *eligible*;
-   `labels` is the trigger. Omitting the first refuses every pull request into
-   `develop`, label or not, with CodeRabbit reporting: *"Auto reviews are
-   disabled on base/target branches other than the default branch."*
-
-   **Config changes take effect on merge, not in the pull request that
-   introduces them.** CodeRabbit reads `.coderabbit.yml` from the base branch, so
-   a pull request carrying a config fix is still judged by the old config — a fix
-   for a broken `base_branches` cannot validate itself. Confirm it on the next
-   pull request instead.
+   Do not add `labels:` — the command is the trigger, and a label there would
+   compete with it.
 
 3. Nothing else — the umbrella already calls the gate.
 
-Until step 1 is done the job emits a warning and exits successfully, leaving
-CodeRabbit at its own behaviour. It does **not** fail the pull request: the GitHub
-API rejects adding a label the repository does not define, and failing on that
-would turn every pull request red in every repository that has not adopted yet.
-
-Only a confirmed `404` is read as "not adopted". A permissions error, a rate limit
-or a transient `5xx` fails the job instead — those are outages, and silently
-treating them as an un-adopted repository would disable the gate while reporting
-the wrong cause.
+Step 1 is genuinely optional now: without the label the reviews still happen,
+the pull requests just carry no badge. Only step 2 is required.
 
 Step 2 matters as much as step 1. With the label present but `enabled` still
 `true`, CodeRabbit reviews everything as before and the label decides nothing —
@@ -307,11 +245,14 @@ reviews:
 Keep `review_status: true` — that is what posts *"Review skipped — required
 labels: review-ready"*, the cheapest confirmation that the gate is working.
 
-**A review already decided cannot be cancelled.** See the `withdraw` section
-above: the decision is taken at the event, so nothing done afterwards stops the
-publication.
-
 **An engaged pull request stays engaged.** Once CodeRabbit has reviewed a pull
-request, moving it out of scope does not disengage it — the label governs the
-initial trigger, not an established engagement. Stopping that needs
-`@coderabbitai ignore` in the description, or `@coderabbitai pause` as a comment.
+request, incremental reviews continue on later pushes on their own — the gate
+controls when a review is *requested*, not an engagement already established.
+Stopping that needs `@coderabbitai ignore` in the description, or
+`@coderabbitai pause` as a comment.
+
+**Reviews are rate-limited by plan.** Requesting one is not free even when the
+gate is behaving: an organisation that burns through its allowance is throttled
+(observed: 61 review attempts in 7 days dropping the allowance to one review per
+hour, plus the spending cap being reached). This is the reason the gate exists,
+and the reason the idempotency marker matters.

--- a/docs/go-pr-validation.md
+++ b/docs/go-pr-validation.md
@@ -77,7 +77,7 @@ The `go-analysis`, `security` and `lib-version` pipelines each have a `*-gate` a
 | `frontend_folder` | Sub-folder treated as an independent scan component in type2 repos (e.g. `"tools/mock-sta-server"`). Ignored when `monorepo_type` is `"type1"`. | string | `'frontend'` |
 | `trivy_skip_dirs` | Comma-separated directories to skip in every Trivy filesystem scan (appended to the built-in skip list). Useful for excluding sub-modules from the root scan (e.g. `"tools/mock-sta-server"`). | string | `''` |
 | `shared_paths` | Path patterns that trigger analysis/security for all components | string | `''` |
-| `enable_coderabbit_gate` | Hold CodeRabbit until this validation passes. Inert until the repo declares the `review-ready` label and sets `auto_review.enabled: false` — see [coderabbit-gate](coderabbit-gate.md) | boolean | `true` |
+| `enable_coderabbit_gate` | Ask CodeRabbit for a review once this validation passes. Needs only `auto_review.enabled: false` in the repo — see [coderabbit-gate](coderabbit-gate.md) | boolean | `true` |
 | `coderabbit_review_base_branches` | Comma-separated exact base branch names whose PRs get a review. Empty removes this dimension | string | `develop` |
 | `coderabbit_review_head_patterns` | Comma-separated globs matched against the head branch; a match is reviewed regardless of base | string | `hotfix/*` |
 | `coderabbit_gate_label` | Trigger label. Must match `reviews.auto_review.labels` in `.coderabbit.yml` | string | `review-ready` |

--- a/docs/js-pr-validation.md
+++ b/docs/js-pr-validation.md
@@ -101,7 +101,7 @@ The `frontend-analysis`, `security` and `socket` pipelines each have a `*-gate` 
 | `socket_app_fail_on_findings` | Fail the Socket job when the App reports adverse checks | boolean | `true` |
 | `socket_app_on_inconclusive` | `block` or `warn` when the App reached no verdict | string | `block` |
 | `socket_app_on_missing` | `warn` or `block` when the App published no checks | string | `warn` |
-| `enable_coderabbit_gate` | Hold CodeRabbit until this validation passes. Inert until the repo declares the `review-ready` label and sets `auto_review.enabled: false` — see [coderabbit-gate](coderabbit-gate.md) | boolean | `true` |
+| `enable_coderabbit_gate` | Ask CodeRabbit for a review once this validation passes. Needs only `auto_review.enabled: false` in the repo — see [coderabbit-gate](coderabbit-gate.md) | boolean | `true` |
 | `coderabbit_review_base_branches` | Comma-separated exact base branch names whose PRs get a review. Empty removes this dimension | string | `develop` |
 | `coderabbit_review_head_patterns` | Comma-separated globs matched against the head branch; a match is reviewed regardless of base | string | `hotfix/*` |
 | `coderabbit_gate_label` | Trigger label. Must match `reviews.auto_review.labels` in `.coderabbit.yml` | string | `review-ready` |


### PR DESCRIPTION
## Description

Switches the gate from applying a label to posting `@coderabbitai review`. The command becomes the only trigger; the `review-ready` label stays as a visual marker.

### Why

The label approach worked, but it made the review depend on four things agreeing — `enabled`, `base_branches`, `labels`, and the label existing in the repository. Each one broke in turn over the last day:

| Failure | Cause |
|---|---|
| every PR red on a repo without the label | `gh pr edit --add-label` fails on a label the repo does not define (#704) |
| release PRs reviewed anyway | a negative label match does not veto the positive trigger (#705) |
| all of `develop` refused | `base_branches` removed on the wrong assumption that it was redundant (#708 → #712/#713) |
| a config fix could not validate itself | `.coderabbit.yml` is read from the base branch, not the head (#713) |

The command has none of those dependencies. It consults no labels, no base branch list, and CodeRabbit documents it as working regardless of auto-review settings — it recommends it itself when skipping a pull request: *"To trigger a single review, invoke the `@coderabbitai review` command."*

A consuming repository now needs exactly one line: `reviews.auto_review.enabled: false`.

### One review per revision

This is the one thing the command does worse than a label, and it needed solving: re-adding a label is a no-op, but repeating a command spends another review. Re-runs and concurrent runs on the same commit are both reachable here — #708 had two simultaneous runs on one SHA.

The gate writes a marker carrying the commit and checks for it before commenting:

```
@coderabbitai review

<!-- coderabbit-gate: <head_sha> -->
```

That matters more than it sounds. CodeRabbit plans are rate-limited, and this repository hit the ceiling today: **61 review attempts over 7 days dropped the allowance to one review per hour**, and the organisation's spending cap was reached. Most of that was spent on the pull requests building this feature — each push triggering an incremental review. A duplicate-request bug would degrade the allowance for every repository in the org.

### Changes

- `coderabbit-gate.yml` — posts the command; `mode` input dropped (there is nothing to withdraw when the trigger is a command), `head_sha` now required as the idempotency key, `label` documented as cosmetic and applied best-effort
- `.coderabbit.yml` — `auto_review.labels` removed so the label cannot act as a competing trigger; `base_branches` kept, since it remains a real filter and its absence caused #712
- `self-pr-validation.yml`, `go-pr-validation.yml`, `js-pr-validation.yml` — `mode` removed from the calls
- docs updated, including the rate-limit note and the adoption checklist, where declaring the label is now genuinely optional

Net: **131 insertions, 289 deletions**.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [x] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

`coderabbit-gate.yml` drops the `mode` input and makes `head_sha` required. Any caller passing `mode:` must remove it, and one not passing `head_sha` must add it.

In practice no consumer is affected: the workflow does not exist in any released tag yet — `v1` still points at a commit that predates it — so no repository can be calling it. The three in-repo callers are updated in this PR. Flagged as breaking because the input contract did change, and the umbrella inputs are public surface.

Repositories that already set `auto_review.labels: ["review-ready"]` should remove that key when adopting, otherwise the label competes with the command.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed:

- `actionlint` (which runs shellcheck over `run:` blocks) clean on all four workflows.
- The decision logic was extracted verbatim and exercised against seven cases: in-scope green first time, in-scope green already requested, in-scope red, release PR out of scope, `hotfix/*` into `main`, stale run whose verdict covers an older commit, and empty scope. All matched expectations.
- `auto_review.labels` confirmed absent after the edit, `base_branches` confirmed still present.

**This PR cannot fully validate itself.** `.coderabbit.yml` is read from the base branch, so `develop` still carries the label-based config while this runs — the same constraint documented in #713. The gate job here will post the command, but the review that follows is governed by the old config. Full confirmation comes from the first pull request opened after this merges.

## Related Issues

Follows #704, #706, #708 and #713. Supersedes the label-as-trigger design those PRs built.
