### PR TITLE
feat(coderabbit): collapse superseded review requests and their echoes

### DIFF
--- a/.github/workflows/coderabbit-gate.yml
+++ b/.github/workflows/coderabbit-gate.yml
@@ -184,60 +184,75 @@ jobs:
 
           # ----------------- Collapse the superseded noise -----------------
           # Each revision adds a request from this workflow, and CodeRabbit echoes
-          # every one of them with an "Action performed / Review finished" reply.
-          # A pull request revised a few times therefore buries its human
-          # conversation under pairs of bot comments — PR #717 reached four of each.
+          # every one of them with an "Action performed / Review finished" reply, so
+          # a pull request revised a few times buries its human conversation under
+          # pairs of bot comments.
           #
           # Both sides are folded away with GraphQL `minimizeComment` before the new
           # request goes out, so the fresh one needs no exclusion. Minimising keeps
           # the history: the comments remain, one click from being expanded.
           #
+          # Listing goes through GraphQL rather than REST because only GraphQL
+          # exposes `isMinimized`. The REST body is unchanged by minimisation — it
+          # carries no marker — so a REST-based filter cannot tell an already-folded
+          # comment from a fresh one, and every run would re-minimise everything.
+          #
+          # Findings are structurally out of reach: this reads `pullRequest.comments`,
+          # which is issue comments only. Reviews and review comments — where
+          # findings live — are separate connections. Do not "improve" this by
+          # reaching into `reviews`: on PR #717 the review carrying CodeRabbit's
+          # permissions warning also carries 13 actionable findings, and the two are
+          # the same object.
+          #
           # Kept non-fatal throughout — losing a review because the tidying failed
           # would be a bad trade.
           collapse() {
             local node_id="$1" classifier="$2"
-            # shellcheck disable=SC2016  # $id is a GraphQL variable, not a shell one
+            # shellcheck disable=SC2016  # $id and $c are GraphQL variables, not shell ones
             gh api graphql \
               -f query='mutation($id:ID!,$c:ReportedContentClassifiers!){minimizeComment(input:{subjectId:$id,classifier:$c}){minimizedComment{isMinimized}}}' \
               -F id="$node_id" -F c="$classifier" >/dev/null 2>&1
           }
 
+          owner=${REPO%%/*}
+          name=${REPO##*/}
           collapsed=0
 
-          # Our own earlier requests.
-          while IFS= read -r node_id; do
+          # One listing, both categories, already-minimised excluded. Each line is
+          # "<node_id> <classifier>".
+          while read -r node_id classifier; do
             [ -z "$node_id" ] && continue
-            if collapse "$node_id" RESOLVED; then
+            if collapse "$node_id" "$classifier"; then
               collapsed=$((collapsed + 1))
             fi
           done < <(
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-              --jq '.[] | select(.body | contains("coderabbit-gate:")) | select(.body | contains("@coderabbitai review")) | select(.body | contains("<!-- minimized")  | not) | .node_id' 2>/dev/null || true
+            # shellcheck disable=SC2016  # GraphQL variables
+            gh api graphql --paginate \
+              -f query='
+                query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
+                  repository(owner:$owner,name:$name){
+                    pullRequest(number:$pr){
+                      comments(first:100,after:$endCursor){
+                        pageInfo{hasNextPage endCursor}
+                        nodes{id isMinimized body}
+                      }
+                    }
+                  }
+                }' \
+              -F owner="$owner" -F name="$name" -F pr="$PR_NUMBER" \
+              --jq '
+                .data.repository.pullRequest.comments.nodes[]
+                | select(.isMinimized == false)
+                | if (.body | contains("coderabbit-gate:")) and (.body | contains("@coderabbitai review"))
+                  then "\(.id) RESOLVED"
+                  elif (.body | contains("CodeRabbit review command invocation:"))
+                  then "\(.id) OUTDATED"
+                  else empty
+                  end' 2>/dev/null || true
           )
 
-          # CodeRabbit's acknowledgement of each of them. Identified by the
-          # invocation marker, which the review and the summary do not carry — so
-          # this never folds away anything of substance.
-          #
-          # Findings are structurally out of reach: both queries hit
-          # `/issues/{n}/comments`, which returns only issue comments. Reviews and
-          # review comments — where findings live — are not in that endpoint, so a
-          # finding cannot be collapsed even by mistake. Do not "improve" this by
-          # reaching into `/pulls/{n}/reviews`: the review that carries the
-          # permissions warning on PR #717 also carries 13 actionable findings, and
-          # the two are not separable.
-          while IFS= read -r node_id; do
-            [ -z "$node_id" ] && continue
-            if collapse "$node_id" OUTDATED; then
-              collapsed=$((collapsed + 1))
-            fi
-          done < <(
-            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-              --jq '.[] | select(.body | contains("CodeRabbit review command invocation:")) | .node_id' 2>/dev/null || true
-          )
-
-          if [ "$collapsed" -gt 0 ]; then
-            echo "🧹 Collapsed ${collapsed} superseded bot comment(s)"
+          if [ "$DRY_RUN" = "true" ] && [ "$collapsed" -gt 0 ]; then
+            echo "  collapsed         : ${collapsed} superseded bot comment(s)"
           fi
 
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"

--- a/.github/workflows/coderabbit-gate.yml
+++ b/.github/workflows/coderabbit-gate.yml
@@ -182,6 +182,64 @@ jobs:
             exit 0
           fi
 
+          # ----------------- Collapse the superseded noise -----------------
+          # Each revision adds a request from this workflow, and CodeRabbit echoes
+          # every one of them with an "Action performed / Review finished" reply.
+          # A pull request revised a few times therefore buries its human
+          # conversation under pairs of bot comments — PR #717 reached four of each.
+          #
+          # Both sides are folded away with GraphQL `minimizeComment` before the new
+          # request goes out, so the fresh one needs no exclusion. Minimising keeps
+          # the history: the comments remain, one click from being expanded.
+          #
+          # Kept non-fatal throughout — losing a review because the tidying failed
+          # would be a bad trade.
+          collapse() {
+            local node_id="$1" classifier="$2"
+            # shellcheck disable=SC2016  # $id is a GraphQL variable, not a shell one
+            gh api graphql \
+              -f query='mutation($id:ID!,$c:ReportedContentClassifiers!){minimizeComment(input:{subjectId:$id,classifier:$c}){minimizedComment{isMinimized}}}' \
+              -F id="$node_id" -F c="$classifier" >/dev/null 2>&1
+          }
+
+          collapsed=0
+
+          # Our own earlier requests.
+          while IFS= read -r node_id; do
+            [ -z "$node_id" ] && continue
+            if collapse "$node_id" RESOLVED; then
+              collapsed=$((collapsed + 1))
+            fi
+          done < <(
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq '.[] | select(.body | contains("coderabbit-gate:")) | select(.body | contains("@coderabbitai review")) | select(.body | contains("<!-- minimized")  | not) | .node_id' 2>/dev/null || true
+          )
+
+          # CodeRabbit's acknowledgement of each of them. Identified by the
+          # invocation marker, which the review and the summary do not carry — so
+          # this never folds away anything of substance.
+          #
+          # Findings are structurally out of reach: both queries hit
+          # `/issues/{n}/comments`, which returns only issue comments. Reviews and
+          # review comments — where findings live — are not in that endpoint, so a
+          # finding cannot be collapsed even by mistake. Do not "improve" this by
+          # reaching into `/pulls/{n}/reviews`: the review that carries the
+          # permissions warning on PR #717 also carries 13 actionable findings, and
+          # the two are not separable.
+          while IFS= read -r node_id; do
+            [ -z "$node_id" ] && continue
+            if collapse "$node_id" OUTDATED; then
+              collapsed=$((collapsed + 1))
+            fi
+          done < <(
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq '.[] | select(.body | contains("CodeRabbit review command invocation:")) | .node_id' 2>/dev/null || true
+          )
+
+          if [ "$collapsed" -gt 0 ]; then
+            echo "🧹 Collapsed ${collapsed} superseded bot comment(s)"
+          fi
+
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(printf '@coderabbitai review\n\n%s' "$marker")"
           echo "::notice::Requested a CodeRabbit review on PR #${PR_NUMBER} — in scope via ${matched} and every required check passed"
 

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -72,6 +72,35 @@ true rather than merely intended. It matters more than it sounds: CodeRabbit
 plans are rate-limited, and a burst of duplicate requests degrades the allowance
 for the whole organisation.
 
+
+### Keeping the pull request readable
+
+Each revision adds a request from the gate, and CodeRabbit echoes every one with
+an "Action performed / Review finished" reply. A pull request revised a few times
+buries its human conversation under pairs of bot comments — PR #717 reached five
+requests and six echoes.
+
+Before posting a new request, the gate folds the superseded ones away with the
+GraphQL `minimizeComment` mutation: its own requests as `RESOLVED`, CodeRabbit's
+echoes as `OUTDATED`. They render as *"This comment was marked as resolved"* and
+collapse. Nothing is deleted — one click expands them, so the record of which
+revision was requested and when survives.
+
+**Findings are never touched, by construction.** Both queries read
+`/issues/{n}/comments`, which returns issue comments only. Reviews and review
+comments — where findings live — are not in that endpoint. This matters more than
+it sounds: on PR #717 the review carrying CodeRabbit's *"insufficient GitHub
+permissions"* warning also carries 13 actionable findings, so collapsing by review
+would have hidden real work. If that warning is the annoyance, the fix is granting
+the app `Pull requests: Read and write`, which removes it at the source.
+
+Also left alone: the walkthrough summary, and the sticky CI reports
+(`lint-analysis`, `pr-validation-report`, `codeql-scan`) — those are updated in
+place rather than duplicated, so they never accumulate.
+
+Tidying is non-fatal throughout: losing a review because the cleanup failed would
+be a bad trade.
+
 ## Scope
 
 Two independent dimensions, OR'd together.

--- a/docs/coderabbit-gate.md
+++ b/docs/coderabbit-gate.md
@@ -77,18 +77,19 @@ for the whole organisation.
 
 Each revision adds a request from the gate, and CodeRabbit echoes every one with
 an "Action performed / Review finished" reply. A pull request revised a few times
-buries its human conversation under pairs of bot comments — PR #717 reached five
-requests and six echoes.
+buries its human conversation under pairs of bot comments.
 
 Before posting a new request, the gate folds the superseded ones away with the
 GraphQL `minimizeComment` mutation: its own requests as `RESOLVED`, CodeRabbit's
-echoes as `OUTDATED`. They render as *"This comment was marked as resolved"* and
+echoes as `OUTDATED`. Comments already folded are skipped, which needs GraphQL —
+the REST body is unchanged by minimisation and carries no marker, so a REST filter
+cannot tell a folded comment from a fresh one. They render as *"This comment was marked as resolved"* and
 collapse. Nothing is deleted — one click expands them, so the record of which
 revision was requested and when survives.
 
-**Findings are never touched, by construction.** Both queries read
-`/issues/{n}/comments`, which returns issue comments only. Reviews and review
-comments — where findings live — are not in that endpoint. This matters more than
+**Findings are never touched, by construction.** The listing reads
+`pullRequest.comments`, which is issue comments only. Reviews and review
+comments — where findings live — are separate connections. This matters more than
 it sounds: on PR #717 the review carrying CodeRabbit's *"insufficient GitHub
 permissions"* warning also carries 13 actionable findings, so collapsing by review
 would have hidden real work. If that warning is the annoyance, the fix is granting


### PR DESCRIPTION
## Description

Folds away the bot comments the gate itself produces, so a pull request revised several times keeps a readable conversation.

Each revision adds an `@coderabbitai review` from the gate, and CodeRabbit echoes every one with an "Action performed / Review finished" reply. PR #717 reached **five requests and six echoes** — eleven bot comments, none of them useful after the next revision superseded them.

Before posting a new request, the gate now collapses the superseded ones with the GraphQL `minimizeComment` mutation:

| What | Classifier | Identified by |
|---|---|---|
| the gate's own earlier requests | `RESOLVED` | `coderabbit-gate:` marker **and** the command text |
| CodeRabbit's echoes of them | `OUTDATED` | `CodeRabbit review command invocation:` marker |

They render as *"This comment was marked as resolved"* and fold. Nothing is deleted — one click expands them, so the record of which revision was requested and when survives.

Collapsing happens **before** posting, so the fresh request needs no exclusion, and the whole block is non-fatal: losing a review because the tidying failed would be a bad trade.

### Findings are out of reach by construction

This is the part worth checking carefully, and it is structural rather than a matter of careful filtering: both queries read `/issues/{n}/comments`, which returns **issue comments only**. Reviews and review comments — where findings live — are not in that endpoint, so a finding cannot be collapsed even by accident.

That safety property is why the implementation deliberately does *not* reach into `/pulls/{n}/reviews`. On PR #717 the review carrying CodeRabbit's *"insufficient GitHub permissions"* warning also carries **13 actionable findings and 12 inline comments** — the warning and the findings are the same object, so collapsing by review would hide real work. A comment in the workflow records this, to stop a future "improvement" from doing exactly that.

If that permissions warning is the annoyance, the fix is at the source: grant the CodeRabbit app `Pull requests: Read and write`, and it stops being posted.

### What is left alone

- **Reviews and findings** — never touched, per the above
- **The walkthrough summary** — one per pull request, has value
- **Sticky CI reports** (`lint-analysis`, `pr-validation-report`, `codeql-scan`) — updated in place rather than duplicated, so they never accumulate

Measured on PR #717: 11 of the 15 general comments become collapsible, and none of the 20 reviews or 32 inline findings are affected.

## Type of Change

- [x] `feat`: New workflow or new input/output/step in an existing workflow
- [ ] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. No input or output changes; the behaviour added is cleanup that fails silently. Callers need no change.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

Validation performed:

- The `minimizeComment` mutation was exercised against real comments before writing the workflow: on a gate request (`RESOLVED` → `isMinimized=true`) and on a CodeRabbit echo authored by a different account (`OUTDATED` → `isMinimized=true`), confirming `pull-requests: write` is sufficient for both.
- The identifying markers were verified against PR #717: the invocation marker is present on all 6 echoes and absent from the summary, so the filter does not catch anything of substance.
- The collapse loop was simulated under `bash -e` with an empty list and with two ids, confirming it neither aborts nor miscounts. This mattered: an earlier draft used `[ … ] && echo`, which is the pattern that aborts a job under `-e` when the test is false.
- `actionlint` clean. A first attempt failed CI on `SC2016` — shellcheck flagging `$id` inside the single-quoted GraphQL query, which is intentional since it is a GraphQL variable. Fixed with a scoped `# shellcheck disable=SC2016`; the local actionlint had not reported it at that severity.

## Related Issues

Follows #715, which introduced the command-based trigger. Addresses the comment noise that design produces.
