### PR TITLE
fix(preview): point the alpha preview at composites that exist

### DIFF
--- a/.github/workflows/js-alpha-preview.yml
+++ b/.github/workflows/js-alpha-preview.yml
@@ -132,7 +132,9 @@ jobs:
       # may use — must not drift between the two.
       - name: Resolve product from branch
         id: resolve
-        uses: LerianStudio/github-actions-shared-workflows/src/config/product-branch-resolver@v1
+        # TODO: pin to @v1 once released. The composite does not exist in v1 —
+        # it was added on develop, and @v1 tracks the last stable release.
+        uses: LerianStudio/github-actions-shared-workflows/src/config/product-branch-resolver@develop
         with:
           ref-name: ${{ github.ref_name }}
           branch-pattern: ${{ inputs.branch_pattern }}
@@ -188,7 +190,10 @@ jobs:
 
       - name: Build and push preview image
         if: steps.resolve.outputs.has-product == 'true'
-        uses: LerianStudio/github-actions-shared-workflows/src/build/docker-build-ts@v1
+        # TODO: pin to @v1 once released. v1 predates raw-tag and
+        # dockerhub-app-name; an input the action does not declare is ignored
+        # silently, so the image would be built with no tag at all.
+        uses: LerianStudio/github-actions-shared-workflows/src/build/docker-build-ts@develop
         with:
           app-name: ${{ steps.tag.outputs.package }}
           dockerhub-app-name: ${{ steps.tag.outputs.dockerhub-package }}


### PR DESCRIPTION
## Description

The alpha preview fails on its first real run:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action
'LerianStudio/github-actions-shared-workflows/src/config/product-branch-resolver@v1'
```

`js-alpha-preview.yml` referenced two composites at `@v1`, which tracks the last stable release and therefore predates both of them:

| Reference | State at `@v1` | Symptom |
|---|---|---|
| `product-branch-resolver@v1` | **does not exist** | run fails outright — the error above |
| `docker-build-ts@v1` | exists, but has no `raw-tag` / `dockerhub-app-name` | **silent** — an undeclared input is ignored, so the image is built with no tag |

The second matters more than the first. Fixing only the visible failure would have moved the problem downstream and disguised it as a tagging bug, one step removed from its cause.

Both now use `@develop` with a TODO to pin, the same way `go-lambda-release.yml`, the helm alpha workflows and `pr-validation.yml` already carry a composite that has not been released yet.

### Audit

Every `@v1` composite reference under `.github/workflows/` was checked against the `v1` tree. All 52 others resolve; these two were the only breaks, and both were introduced in #717.

Worth noting what that audit does **not** catch: a composite that exists at `@v1` but lacks an input added later. That is exactly the `docker-build-ts` case, and it produces no error at all — the same shape as the `pr-source-branch@v1` gap caught during review of #712.

## Type of Change

- [ ] `feat`: New workflow or new input/output/step in an existing workflow
- [x] `fix`: Bug fix in a workflow (incorrect behavior, broken step, wrong condition)
- [ ] `perf`: Performance improvement (e.g. caching, parallelism, reduced steps)
- [ ] `refactor`: Internal restructuring with no behavior change
- [ ] `docs`: Documentation only (README, docs/, inline comments)
- [ ] `ci`: Changes to self-CI (workflows under `.github/workflows/` that run on this repo)
- [ ] `chore`: Dependency bumps, config updates, maintenance
- [ ] `test`: Adding or updating tests
- [ ] `BREAKING CHANGE`: Callers must update their configuration after this PR

## Breaking Changes

None. The workflow was unusable as shipped; this makes it run.

## Testing

- [x] YAML syntax validated locally
- [ ] Triggered a real workflow run on a caller repository using `@this-branch` or the beta tag
- [x] Verified all existing inputs still work with default values
- [x] Confirmed no secrets or tokens are printed in logs
- [x] Checked that unrelated workflows are not affected

`actionlint` clean. Both replacements verified to exist on `develop`, and `ghcr-alpha-cleanup@v1` confirmed still compatible — its composite was untouched by #717, and all seven inputs the workflow passes are present at `v1`.

**Caller repo / workflow run:** the failing run is on `LerianStudio/product-console`, which consumes `v1.63.0-beta.4`. It needs the beta cut from this branch to retest.

## Related Issues

Fixes a defect introduced in #717.
