### PR TITLE
test(coderabbit): verify the command is what triggers the review

### DIFF
--- a/CODERABBIT-COMMAND-TEST.md
+++ b/CODERABBIT-COMMAND-TEST.md
@@ -1,0 +1,43 @@
+# CodeRabbit gate — throwaway test file
+
+**Do not merge.** Close this pull request and delete the branch once the
+behaviour has been observed.
+
+## What is being tested
+
+Whether `@coderabbitai review`, posted by CI, is what triggers the review — with
+no label able to take the credit.
+
+#715 changed the gate from applying a `review-ready` label to posting the
+command, and removed `labels` from `.coderabbit.yml` so the label can no longer
+act as a trigger. Every earlier attempt to verify this was ambiguous:
+
+| Pull request | Why it could not settle the question |
+|---|---|
+| #715 | both triggers were live at once, 2 seconds apart, because the config in force still came from `develop` |
+| #714 | its branch predates the change and carries the old label-based gate |
+| #712 | already carried the label from before the fix, so no event existed to react to |
+
+This branch is the first cut from a `develop` that has the command gate **and**
+no label trigger, so nothing else can explain a review appearing.
+
+## Expected outcome
+
+| Step | Expectation |
+|------|-------------|
+| Every required check | passes |
+| `Request CodeRabbit Review` | posts `@coderabbitai review` with a commit marker |
+| `review-ready` | applied as a cosmetic marker, after the comment |
+| CodeRabbit | reviews this pull request |
+
+**A review appearing proves the command works**, since no label trigger exists
+any more. It also settles the second question: the label is applied two seconds
+after the comment and is not consulted by anything, so it is decoration.
+
+If no review appears, the note CodeRabbit posted on #715 was literal —
+*"This command is applicable only when automatic reviews are paused"* — the
+premise behind #715 is wrong, and the rollback is one line: restore
+`labels: ["review-ready"]` in `.coderabbit.yml`.
+
+Note that reviews are currently rate-limited to one per hour for this
+organisation, so absence of a review is only meaningful after that window.


### PR DESCRIPTION
## Description

**Throwaway PR — do not merge.** Opened to settle two questions, then closed.

1. Is `@coderabbitai review`, posted by CI, what actually triggers the review?
2. Is `review-ready` now purely cosmetic?

#715 switched the gate from applying a label to posting the command, and removed `labels` from `.coderabbit.yml` so the label can no longer trigger anything. Every earlier attempt to verify this was ambiguous:

| PR | Why it could not settle it |
|---|---|
| #715 | both triggers live at once, 2s apart — the config in force still came from `develop` |
| #714 | branch predates the change, carries the old label gate |
| #712 | already had the label from before the fix, so no event existed to react to |

This is the first branch cut from a `develop` that has the command gate **and** no label trigger. Nothing else can explain a review appearing.

## Expected outcome

| Step | Expectation |
|------|-------------|
| Required checks | pass |
| `Request CodeRabbit Review` | posts `@coderabbitai review` with a commit marker |
| `review-ready` | applied after the comment, cosmetic |
| CodeRabbit | reviews this PR |

**A review appearing proves the command works**, with no label trigger left to take the credit — and settles question 2 at the same time, since the label lands two seconds later and nothing consults it.

If no review appears, the note CodeRabbit posted on #715 was literal — *"This command is applicable only when automatic reviews are paused"* — the premise behind #715 is wrong, and the rollback is one line: restore `labels: ["review-ready"]`.

⚠️ Reviews are currently rate-limited to **one per hour** for this organisation (61 attempts over 7 days, spending cap reached), so absence of a review is only meaningful after that window.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [x] `test`: Adding or updating tests

## Breaking Changes

None. Adds one throwaway markdown file; touches no workflow, composite or config.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

This PR is the test; its own outcome is the evidence.

## Related Issues

Verifies #715. Follows #713 and the closed test PR #714.