### PR TITLE
test(coderabbit): measure whether incremental review runs unprompted

### DIFF
--- a/.github/workflows/coderabbit-gate.yml
+++ b/.github/workflows/coderabbit-gate.yml
@@ -182,6 +182,28 @@ jobs:
             exit 0
           fi
 
+          # Collapse the previous requests before adding a new one. A pull request
+          # revised many times would otherwise accumulate one visible bot comment
+          # per revision, burying the human conversation. Minimising as `RESOLVED`
+          # keeps the history — the comments are still there, just folded away.
+          #
+          # Done before posting, so the fresh request needs no exclusion, and kept
+          # non-fatal: failing to tidy up must never cost a review.
+          while IFS= read -r node_id; do
+            [ -z "$node_id" ] && continue
+            if gh api graphql \
+                 -f query='mutation($id:ID!){minimizeComment(input:{subjectId:$id,classifier:RESOLVED}){minimizedComment{isMinimized}}}' \
+                 -F id="$node_id" >/dev/null 2>&1; then
+              collapsed=$((${collapsed:-0} + 1))
+            fi
+          done < <(
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq '.[] | select(.body | contains("coderabbit-gate:")) | select(.body | contains("@coderabbitai review")) | .node_id' 2>/dev/null || true
+          )
+          if [ "${collapsed:-0}" -gt 0 ]; then
+            echo "🧹 Collapsed ${collapsed} earlier review request(s)"
+          fi
+
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
           echo "::notice::Requested a CodeRabbit review on PR #${PR_NUMBER} — in scope via ${matched} and every required check passed"
 

--- a/CODERABBIT-INCREMENTAL-TEST.md
+++ b/CODERABBIT-INCREMENTAL-TEST.md
@@ -32,3 +32,14 @@ label was removed. Nothing has been measured under the command-based config.
 ## Section for the second revision
 
 <!-- second push appends below this line -->
+
+### Second revision
+
+This paragraph is the only change in the second push. It exists to give
+CodeRabbit something to review incrementally, and to be substantial enough that
+a review would have something to say: the sentence you are reading was added
+without any `@coderabbitai review` command accompanying it, because the gate was
+suppressed by pre-posting its own idempotency marker.
+
+If a review lands on this revision, incremental review runs unprompted and the
+gate only needs to ask once per pull request.

--- a/CODERABBIT-INCREMENTAL-TEST.md
+++ b/CODERABBIT-INCREMENTAL-TEST.md
@@ -43,3 +43,9 @@ suppressed by pre-posting its own idempotency marker.
 
 If a review lands on this revision, incremental review runs unprompted and the
 gate only needs to ask once per pull request.
+
+### Third revision — clean attempt
+
+The second attempt was contaminated: the suppression comment mentioned the
+command inside its own explanatory text, and CodeRabbit read that as a request.
+This revision repeats the experiment with a marker carrying no prose at all.

--- a/CODERABBIT-INCREMENTAL-TEST.md
+++ b/CODERABBIT-INCREMENTAL-TEST.md
@@ -1,0 +1,34 @@
+# CodeRabbit gate — throwaway measurement
+
+**Do not merge.** Close and delete the branch once measured.
+
+## Question
+
+Under the current config (`auto_review.enabled: false`, no `labels`), does
+CodeRabbit keep reviewing later pushes **on its own** — incremental review — or
+does every revision need its own `@coderabbitai review` from the gate?
+
+This decides whether the gate should comment once per pull request or once per
+push, which in turn decides how noisy the pull request gets.
+
+## Method
+
+1. First push: the gate comments, CodeRabbit reviews. Confirms engagement.
+2. Second push: the gate is **suppressed** by pre-posting only its idempotency
+   marker — the HTML comment without the command — so it finds the marker and
+   stays quiet.
+3. Watch for a review with no command in between.
+
+A review appearing at step 3 means incremental works and the command is only
+needed once. No review means every revision needs its own command.
+
+## Prior evidence, and why it is not enough
+
+On #705, two reviews landed at 14:15:23 and 14:22:11 after the trigger label had
+been removed at 14:09:59 — suggesting incremental runs unprompted. But that was
+under the label-based regime, and the decision may have been taken before the
+label was removed. Nothing has been measured under the command-based config.
+
+## Section for the second revision
+
+<!-- second push appends below this line -->

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -72,6 +72,28 @@ true rather than merely intended. It matters more than it sounds: CodeRabbit
 plans are rate-limited, and a burst of duplicate requests degrades the allowance
 for the whole organisation.
 
+
+### Keeping the pull request readable
+
+A pull request revised many times would otherwise collect one visible bot comment
+per revision, burying the human conversation under review requests. Before posting
+a new one, the gate collapses the previous ones with the GraphQL `minimizeComment`
+mutation and classifier `RESOLVED` — they render as *"This comment was marked as
+resolved"* and fold away.
+
+The history is kept, not deleted: the comments are still there, one click from
+being expanded, so the record of which revision was requested and when survives.
+
+Two deliberate choices:
+
+- **Collapsed before posting**, so the fresh request needs no special-casing.
+- **Non-fatal.** A failure to tidy up is swallowed — losing a review because the
+  cleanup failed would be a bad trade.
+
+Only the gate's own requests are collapsed: the filter requires both the
+`coderabbit-gate:` marker and the command text, so it never touches a review
+request a human typed.
+
 ## Scope
 
 Two independent dimensions, OR'd together.


### PR DESCRIPTION
## Description

**Throwaway PR — do not merge.** Measurement only.

**Question:** under the current config (`auto_review.enabled: false`, no `labels`), does CodeRabbit keep reviewing later pushes on its own, or does every revision need its own `@coderabbitai review` from the gate?

This decides whether the gate should comment **once per PR** or **once per push** — and therefore how many bot comments a PR accumulates.

## Method

1. **First push** — gate comments, CodeRabbit reviews. Confirms engagement.
2. **Second push** — the gate is suppressed by pre-posting only its idempotency marker (the HTML comment, without the command), so it finds the marker and stays quiet.
3. **Observe** whether a review lands with no command in between.

| Outcome | Conclusion | Consequence |
|---|---|---|
| review appears | incremental works unprompted | comment **once per PR** — drop the SHA from the marker |
| no review | every revision needs its own command | keep the SHA, and consider collapsing old comments |

## Prior evidence, and why it is insufficient

On #705 two reviews landed at 14:15:23 and 14:22:11 *after* the trigger label was removed at 14:09:59 — suggesting incremental runs unprompted. But that was the label-based regime, and the decision may well have been taken before the removal. Nothing has been measured under the command-based config.

⚠️ Reviews are rate-limited to **one per hour** for this organisation, so step 3 may take a while to be conclusive.

## Type of Change

- [x] `test`: Adding or updating tests

## Breaking Changes

None. One throwaway markdown file.

## Testing

This PR is the measurement; its own outcome is the evidence.